### PR TITLE
Fix a bug where skia binaries are built with asserts even in Release, 15Mo instead of 5Mo DLL

### DIFF
--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -101,7 +101,7 @@
         'configurations': {
           'Debug':   { 'defines': [ 'SK_DEBUG=1' ] },
           'Release': { 'defines': [ 'NDEBUG' ] },
-          'Release_Developer': {
+          'ReleaseDeveloper': {
             'inherit_from': ['Release'],
             'defines': [ 'SK_DEBUG=1' ],
             'conditions': [

--- a/gyp/common_conditions.gypi
+++ b/gyp/common_conditions.gypi
@@ -178,8 +178,8 @@
                   },
                 },
               },
-              'Release_Developer_x64': {
-                'inherit_from': ['Release_Developer'],
+              'ReleaseDeveloper_x64': {
+                'inherit_from': ['ReleaseDeveloper'],
                 'msvs_settings': {
                   'VCCLCompilerTool': {
                      # Don't specify /arch. SSE2 is implied by 64bit and specifying it warns.


### PR DESCRIPTION
Hi there! 😄 

While toying with SkiaSharp, I discovered that the `libSkiaSharp.dll` was 15Mo 😱 

The SK_DEBUG=1 was set for the Release config (at least on msvc). Resulting in a DLL/LIB bloated with many asserts (15Mo instead of 5Mo), most likely also slower. Haven't checked if it affects also the others gyp generators/platforms.

The bug took me a while to find, because it is deeply nested into gyp and is caused by the skia config "Release_Developer" which is getting incorrectly merged by gyp into the "Release" config (and the `Release_Developer` has the SK_DEBUG=1 set)

gyp and specifically the function [`_GetConfigurationAndPlatform` in `msvc.py`](https://chromium.googlesource.com/external/gyp/+/702ac58e477214c635d9b541932e75a95d349352/pylib/gyp/generator/msvs.py#2645) is expecting a single _ to separate from the optional platform (x64). 

It looks like gyp projects should not use any `_` in their configuration names (apart for the optional platform overrides)

Sorry If I'm using the `xamarin-mobile-bindings` branch, let me know which branch is better.

I will report this to skia bug tracker after.
