### PR TITLE
Compute the correct dst->src rect for bitmap tiles in SkGpuDevice

### DIFF
--- a/gm/verylargebitmap.cpp
+++ b/gm/verylargebitmap.cpp
@@ -41,28 +41,28 @@ static void show_image(SkCanvas* canvas, int width, int height, SkColor colors[2
                        ImageMakerProc proc) {
     sk_sp<SkImage> image(proc(width, height, colors));
 
-    SkPaint paint;
-    SkRect r;
-    SkIRect ir;
+    SkPaint borderPaint;
 
-    paint.setStyle(SkPaint::kStroke_Style);
+    borderPaint.setStyle(SkPaint::kStroke_Style);
 
-    ir.set(0, 0, 128, 128);
-    r.set(ir);
+    SkRect dstRect = SkRect::MakeWH(128.f, 128.f);
 
     canvas->save();
-    canvas->clipRect(r);
+    canvas->clipRect(dstRect);
     canvas->drawImage(image, 0, 0, nullptr);
     canvas->restore();
-    canvas->drawRect(r, paint);
+    canvas->drawRect(dstRect, borderPaint);
 
-    r.offset(SkIntToScalar(150), 0);
-    canvas->drawImageRect(image, ir, r, nullptr);
-    canvas->drawRect(r, paint);
+    dstRect.offset(SkIntToScalar(150), 0);
+    int hw = width / 2;
+    int hh = height / 2;
+    SkIRect subset = SkIRect::MakeLTRB(hw - 64, hh - 32, hw + 64, hh + 32);
+    canvas->drawImageRect(image, subset, dstRect, nullptr);
+    canvas->drawRect(dstRect, borderPaint);
 
-    r.offset(SkIntToScalar(150), 0);
-    canvas->drawImageRect(image, r, nullptr);
-    canvas->drawRect(r, paint);
+    dstRect.offset(SkIntToScalar(150), 0);
+    canvas->drawImageRect(image, dstRect, nullptr);
+    canvas->drawRect(dstRect, borderPaint);
 }
 
 class VeryLargeBitmapGM : public skiagm::GM {

--- a/src/gpu/SkGpuDevice.cpp
+++ b/src/gpu/SkGpuDevice.cpp
@@ -1034,7 +1034,7 @@ void SkGpuDevice::drawBitmapTile(const SkBitmap& bitmap,
 
     SkMatrix texMatrix;
     // Compute a matrix that maps the rect we will draw to the src rect.
-    texMatrix.setRectToRect(dstRect, srcRect, SkMatrix::kStart_ScaleToFit);
+    texMatrix.setRectToRect(dstRect, srcRect, SkMatrix::kFill_ScaleToFit);
     texMatrix.postScale(iw, ih);
 
     // Construct a GrPaint by setting the bitmap texture as the first effect and then configuring


### PR DESCRIPTION
Use anisotropic scale to show bug in verylargebitmap test.

Cherry pick to M55

BUG=chromium:664615

GOLD_TRYBOT_URL= https://gold.skia.org/search?issue=4774

Change-Id: If92eab6d26b9fb506670412a80df259f99db2a21
Reviewed-on: https://skia-review.googlesource.com/4774
Commit-Queue: Brian Salomon <bsalomon@google.com>
Reviewed-by: Robert Phillips <robertphillips@google.com>
Reviewed-on: https://skia-review.googlesource.com/4825
Reviewed-by: Brian Salomon <bsalomon@google.com>