### PR TITLE
Added methods to SkTypeface

### DIFF
--- a/gyp/core.gypi
+++ b/gyp/core.gypi
@@ -26,7 +26,7 @@
         '<(skia_include_path)/c/xamarin/sk_x_shader.h',
         '<(skia_include_path)/c/xamarin/sk_x_stream.h',
         '<(skia_include_path)/c/xamarin/sk_x_typeface.h',
-		'<(skia_include_path)/c/xamarin/sk_x_string.h',
+        '<(skia_include_path)/c/xamarin/sk_x_string.h',
         '<(skia_src_path)/c/xamarin/sk_x_types_priv.h',
         '<(skia_src_path)/c/xamarin/sk_x_bitmap.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_imagedecoder.cpp',
@@ -41,7 +41,7 @@
         '<(skia_src_path)/c/xamarin/sk_x_shader.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_stream.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_typeface.cpp',
-		'<(skia_src_path)/c/xamarin/sk_x_string.cpp',
+        '<(skia_src_path)/c/xamarin/sk_x_string.cpp',
         
         '<(skia_include_path)/c/sk_canvas.h',
         '<(skia_include_path)/c/sk_data.h',

--- a/gyp/core.gypi
+++ b/gyp/core.gypi
@@ -26,6 +26,7 @@
         '<(skia_include_path)/c/xamarin/sk_x_shader.h',
         '<(skia_include_path)/c/xamarin/sk_x_stream.h',
         '<(skia_include_path)/c/xamarin/sk_x_typeface.h',
+		'<(skia_include_path)/c/xamarin/sk_x_string.h',
         '<(skia_src_path)/c/xamarin/sk_x_types_priv.h',
         '<(skia_src_path)/c/xamarin/sk_x_bitmap.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_imagedecoder.cpp',
@@ -40,6 +41,7 @@
         '<(skia_src_path)/c/xamarin/sk_x_shader.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_stream.cpp',
         '<(skia_src_path)/c/xamarin/sk_x_typeface.cpp',
+		'<(skia_src_path)/c/xamarin/sk_x_string.cpp',
         
         '<(skia_include_path)/c/sk_canvas.h',
         '<(skia_include_path)/c/sk_data.h',

--- a/include/c/xamarin/sk_x_string.h
+++ b/include/c/xamarin/sk_x_string.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+// EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL
+// DO NOT USE -- FOR INTERNAL TESTING ONLY
+
+#ifndef sk_x_string_DEFINED
+#define sk_x_string_DEFINED
+
+#include "sk_types.h"
+#include "xamarin/sk_x_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+/**
+    Returns a new empty sk_string_t.  This call must be balanced with a call to
+    sk_string_destructor().
+*/
+SK_API sk_string_t* sk_string_new_empty();
+/**
+    Returns a new sk_string_t by copying the specified source string, encoded in UTF-8.
+    This call must be balanced with a call to sk_string_destructor().
+*/
+SK_API sk_string_t* sk_string_new_with_copy(const char* src, size_t length);
+
+/**
+    Deletes the string.
+*/
+SK_API void sk_string_destructor(const sk_string_t*);
+
+/**
+    Returns the number of bytes stored in the UTF 8 string. Note that this is the number of bytes, not characters.
+*/
+SK_API size_t sk_string_get_size(const sk_string_t*);
+/**
+    Returns the pointer to the string.
+ */
+SK_API const char* sk_string_get_c_str(const sk_string_t*);
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/include/c/xamarin/sk_x_typeface.h
+++ b/include/c/xamarin/sk_x_typeface.h
@@ -23,7 +23,7 @@ SK_API sk_typeface_t* sk_typeface_create_from_file(const char* path, int index);
 SK_API sk_typeface_t* sk_typeface_create_from_stream(sk_stream_asset_t* stream, int index);
 SK_API int sk_typeface_chars_to_glyphs(sk_typeface_t* typeface, const char *chars, sk_encoding_t encoding, uint16_t glyphs[], int glyphCount);
 
-SK_API void sk_typeface_get_family_name(sk_typeface_t* typeface, sk_string_t* family_name);
+SK_API sk_string_t* sk_typeface_get_family_name(sk_typeface_t* typeface);
 
 SK_API int sk_typeface_count_tables(sk_typeface_t* typeface);
 SK_API int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t tags[]);

--- a/include/c/xamarin/sk_x_typeface.h
+++ b/include/c/xamarin/sk_x_typeface.h
@@ -23,6 +23,13 @@ SK_API sk_typeface_t* sk_typeface_create_from_file(const char* path, int index);
 SK_API sk_typeface_t* sk_typeface_create_from_stream(sk_stream_asset_t* stream, int index);
 SK_API int sk_typeface_chars_to_glyphs(sk_typeface_t* typeface, const char *chars, sk_encoding_t encoding, uint16_t glyphs[], int glyphCount);
 
