### PR TITLE
Add SkColorTable setting support to C API

### DIFF
--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -42,7 +42,7 @@ SK_API void sk_bitmap_set_pixel_colors(sk_bitmap_t* cbitmap, const sk_color_t* c
 SK_API bool sk_bitmap_try_alloc_pixels(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, size_t rowBytes);
 SK_API bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, sk_pixelref_factory_t* factory, sk_colortable_t* ctable);
 SK_API sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap);
-SK_API void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, const void* pixels, sk_colortable_t* ctable);
+SK_API void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ctable);
 
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -41,6 +41,7 @@ SK_API void sk_bitmap_set_pixel_colors(sk_bitmap_t* cbitmap, const sk_color_t* c
 SK_API bool sk_bitmap_try_alloc_pixels(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, size_t rowBytes);
 SK_API bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, sk_pixelref_factory_t* factory, sk_colortable_t* ctable);
 SK_API sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap);
+SK_API void sk_bitmap_set_colortable(sk_bitmap_t* cbitmap, sk_colortable_t* ctable);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -32,7 +32,6 @@ SK_API void sk_bitmap_erase_rect(sk_bitmap_t* cbitmap, sk_color_t color, sk_irec
 SK_API sk_color_t sk_bitmap_get_pixel_color(sk_bitmap_t* cbitmap, int x, int y);
 SK_API sk_color_t sk_bitmap_get_index8_color(sk_bitmap_t* cbitmap, int x, int y);
 SK_API void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t color);
-SK_API void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct);
 SK_API bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct);
 SK_API bool sk_bitmap_can_copy_to(sk_bitmap_t* cbitmap, sk_colortype_t ct);
 SK_API void sk_bitmap_lock_pixels(sk_bitmap_t* cbitmap);

--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -41,6 +41,7 @@ SK_API void sk_bitmap_set_pixel_colors(sk_bitmap_t* cbitmap, const sk_color_t* c
 SK_API bool sk_bitmap_try_alloc_pixels(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, size_t rowBytes);
 SK_API bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, sk_pixelref_factory_t* factory, sk_colortable_t* ctable);
 SK_API sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap);
+SK_API bool sk_bitmap_set_colortable(sk_colortable_t* ctable);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -32,6 +32,7 @@ SK_API void sk_bitmap_erase_rect(sk_bitmap_t* cbitmap, sk_color_t color, sk_irec
 SK_API sk_color_t sk_bitmap_get_pixel_color(sk_bitmap_t* cbitmap, int x, int y);
 SK_API sk_color_t sk_bitmap_get_index8_color(sk_bitmap_t* cbitmap, int x, int y);
 SK_API void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t color);
+SK_API void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct);
 SK_API bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct);
 SK_API bool sk_bitmap_can_copy_to(sk_bitmap_t* cbitmap, sk_colortype_t ct);
 SK_API void sk_bitmap_lock_pixels(sk_bitmap_t* cbitmap);

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -209,12 +209,6 @@ void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t co
     }
 }
 
-void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct)
-{
-    SkBitmap* bmp = AsBitmap(cbitmap);
-    bmp->setPixels(pixels, AsColorTable(ctable));
-}
-
 bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct)
 {
     return AsBitmap(cbitmap)->copyTo(AsBitmap(dst), (SkColorType)ct);

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -300,3 +300,9 @@ sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap)
 {
     return ToColorTable(AsBitmap(cbitmap)->getColorTable());
 }
+
+void sk_bitmap_set_colortable(sk_bitmap_t* cbitmap, sk_colortable_t* ctable)
+{
+    SkBitmap* bmp = AsBitmap(cbitmap);
+    bmp->setPixels(bmp->getPixels(), AsColorTable(ctable));
+}

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -198,6 +198,12 @@ void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t co
     }
 }
 
+void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct)
+{
+    SkBitmap* bmp = AsBitmap(cbitmap);
+    bmp->setPixels(pixels, AsColorTable(ctable));
+}
+
 bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct)
 {
     return AsBitmap(cbitmap)->copyTo(AsBitmap(dst), (SkColorType)ct);

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -209,6 +209,12 @@ void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t co
     }
 }
 
+void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct)
+{
+    SkBitmap* bmp = AsBitmap(cbitmap);
+    bmp->setPixels(pixels, AsColorTable(ctable));
+}
+
 bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct)
 {
     return AsBitmap(cbitmap)->copyTo(AsBitmap(dst), (SkColorType)ct);

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -25,6 +25,17 @@ static inline void copyAlpha8ToColor(size_t size, const uint8_t* pixels, sk_colo
     }
 }
 
