### PR TITLE
Add bitmap resize support to C API

### DIFF
--- a/include/c/sk_bitmap.h
+++ b/include/c/sk_bitmap.h
@@ -45,6 +45,7 @@ SK_API bool sk_bitmap_try_alloc_pixels(sk_bitmap_t* cbitmap, const sk_imageinfo_
 SK_API bool sk_bitmap_try_alloc_pixels_with_color_table(sk_bitmap_t* cbitmap, const sk_imageinfo_t* requestedInfo, sk_pixelref_factory_t* factory, sk_colortable_t* ctable);
 SK_API sk_colortable_t* sk_bitmap_get_colortable(sk_bitmap_t* cbitmap);
 SK_API void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* ctable);
+SK_API bool sk_bitmap_resize(sk_bitmap_t* cbitmap_dst, sk_bitmap_t* cbitmap_src, const sk_resize_mode_t mode);
 
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -186,6 +186,15 @@ typedef struct sk_surface_t sk_surface_t;
 */
 typedef struct sk_region_t sk_region_t;
 
+typedef enum  {
+    RESIZE_BOX,
+    RESIZE_TRIANGLE,
+    RESIZE_LANCZOS3,
+    RESIZE_HAMMING,
+    RESIZE_MITCHELL,
+    RESIZE_FirstMethod = RESIZE_BOX,
+    RESIZE_LastMethod = RESIZE_MITCHELL,
+} sk_resize_mode_t;
 
 typedef enum {
     CLEAR_SK_XFERMODE_MODE,

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -346,7 +346,8 @@ bool sk_bitmap_resize(sk_bitmap_t* cbitmap_dst, sk_bitmap_t* cbitmap_src, const 
 {
     SkBitmap* dstBmp = AsBitmap(cbitmap_dst);
     SkBitmap* srcBmp = AsBitmap(cbitmap_src);
-    SkPixmap srcPixMap = SkPixmap(srcBmp->info(), srcBmp->getPixels(), srcBmp->getSize(), srcBmp->getColorTable());
-    SkPixmap dstPixMap = SkPixmap(dstBmp->info(), dstBmp->getPixels(), dstBmp->getSize(), dstBmp->getColorTable());
-    return (SkBitmapScaler::Resize(dstPixMap, srcPixMap, (SkBitmapScaler::ResizeMethod)mode) && dstBmp->installPixels(dstPixMap));
+    SkPixmap srcPix, dstPix;
+    srcBmp->peekPixels(&srcPix);
+    dstBmp->peekPixels(&dstPix);
+    return (SkBitmapScaler::Resize(dstPix, srcPix, (SkBitmapScaler::ResizeMethod)mode) && dstBmp->installPixels(dstPix));
 }

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -346,6 +346,7 @@ bool sk_bitmap_resize(sk_bitmap_t* cbitmap_dst, sk_bitmap_t* cbitmap_src, const 
 {
     SkBitmap* dstBmp = AsBitmap(cbitmap_dst);
     SkBitmap* srcBmp = AsBitmap(cbitmap_src);
-    SkPixmap pixMap = SkPixmap(srcBmp->info(), srcBmp->getPixels(), srcBmp->getSize(), srcBmp->getColorTable());
-    return SkBitmapScaler::Resize(dstBmp, pixMap, (SkBitmapScaler::ResizeMethod)mode, dstBmp->width(), dstBmp->height());
+    SkPixmap srcPixMap = SkPixmap(srcBmp->info(), srcBmp->getPixels(), srcBmp->getSize(), srcBmp->getColorTable());
+    SkPixmap dstPixMap = SkPixmap(dstBmp->info(), dstBmp->getPixels(), dstBmp->getSize(), dstBmp->getColorTable());
+    return (SkBitmapScaler::Resize(dstPixMap, srcPixMap, (SkBitmapScaler::ResizeMethod)mode) && dstBmp->installPixels(dstPixMap));
 }

--- a/src/c/sk_bitmap.cpp
+++ b/src/c/sk_bitmap.cpp
@@ -12,6 +12,7 @@
 #include "SkImageInfo.h"
 #include "SkMath.h"
 #include "SkUnPreMultiply.h"
+#include "SkBitmapScaler.h"
 
 #include "sk_bitmap.h"
 
@@ -339,4 +340,12 @@ void sk_bitmap_set_pixels(sk_bitmap_t* cbitmap, void* pixels, sk_colortable_t* c
 {
     SkBitmap* bmp = AsBitmap(cbitmap);
     bmp->setPixels(pixels, AsColorTable(ctable));
+}
+
+bool sk_bitmap_resize(sk_bitmap_t* cbitmap_dst, sk_bitmap_t* cbitmap_src, const sk_resize_mode_t mode)
+{
+    SkBitmap* dstBmp = AsBitmap(cbitmap_dst);
+    SkBitmap* srcBmp = AsBitmap(cbitmap_src);
+    SkPixmap pixMap = SkPixmap(srcBmp->info(), srcBmp->getPixels(), srcBmp->getSize(), srcBmp->getColorTable());
+    return SkBitmapScaler::Resize(dstBmp, pixMap, (SkBitmapScaler::ResizeMethod)mode, dstBmp->width(), dstBmp->height());
 }

--- a/tests/CTest.cpp
+++ b/tests/CTest.cpp
@@ -7,6 +7,7 @@
 
 #include "Test.h"
 
+#include "sk_bitmap.h"
 #include "sk_canvas.h"
 #include "sk_paint.h"
 #include "sk_surface.h"
@@ -73,7 +74,7 @@ static void test_c(skiatest::Reporter* reporter) {
     sk_canvas_draw_paint(canvas, paint);
     REPORTER_ASSERT(reporter, 0xFFFFFFFF == pixel[0]);
 
-    sk_paint_set_xfermode_mode(paint, SRC_SK_XFERMODE_MODE);
+    sk_paint_set_blendmode(paint, SRC_SK_BLENDMODE);
     sk_paint_set_color(paint, sk_color_set_argb(0x80, 0x80, 0x80, 0x80));
     sk_canvas_draw_paint(canvas, paint);
     REPORTER_ASSERT(reporter, 0x80404040 == pixel[0]);
@@ -82,7 +83,21 @@ static void test_c(skiatest::Reporter* reporter) {
     sk_surface_unref(surface);
 }
 
+static void bitmap_resize_test(skiatest::Reporter* reporter) {
+    const sk_imageinfo_t srcInfo = {64, 64, (sk_colortype_t)SkColorType::kN32_SkColorType, PREMUL_SK_ALPHATYPE};
+    const sk_imageinfo_t dstInfo = {128, 128, (sk_colortype_t)SkColorType::kN32_SkColorType, PREMUL_SK_ALPHATYPE};
+
+    sk_bitmap_t* bitmap_src = sk_bitmap_new();
+    sk_bitmap_t* bitmap_dst = sk_bitmap_new();
+    REPORTER_ASSERT(reporter, sk_bitmap_try_alloc_pixels(bitmap_src, &srcInfo, srcInfo.width * 4));
+    REPORTER_ASSERT(reporter, sk_bitmap_try_alloc_pixels(bitmap_dst, &dstInfo, dstInfo.width * 4));
+    REPORTER_ASSERT(reporter, sk_bitmap_resize(bitmap_dst, bitmap_src, RESIZE_BOX));
+
+    REPORTER_ASSERT(reporter, bitmap_dst != nullptr);
+}
+
 DEF_TEST(C_API, reporter) {
     test_c(reporter);
     shader_test(reporter);
+    bitmap_resize_test(reporter);
 }


### PR DESCRIPTION
Add bitmap resizing support to the C API. This exposes a number of options which have better quality than using the canvas scaling to resize bitmaps.

My only concern with the added function is whether the exposed C function should take a target bitmap, or a target width and height.