### PR TITLE
[WIP] Optional GPU

### DIFF
--- a/src/c/gr_context.cpp
+++ b/src/c/gr_context.cpp
@@ -5,6 +5,8 @@
  * found in the LICENSE file.
  */
 
+#if SK_SUPPORT_GPU
+
 #include "GrContext.h"
 #include "gl/GrGLInterface.h"
 #include "gl/GrGLAssembleInterface.h"
@@ -89,3 +91,78 @@ bool gr_glinterface_validate(gr_glinterface_t* glInterface) {
 bool gr_glinterface_has_extension(gr_glinterface_t* glInterface, const char* extension) {
     return AsGrGLInterface(glInterface)->hasExtension(extension);
 }
+
+#else // !SK_SUPPORT_GPU
+
+#include "gr_context.h"
+#include "sk_types_priv.h"
+
+gr_context_t* gr_context_create(gr_backend_t backend, gr_backendcontext_t backendContext, const gr_context_options_t* options) {
+    return nullptr;
+}
+
+gr_context_t* gr_context_create_with_defaults(gr_backend_t backend, gr_backendcontext_t backendContext) {
+    return nullptr;
+}
+
+void gr_context_unref(gr_context_t* context) {
+}
+
+void gr_context_abandon_context(gr_context_t* context) {
+}
+
+void gr_context_release_resources_and_abandon_context(gr_context_t* context) {
+}
+
+void gr_context_get_resource_cache_limits(gr_context_t* context, int* maxResources, size_t* maxResourceBytes) {
+}
+
+void gr_context_set_resource_cache_limits(gr_context_t* context, int maxResources, size_t maxResourceBytes) {
+}
+
+void gr_context_get_resource_cache_usage(gr_context_t* context, int* maxResources, size_t* maxResourceBytes) {
+}
+
+int gr_context_get_recommended_sample_count(gr_context_t* context, gr_pixelconfig_t config, float dpi) {
+    return 0;
+}
+
+void gr_context_flush(gr_context_t* context) {
+}
+
+const gr_glinterface_t* gr_glinterface_default_interface() {
+    return nullptr;
+}
+
+const gr_glinterface_t* gr_glinterface_create_native_interface() {
+    return nullptr;
+}
+
+const gr_glinterface_t* gr_glinterface_assemble_interface(void* ctx, gr_gl_get_proc get) {
+    return nullptr;
+}
+
+const gr_glinterface_t* gr_glinterface_assemble_gl_interface(void* ctx, gr_gl_get_proc get) {
+    return nullptr;
+}
+
+const gr_glinterface_t* gr_glinterface_assemble_gles_interface(void* ctx, gr_gl_get_proc get) {
+    return nullptr;
+}
+
+void gr_glinterface_unref(gr_glinterface_t* glInterface) {
+}
+
+gr_glinterface_t* gr_glinterface_clone(gr_glinterface_t* glInterface) {
+    return nullptr;
+}
+
+bool gr_glinterface_validate(gr_glinterface_t* glInterface) {
+    return false;
+}
+
+bool gr_glinterface_has_extension(gr_glinterface_t* glInterface, const char* extension) {
+    return false;
+}
+
+#endif // SK_SUPPORT_GPU

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -48,7 +48,7 @@ class SkPaint;
 class SkShader;
 class GrContext;
 struct GrContextOptions;
-class GrGLInterface;
+struct GrGLInterface;
 
 static inline const SkPaint& AsPaint(const sk_paint_t& cpaint) {
     return reinterpret_cast<const SkPaint&>(cpaint);

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -28,7 +28,6 @@
 #include "Sk1DPathEffect.h"
 #include "SkFontStyle.h"
 #include "SkXMLWriter.h"
-#include "GrContext.h"
 #include "SkPathOps.h"
 #include "SkRegion.h"
 #include "SkTypeface.h"
@@ -36,7 +35,6 @@
 #include "SkEncodedInfo.h"
 #include "SkTime.h"
 #include "SkCamera.h"
-#include "gl/GrGLInterface.h"
 
 #include "sk_path.h"
 #include "sk_paint.h"
@@ -48,6 +46,9 @@
 class SkMaskFilter;
 class SkPaint;
 class SkShader;
+class GrContext;
+struct GrContextOptions;
+class GrGLInterface;
 
 static inline const SkPaint& AsPaint(const sk_paint_t& cpaint) {
     return reinterpret_cast<const SkPaint&>(cpaint);

--- a/src/image/SkSurface.cpp
+++ b/src/image/SkSurface.cpp
@@ -221,8 +221,8 @@ sk_sp<SkSurface> SkSurface::MakeFromBackendRenderTarget(GrContext*,
     return nullptr;
 }
 
-sk_sp<SkSurface> MakeFromBackendTextureAsRenderTarget(GrContext*, const GrBackendTextureDesc&,
-                                                      sk_sp<SkColorSpace>, const SkSurfaceProps*) {
+sk_sp<SkSurface> SkSurface::MakeFromBackendTextureAsRenderTarget(GrContext*, const GrBackendTextureDesc&,
+                                                                 sk_sp<SkColorSpace>, const SkSurfaceProps*) {
     return nullptr;
 }
 


### PR DESCRIPTION
Changed the source a bit so the compiling with `SK_SUPPORT_GPU=0` does not fail. The implementations for the C API for the GPU-specific bits are no-op and return null/0/false - similar to what is done for some `SkSurface` methods:

https://github.com/mono/skia/blob/aa90f17123bf435893271d4e95af88f56488017a/src/image/SkSurface.cpp#L205-L229