### PR TITLE
Fix bug in utf16 C APIs where character count and byte count were confused.

### DIFF
--- a/src/c/sk_paint.cpp
+++ b/src/c/sk_paint.cpp
@@ -221,12 +221,12 @@ size_t sk_paint_break_utf16_text(sk_paint_t* cpaint, const void* text, size_t le
     auto encoding = paint->getTextEncoding ();
     int changed = 0;
     if (encoding != SkPaint::kUTF16_TextEncoding){
-       changed = 1;
+        changed = 1;
         paint->setTextEncoding(SkPaint::kUTF16_TextEncoding);
     }
-    auto ret = paint->breakText(text, length, maxWidth, measuredWidth);
+    auto ret = paint->breakText(text, length * sizeof(uint16_t), maxWidth, measuredWidth);
     if (changed != 0){
-       paint->setTextEncoding(encoding);
+        paint->setTextEncoding(encoding);
     }
     return ret;
 }
@@ -240,12 +240,12 @@ float sk_paint_measure_utf16_text(sk_paint_t* cpaint, const void* text, size_t l
     auto encoding = paint->getTextEncoding ();
     int changed = 0;
     if (encoding != SkPaint::kUTF16_TextEncoding){
-       changed = 1;
+        changed = 1;
         paint->setTextEncoding(SkPaint::kUTF16_TextEncoding);
     }
-    auto ret = paint->measureText(text, length, AsRect(bounds));
+    auto ret = paint->measureText(text, length * sizeof(uint16_t), AsRect(bounds));
     if (changed != 0){
-       paint->setTextEncoding(encoding);
+        paint->setTextEncoding(encoding);
     }
     return ret;
 }


### PR DESCRIPTION
Add multiply by sizeof UTF16 character, because SkPaint::measureText and SkPaint::breakText take a byte count. This causes the corresponding SkiaSharp APIs to only measure the first half of a string of text.

Also a minor whitespace fix nearby.
