### PR TITLE
Remove restrictive format pattern for Fontconfig matching

### DIFF
--- a/src/ports/SkFontConfigInterface_direct.cpp
+++ b/src/ports/SkFontConfigInterface_direct.cpp
@@ -597,11 +597,6 @@ bool SkFontConfigInterfaceDirect::matchFamilyName(const char familyName[],
 
     FcPatternAddBool(pattern, FC_SCALABLE, FcTrue);
 
-#ifdef SK_FONT_CONFIG_INTERFACE_ONLY_ALLOW_SFNT_FONTS
-    FcPatternAddString(pattern, FC_FONTFORMAT, reinterpret_cast<const FcChar8*>(kFontFormatTrueType));
-    FcPatternAddString(pattern, FC_FONTFORMAT, reinterpret_cast<const FcChar8*>(kFontFormatCFF));
-#endif
-
     FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
     FcDefaultSubstitute(pattern);
 


### PR DESCRIPTION
This pattern pushes CFF fonts too far low in the list. Instead
it is enough to rely on the isValidPattern function to skip
Type 1 fonts.

Merged to m55 branch in order to unblock chromium:649468

BUG=skia:5846
GOLD_TRYBOT_URL= https://gold.skia.org/search?issue=2410063002

Review-Url: https://codereview.chromium.org/2410063002
NOTREECHECKS=true
NOTRY=true
NOPRESUBMIT=true

Review-Url: https://codereview.chromium.org/2423433002
