### PR TITLE
SkPDF: Glyph validation change

### DIFF
--- a/include/core/SkPostConfig.h
+++ b/include/core/SkPostConfig.h
@@ -245,7 +245,11 @@
 //////////////////////////////////////////////////////////////////////
 
 #if !defined(SK_UNUSED)
-#  define SK_UNUSED SK_ATTRIBUTE(unused)
+#  if defined(_MSC_VER)
+#    define SK_UNUSED __pragma(warning(suppress:4189))
+#  else
+#    define SK_UNUSED SK_ATTRIBUTE(unused)
+#  endif
 #endif
 
 #if !defined(SK_ATTR_DEPRECATED)

--- a/src/pdf/SkPDFDevice.h
+++ b/src/pdf/SkPDFDevice.h
@@ -277,8 +277,11 @@ private:
     int addGraphicStateResource(SkPDFObject* gs);
     int addXObjectResource(SkPDFObject* xObject);
 
-    // returns false when a valid SkFont can not be produced
-    bool updateFont(const SkPaint& paint, uint16_t glyphID, ContentEntry* contentEntry);
+    // returns nullptr when a valid SkFont can not be produced
+    SkPDFFont* updateFont(SkTypeface* typeface,
+                          SkScalar textSize,
+                          uint16_t glyphID,
+                          ContentEntry* contentEntry);
     int getFontResourceIndex(SkTypeface* typeface, uint16_t glyphID);
 
 

--- a/src/pdf/SkScopeExit.h
+++ b/src/pdf/SkScopeExit.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef SkScopeExit_DEFINED
+#define SkScopeExit_DEFINED
+
+#include "SkTypes.h"
+
+/**
+ * SK_AT_SCOPE_EXIT(stmt) evaluates stmt when the current scope ends.
+ *
+ * E.g.
+ *    {
+ *        int x = 5;
+ *        {
+ *           SK_AT_SCOPE_EXIT(x--);
+ *           SkASSERT(x == 5);
+ *        }
+ *        SkASSERT(x == 4);
+ *    }
+ */
+template <typename Fn>
+class SkScopeExit {
+public:
+    SkScopeExit(Fn f) : fFn(std::move(f)) {}
+    ~SkScopeExit() { fFn(); }
+
+private:
+    Fn fFn;
+
+    SkScopeExit(           const SkScopeExit& ) = delete;
+    SkScopeExit& operator=(const SkScopeExit& ) = delete;
+    SkScopeExit(                 SkScopeExit&&) = delete;
+    SkScopeExit& operator=(      SkScopeExit&&) = delete;
+};
+
+template <typename Fn>
+inline SkScopeExit<Fn> SkMakeScopeExit(Fn&& fn) {
+    return {std::move(fn)};
+}
+
+#define SK_AT_SCOPE_EXIT(stmt)                              \
+    SK_UNUSED auto&& SK_MACRO_APPEND_LINE(at_scope_exit_) = \
+        SkMakeScopeExit([&]() { stmt; });
+
+#endif  // SkScopeExit_DEFINED

--- a/tests/CPlusPlusEleven.cpp
+++ b/tests/CPlusPlusEleven.cpp
@@ -6,6 +6,7 @@
  */
 #include "Test.h"
 #include "SkTemplates.h"
+#include "SkScopeExit.h"
 #include <utility>
 
 namespace {
@@ -54,4 +55,13 @@ DEF_TEST(CPlusPlusEleven_default_move, r) {
     TestClass c(std::move(a));
     REPORTER_ASSERT(r, b.fFoo.fCopied);
     REPORTER_ASSERT(r, !c.fFoo.fCopied);
+}
+
+DEF_TEST(SkAtScopeExit, r) {
+    int x = 5;
+    {
+        SK_AT_SCOPE_EXIT(x--);
+        REPORTER_ASSERT(r, x == 5);
+    }
+    REPORTER_ASSERT(r, x == 4);
 }


### PR DESCRIPTION
[cherry-pick https://skia.googlesource.com/skia.git/+/4871f22 to m54]

Instead of mapping invaid glyphIDs to zero or maxGlyphID,
don't draw them at all.

Validate glyphs when glyph is written, not ahead of time.

Don't allocate array to copy user-provided glyphs.

Easy early exit from SkPDFDevice::internalDrawText()
    GlyphPositioner::flush() called ~GlyphPositioner()
    SkScopeExit class now exists.

Assume SkTypeface\* pointers are now never null in more
places.

precalculate alignmentFactor to clean up code.

SkPDFDevice::updateFont must be called with validated
glyphID.  Skip bad glyphs to make this true.

SkPDFDevice::updateFont always succeeds.

SkPDFFont::GetFontResource always succeeds (preconditions are
asserted).  If GetMetrics fails, don't call GetFontResource.

SkPDFFont::glyphsToPDFFontEncodingCount() becomes
SkPDFFont::countStretch() and is inlined.

SkPDFFont::glyphsToPDFFontEncoding now works one Glyph at a
time and is inlined.

SkPDFFont::noteGlyphUsage() operates one glyph at a time.

Add SkScopeExit.h; also a unit test for it.

SkPostConfig: Fix SK_UNUSED for Win32.

No public API changes.
TBR=reed@google.com

BUG=625995

GOLD_TRYBOT_URL= https://gold.skia.org/search?issue=2278703002

Review-Url: https://codereview.chromium.org/2278703002
NOTREECHECKS=true
NOTRY=true
NOPRESUBMIT=true

Review-Url: https://codereview.chromium.org/2302353002