+SK_API void sk_typeface_get_family_name(sk_typeface_t* typeface, sk_string_t* family_name);
+
+SK_API int sk_typeface_count_tables(sk_typeface_t* typeface);
+SK_API int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t tags[]);
+SK_API size_t sk_typeface_get_table_size(sk_typeface_t* typeface, sk_font_table_tag_t tag);
+SK_API size_t sk_typeface_get_table_data(sk_typeface_t* typeface, sk_font_table_tag_t tag, size_t offset, size_t length, void* data);
+
 SK_C_PLUS_PLUS_END_GUARD
 
 #endif

--- a/include/c/xamarin/sk_x_types.h
+++ b/include/c/xamarin/sk_x_types.h
@@ -58,6 +58,11 @@ typedef struct {
 #define FONTMETRICS_FLAGS_UNDERLINE_POSITION_IS_VALID (1U << 1)
 
 /**
+    A lightweight managed string.
+*/
+typedef struct sk_string_t sk_string_t;
+/**
+
     A sk_bitmap_t is an abstraction that specifies a raster bitmap.
 */
 typedef struct sk_bitmap_t sk_bitmap_t;
@@ -77,6 +82,8 @@ typedef struct sk_imagefilter_croprect_t sk_imagefilter_croprect_t;
     Typeface objects are immutable, and so they can be shared between threads.
 */
 typedef struct sk_typeface_t sk_typeface_t;
+typedef uint32_t sk_font_table_tag_t;
+
 /**
    Various stream types
 */

--- a/src/c/xamarin/sk_x_string.cpp
+++ b/src/c/xamarin/sk_x_string.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "SkString.h"
+
+#include "xamarin/sk_x_string.h"
+
+#include "../sk_types_priv.h"
+#include "sk_x_types_priv.h"
+
+sk_string_t* sk_string_new_empty() {
+	return ToString(new SkString());
+}
+
+sk_string_t* sk_string_new_with_copy(const char* src, size_t length) {
+	return ToString(new SkString(src, length));
+}
+
+void sk_string_destructor(const sk_string_t* cstring) {
+	delete AsString(cstring);
+}
+
+size_t sk_string_get_size(const sk_string_t* cstring) {
+	return AsString(cstring)->size();
+}
+
+const char* sk_string_get_c_str(const sk_string_t* cstring) {
+	return AsString(cstring)->c_str();
+}

--- a/src/c/xamarin/sk_x_string.cpp
+++ b/src/c/xamarin/sk_x_string.cpp
@@ -13,21 +13,21 @@
 #include "sk_x_types_priv.h"
 
 sk_string_t* sk_string_new_empty() {
-	return ToString(new SkString());
+    return ToString(new SkString());
 }
 
 sk_string_t* sk_string_new_with_copy(const char* src, size_t length) {
-	return ToString(new SkString(src, length));
+    return ToString(new SkString(src, length));
 }
 
 void sk_string_destructor(const sk_string_t* cstring) {
-	delete AsString(cstring);
+    delete AsString(cstring);
 }
 
 size_t sk_string_get_size(const sk_string_t* cstring) {
-	return AsString(cstring)->size();
+    return AsString(cstring)->size();
 }
 
 const char* sk_string_get_c_str(const sk_string_t* cstring) {
-	return AsString(cstring)->c_str();
+    return AsString(cstring)->c_str();
 }

--- a/src/c/xamarin/sk_x_typeface.cpp
+++ b/src/c/xamarin/sk_x_typeface.cpp
@@ -77,25 +77,25 @@ int sk_typeface_glyph_count (sk_typeface_t* typeface)
 
 void sk_typeface_get_family_name(sk_typeface_t* typeface, sk_string_t* family_name)
 {
-	((SkTypeface*)typeface)->getFamilyName(AsString(family_name));
+    ((SkTypeface*)typeface)->getFamilyName(AsString(family_name));
 }
 
 int sk_typeface_count_tables(sk_typeface_t* typeface)
 {
-	return ((SkTypeface*)typeface)->countTables();
+    return ((SkTypeface*)typeface)->countTables();
 }
 
 int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t tags[])
 {
-	return ((SkTypeface*)typeface)->getTableTags(tags);
+    return ((SkTypeface*)typeface)->getTableTags(tags);
 }
 
 size_t sk_typeface_get_table_size(sk_typeface_t* typeface, sk_font_table_tag_t tag)
 {
-	return ((SkTypeface*)typeface)->getTableSize(tag);
+    return ((SkTypeface*)typeface)->getTableSize(tag);
 }
 
 size_t sk_typeface_get_table_data(sk_typeface_t* typeface, sk_font_table_tag_t tag, size_t offset, size_t length, void* data)
 {
-	return ((SkTypeface*)typeface)->getTableData(tag, offset, length, data);
+    return ((SkTypeface*)typeface)->getTableData(tag, offset, length, data);
 }