+static inline void copyIndex8ToColor(sk_bitmap_t* cbitmap, size_t size, const uint8_t* pixels, sk_color_t* colors)
+{
+    SkBitmap* bmp = AsBitmap(cbitmap);
+    SkColorTable* ctable = bmp->getColorTable();
+    while (size-- != 0) {
+        const uint8_t* addr = pixels++;
+        const SkPMColor c = (*ctable)[*addr];
+        *colors++ = SkUnPreMultiply::PMColorToColor(c);
+    }
+}
+
 static inline void copyGray8ToColor(size_t size, const uint8_t* pixels, sk_color_t* colors)
 {
     while (size-- != 0) {
@@ -231,6 +242,9 @@ void sk_bitmap_get_pixel_colors(sk_bitmap_t* cbitmap, sk_color_t* colors)
     case kAlpha_8_SkColorType:
         copyAlpha8ToColor(size, (const uint8_t*)pixels, colors);
         break;
+    case kIndex_8_SkColorType:
+        copyIndex8ToColor(cbitmap, size, (const uint8_t*)pixels, colors);
+        break;
     case kGray_8_SkColorType:
         copyGray8ToColor(size, (const uint8_t*)pixels, colors);
         break;
@@ -299,4 +313,10 @@ bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t* cbitmap, const sk_
 sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap)
 {
     return ToColorTable(AsBitmap(cbitmap)->getColorTable());
+}
+
+void sk_bitmap_set_colortable(sk_bitmap_t* cbitmap, sk_colortable_t* ctable)
+{
+    SkBitmap* bmp AsBitmap(cbitmap);
+    bmp->setPixels(bmp->getPixels(), AsColorTable(ctable));
 }

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -209,12 +209,6 @@ void sk_bitmap_set_pixel_color(sk_bitmap_t* cbitmap, int x, int y, sk_color_t co
     }
 }
 
-void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ct)
-{
-    SkBitmap* bmp = AsBitmap(cbitmap);
-    bmp->setPixels(pixels, AsColorTable(ctable));
-}
-
 bool sk_bitmap_copy(sk_bitmap_t* cbitmap, sk_bitmap_t* dst, sk_colortype_t ct)
 {
     return AsBitmap(cbitmap)->copyTo(AsBitmap(dst), (SkColorType)ct);
@@ -323,6 +317,6 @@ sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap)
 
 void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ctable)
 {
-    SkBitmap* bmp AsBitmap(cbitmap);
+    SkBitmap* bmp = AsBitmap(cbitmap);
     bmp->setPixels(pixels, AsColorTable(ctable));
 }

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -25,6 +25,17 @@ static inline void copyAlpha8ToColor(size_t size, const uint8_t* pixels, sk_colo
     }
 }
 
+static inline void copyIndex8ToColor(sk_bitmap_t* cbitmap, size_t size, const uint8_t* pixels, sk_color_t* colors)
+{
+    SkBitmap* bmp = AsBitmap(cbitmap);
+    SkColorTable* ctable = bmp->getColorTable();
+    while (size-- != 0) {
+        const uint8_t* addr = pixels++;
+        const SkPMColor c = (*ctable)[*addr];
+        *colors++ = SkUnPreMultiply::PMColorToColor(c);
+    }
+}
+
 static inline void copyGray8ToColor(size_t size, const uint8_t* pixels, sk_color_t* colors)
 {
     while (size-- != 0) {
@@ -230,6 +241,9 @@ void sk_bitmap_get_pixel_colors(sk_bitmap_t* cbitmap, sk_color_t* colors)
     switch (bmp->colorType()) {
     case kAlpha_8_SkColorType:
         copyAlpha8ToColor(size, (const uint8_t*)pixels, colors);
+        break;
+    case kIndex_8_SkColorType:
+        copyIndex8ToColor(cbitmap, size, (const uint8_t*)pixels, colors);
         break;
     case kGray_8_SkColorType:
         copyGray8ToColor(size, (const uint8_t*)pixels, colors);

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -315,8 +315,8 @@ sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap)
     return ToColorTable(AsBitmap(cbitmap)->getColorTable());
 }
 
-void sk_bitmap_set_colortable(sk_bitmap_t* cbitmap, sk_colortable_t* ctable)
+void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, const void* pixels, sk_colortable_t* ctable)
 {
     SkBitmap* bmp AsBitmap(cbitmap);
-    bmp->setPixels(bmp->getPixels(), AsColorTable(ctable));
+    bmp->setPixels(pixels, AsColorTable(ctable));
 }

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -321,7 +321,7 @@ sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap)
     return ToColorTable(AsBitmap(cbitmap)->getColorTable());
 }
 
-void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, const void* pixels, sk_colortable_t* ctable)
+void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ctable)
 {
     SkBitmap* bmp AsBitmap(cbitmap);
     bmp->setPixels(pixels, AsColorTable(ctable));


### PR DESCRIPTION
This PR provides a getter as well as setter support for modifying the underlying color table of index8 type bitmaps.