### PR TITLE
Add C API for SKPaint::getFontMetrics

### DIFF
--- a/include/c/sk_paint.h
+++ b/include/c/sk_paint.h
@@ -206,7 +206,10 @@ SK_API float sk_paint_measure_text(const sk_paint_t* cpaint, const void* text, s
  *  Return the width of the UTF16 encoded text
  */
 SK_API float sk_paint_measure_utf16_text(sk_paint_t* cpaint, const void* text, size_t length, sk_rect_t* cbounds);
-
+/**
+ *  Get the font metrics for the current typeface and type size. 
+ */
+SK_API void sk_paint_get_fontmetrics(sk_paint_t* cpaint, sk_fontmetrics_t* cfontmetrics);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -128,6 +128,27 @@ typedef struct {
     float   mat[9];
 } sk_matrix_t;
 
+typedef struct {
+    uint32_t fFlags;            // Bit field to identify which values are unknown
+    float    fTop;              // The greatest distance above the baseline for any glyph (will be <= 0)
+    float    fAscent;           // The recommended distance above the baseline (will be <= 0)
+    float    fDescent;          // The recommended distance below the baseline (will be >= 0)
+    float    fBottom;           // The greatest distance below the baseline for any glyph (will be >= 0)
+    float    fLeading;          // The recommended distance to add between lines of text (will be >= 0)
+    float    fAvgCharWidth;     // the average character width (>= 0)
+    float    fMaxCharWidth;     // the max character width (>= 0)
+    float    fXMin;             // The minimum bounding box x value for all glyphs
+    float    fXMax;             // The maximum bounding box x value for all glyphs
+    float    fXHeight;          // The height of an 'x' in px, or 0 if no 'x' in face
+    float    fCapHeight;        // The cap height (> 0), or 0 if cannot be determined.
+    float    fUnderlineThickness; // underline thickness, or 0 if cannot be determined
+    float    fUnderlinePosition; // underline position, or 0 if cannot be determined
+} sk_fontmetrics_t;
+
+// Flags for fFlags member of sk_fontmetrics_t
+#define FONTMETRICS_FLAGS_UNDERLINE_THICKNESS_IS_VALID (1U << 0)
+#define FONTMETRICS_FLAGS_UNDERLINE_POSITION_IS_VALID (1U << 1)
+
 /**
     A sk_canvas_t encapsulates all of the state about drawing into a
     destination This includes a reference to the destination itself,

--- a/src/c/sk_paint.cpp
+++ b/src/c/sk_paint.cpp
@@ -250,3 +250,9 @@ float sk_paint_measure_utf16_text(sk_paint_t* cpaint, const void* text, size_t l
     return ret;
 }
 
+void sk_paint_get_fontmetrics(sk_paint_t* cpaint, sk_fontmetrics_t* cfontmetrics)
+{
+    SkPaint *paint = AsPaint(cpaint);
+    paint->getFontMetrics(AsFontMetrics(cfontmetrics));
+}
+

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -256,6 +256,14 @@ static inline const SkImageFilter::CropRect* AsImageFilterCropRect(const sk_imag
     return reinterpret_cast<const SkImageFilter::CropRect*>(p);
 }
 
+static inline SkPaint::FontMetrics* AsFontMetrics(sk_fontmetrics_t* p) {
+    return reinterpret_cast<SkPaint::FontMetrics*>(p);
+}
+
+static inline sk_fontmetrics_t* ToFontMetrics(SkPaint::FontMetrics* p) {
+    return reinterpret_cast<sk_fontmetrics_t*>(p);
+}
+
 const struct {
     sk_xfermode_mode_t  fC;
     SkXfermode::Mode    fSK;


### PR DESCRIPTION
Adds a C API equivalent of SKPaint::getFontMetrics. This is to enable SkiaSharp to expose this API. SkiaSharp PR to come shortly.