--- a/src/c/xamarin/sk_x_typeface.cpp
+++ b/src/c/xamarin/sk_x_typeface.cpp
@@ -75,9 +75,11 @@ int sk_typeface_glyph_count (sk_typeface_t* typeface)
     return ((SkTypeface*) typeface)->countGlyphs();
 }
 
-void sk_typeface_get_family_name(sk_typeface_t* typeface, sk_string_t* family_name)
+sk_string_t* sk_typeface_get_family_name(sk_typeface_t* typeface)
 {
-    ((SkTypeface*)typeface)->getFamilyName(AsString(family_name));
+    SkString* family_name = new SkString();
+    ((SkTypeface*)typeface)->getFamilyName(family_name);
+    return ToString(family_name);
 }
 
 int sk_typeface_count_tables(sk_typeface_t* typeface)

--- a/src/c/xamarin/sk_x_typeface.cpp
+++ b/src/c/xamarin/sk_x_typeface.cpp
@@ -74,3 +74,28 @@ int sk_typeface_glyph_count (sk_typeface_t* typeface)
 {
     return ((SkTypeface*) typeface)->countGlyphs();
 }
+
+void sk_typeface_get_family_name(sk_typeface_t* typeface, sk_string_t* family_name)
+{
+	((SkTypeface*)typeface)->getFamilyName(AsString(family_name));
+}
+
+int sk_typeface_count_tables(sk_typeface_t* typeface)
+{
+	return ((SkTypeface*)typeface)->countTables();
+}
+
+int sk_typeface_get_table_tags(sk_typeface_t* typeface, sk_font_table_tag_t tags[])
+{
+	return ((SkTypeface*)typeface)->getTableTags(tags);
+}
+
+size_t sk_typeface_get_table_size(sk_typeface_t* typeface, sk_font_table_tag_t tag)
+{
+	return ((SkTypeface*)typeface)->getTableSize(tag);
+}
+
+size_t sk_typeface_get_table_data(sk_typeface_t* typeface, sk_font_table_tag_t tag, size_t offset, size_t length, void* data)
+{
+	return ((SkTypeface*)typeface)->getTableData(tag, offset, length, data);
+}

--- a/src/c/xamarin/sk_x_types_priv.h
+++ b/src/c/xamarin/sk_x_types_priv.h
@@ -634,11 +634,11 @@ static inline sk_fontmetrics_t* ToFontMetrics(SkPaint::FontMetrics* p) {
 }
 
 static inline SkString* AsString(const sk_string_t* cdata) {
-	return reinterpret_cast<SkString*>(const_cast<sk_string_t*>(cdata));
+    return reinterpret_cast<SkString*>(const_cast<sk_string_t*>(cdata));
 }
 
 static inline sk_string_t* ToString(SkString* data) {
-	return reinterpret_cast<sk_string_t*>(data);
+    return reinterpret_cast<sk_string_t*>(data);
 }
 
 

--- a/src/c/xamarin/sk_x_types_priv.h
+++ b/src/c/xamarin/sk_x_types_priv.h
@@ -20,6 +20,7 @@
 #include "SkPictureRecorder.h"
 #include "SkPoint3.h"
 #include "SkStream.h"
+#include "SkString.h"
 #include "../../include/effects/SkDisplacementMapEffect.h"
 #include "../../include/effects/SkDropShadowImageFilter.h"
 #include "../../include/effects/SkMatrixConvolutionImageFilter.h"
@@ -631,5 +632,14 @@ static inline SkPaint::FontMetrics* AsFontMetrics(sk_fontmetrics_t* p) {
 static inline sk_fontmetrics_t* ToFontMetrics(SkPaint::FontMetrics* p) {
     return reinterpret_cast<sk_fontmetrics_t*>(p);
 }
+
+static inline SkString* AsString(const sk_string_t* cdata) {
+	return reinterpret_cast<SkString*>(const_cast<sk_string_t*>(cdata));
+}
+
+static inline sk_string_t* ToString(SkString* data) {
+	return reinterpret_cast<sk_string_t*>(data);
+}
+
 
 #endif


### PR DESCRIPTION
This branch adds some methods methods to the SKTypeface class. It also fixes an issue where if the typeface didn't exist, it would not raise an error, but generate an Access violation later.

I added tests for the new methods and another for the error in case the typeface doesn't exist.
