### PR TITLE
Modernizing the Repository

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -743,6 +743,40 @@ component("skia") {
   }
 }
 
+config("SkiaSharp_public") {
+  include_dirs = skia_public_includes + [ "include/xamarin" ]
+  defines = [ "SKIA_C_DLL" ]
+  if (is_linux) {
+    defines += [ "SK_SAMPLES_FOR_X" ]
+  }
+  if (!skia_enable_gpu) {
+    defines += [ "SK_SUPPORT_GPU=0" ]
+  }
+}
+
+shared_library("SkiaSharp") {
+  public_configs = [ ":skia_public", ":SkiaSharp_public" ]
+  configs += skia_library_configs + [ ":SkiaSharp_public" ]
+
+  deps = [
+    ":skia",
+  ]
+
+  # clear the sources and add explicitly
+  set_sources_assignment_filter([])
+  sources = [
+    "src/xamarin/sk_managedpixelserializer.cpp",
+    "src/xamarin/sk_managedstream.cpp",
+    "src/xamarin/sk_xamarin.cpp",
+    "src/xamarin/SkiaKeeper.c",
+    "src/xamarin/SkManagedPixelSerializer.cpp",
+    "src/xamarin/SkManagedStream.cpp",
+    "src/xamarin/WinRTCompat.cpp",
+  ]
+
+  libs = []
+}
+
 # Targets guarded by skia_enable_tools may use //third_party freely.
 if (skia_enable_tools) {
   # Used by gn_to_bp.py to list our public include dirs.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -756,7 +756,7 @@ config("SkiaSharp_public") {
 
 shared_library("SkiaSharp") {
   public_configs = [ ":skia_public", ":SkiaSharp_public" ]
-  configs += skia_library_configs + [ ":SkiaSharp_public" ]
+  configs += skia_library_configs + [ ":SkiaSharp_public", "//gn:debug_symbols" ]
 
   deps = [
     ":skia",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -432,9 +432,11 @@ optional("gpu") {
     libs += [ "EGL" ]
   } else if (is_linux) {
     sources += [ "src/gpu/gl/glx/GrGLCreateNativeInterface_glx.cpp" ]
+    # GPU is not linked in, but loaded at runtime
     libs += [
-      "GL",
-      "GLU",
+      # "GL",
+      # "GLU",
+      "dl",
     ]
   } else if (is_mac) {
     sources += [ "src/gpu/gl/mac/GrGLCreateNativeInterface_mac.cpp" ]

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -698,6 +698,9 @@ toolchain("gcc_like") {
 
   tool("solink") {
     soname = "{{target_output_name}}{{output_extension}}"
+    if (linux_soname_version != "") {
+      soname += ".$linux_soname_version"
+    }
 
     rpath = "-Wl,-soname,$soname"
     if (is_mac) {

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -567,10 +567,12 @@ toolchain("msvc") {
   }
 
   tool("solink") {
-    dllname = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
-    libname = "${dllname}.lib"
-    pdbname = "${dllname}.pdb"
-    rspfile = "${dllname}.rsp"
+    output_prefix = "lib"
+    dllname_no_ext = "{{output_dir}}/{{target_output_name}}"
+    dllname = "${dllname_no_ext}{{output_extension}}"
+    libname = "${dllname_no_ext}.lib"
+    pdbname = "${dllname_no_ext}.pdb"
+    rspfile = "${dllname_no_ext}.rsp"
 
     command = "$env_setup\"$bin/link.exe\" /nologo /IMPLIB:$libname /DLL /OUT:$dllname /PDB:$pdbname @$rspfile$env_setup_end"
     outputs = [

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -3,6 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+exec_script("xamarin_inject_compat.py", [ rebase_path("..") ])
+
 declare_args() {
   ar = "ar"
   cc = "cc"

--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -698,7 +698,7 @@ toolchain("gcc_like") {
 
   tool("solink") {
     soname = "{{target_output_name}}{{output_extension}}"
-    if (linux_soname_version != "") {
+    if (is_linux && linux_soname_version != "") {
       soname += ".$linux_soname_version"
     }
 

--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -16,6 +16,7 @@ declare_args() {
   } else {
     ndk_api = 21
   }
+  linux_soname_version = ""
   sanitize = ""
 }
 declare_args() {

--- a/gn/xamarin_inject_compat.py
+++ b/gn/xamarin_inject_compat.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+root = sys.argv[1]
+
+files = [
+    "third_party/externals/dng_sdk/source/dng_string.cpp",
+    "third_party/externals/dng_sdk/source/dng_utils.cpp",
+    "third_party/externals/dng_sdk/source/dng_pthread.cpp",
+    "third_party/externals/zlib/deflate.c",
+    "third_party/externals/libjpeg-turbo/simd/jsimd_x86_64.c",
+    "third_party/externals/libjpeg-turbo/simd/jsimd_i386.c",
+    "third_party/externals/libjpeg-turbo/simd/jsimd_arm.c",
+    "third_party/externals/libjpeg-turbo/simd/jsimd_arm64.c",
+]
+
+for f in files:
+    # read the file
+    af = os.path.join(root, f)
+    with file(af, 'r') as original:
+        data = original.read()
+    # create the include
+    slashes = "../" * f.count('/')
+    inc = '#include "' + slashes + 'include/xamarin/WinRTCompat.h"'
+    # write it to the file
+    if not data.startswith(inc):
+        with file(af, 'w') as modified:
+            modified.write(inc + '\n' + data)

--- a/include/c/sk_colorspace.h
+++ b/include/c/sk_colorspace.h
@@ -13,8 +13,8 @@
 SK_C_PLUS_PLUS_BEGIN_GUARD
 
 SK_C_API void sk_colorspace_unref(sk_colorspace_t* cColorSpace);
-SK_C_API sk_colorspace_t* sk_colorspace_new_srgb();
-SK_C_API sk_colorspace_t* sk_colorspace_new_srgb_linear();
+SK_C_API sk_colorspace_t* sk_colorspace_new_srgb(void);
+SK_C_API sk_colorspace_t* sk_colorspace_new_srgb_linear(void);
 SK_C_API sk_colorspace_t* sk_colorspace_new_icc(const void* input, size_t len);
 SK_C_API sk_colorspace_t* sk_colorspace_new_rgb_with_gamma(sk_colorspace_render_target_gamma_t gamma, const sk_matrix44_t* toXYZD50);
 SK_C_API sk_colorspace_t* sk_colorspace_new_rgb_with_gamma_and_gamut(sk_colorspace_render_target_gamma_t gamma, sk_colorspace_gamut_t gamut);

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -741,7 +741,7 @@ typedef intptr_t gr_backendcontext_t;
 
 typedef struct gr_glinterface_t gr_glinterface_t;
 
-typedef void (*gr_gl_func_ptr)();
+typedef void (*gr_gl_func_ptr)(void);
 typedef gr_gl_func_ptr (*gr_gl_get_proc)(void* ctx, const char* name);
 
 typedef enum {

--- a/include/xamarin/SkManagedPixelSerializer.h
+++ b/include/xamarin/SkManagedPixelSerializer.h
@@ -1,0 +1,39 @@
+//
+//  SkManagedPixelSerializer.h
+//
+//  Created by Matthew on 2017/08/18.
+//  Copyright © 2017 Xamarin. All rights reserved.
+//
+
+#ifndef SkManagedPixelSerializer_h
+#define SkManagedPixelSerializer_h
+
+#include "SkTypes.h"
+#include "SkPixelSerializer.h"
+
+
+class SkData;
+class SkPixmap;
+class SkManagedPixelSerializer;
+
+// delegate declarations
+typedef bool    (*use_delegate)    (SkManagedPixelSerializer* managed, const void* data, size_t len);
+typedef SkData* (*encode_delegate) (SkManagedPixelSerializer* managed, const SkPixmap& pixmap);
+
+// managed wrapper
+class SkManagedPixelSerializer : public SkPixelSerializer {
+public:
+    SkManagedPixelSerializer();
+
+    static void setDelegates(const use_delegate pUse, const encode_delegate pEncode);
+
+protected:
+    bool onUseEncodedData(const void* data, size_t len) override;
+    SkData* onEncode(const SkPixmap&) override;
+
+private:
+    typedef SkPixelSerializer INHERITED;
+};
+
+
+#endif

--- a/include/xamarin/SkManagedStream.h
+++ b/include/xamarin/SkManagedStream.h
@@ -1,0 +1,106 @@
+//
+//  SkManagedStream.hpp
+//
+//  Created by Matthew on 2016/01/08.
+//  Copyright © 2016 Xamarin. All rights reserved.
+//
+
+#ifndef SkManagedStream_h
+#define SkManagedStream_h
+
+#include "SkTypes.h"
+#include "SkStream.h"
+
+
+class SkManagedWStream;
+class SkManagedStream;
+
+// delegate declarations
+typedef size_t            (*read_delegate)        (SkManagedStream* managedStream, void* buffer, size_t size);
+typedef size_t            (*peek_delegate)        (SkManagedStream* managedStream, void* buffer, size_t size);
+typedef bool              (*isAtEnd_delegate)     (const SkManagedStream* managedStream);
+typedef bool              (*hasPosition_delegate) (const SkManagedStream* managedStream);
+typedef bool              (*hasLength_delegate)   (const SkManagedStream* managedStream);
+typedef bool              (*rewind_delegate)      (SkManagedStream* managedStream);
+typedef size_t            (*getPosition_delegate) (const SkManagedStream* managedStream);
+typedef bool              (*seek_delegate)        (SkManagedStream* managedStream, size_t position);
+typedef bool              (*move_delegate)        (SkManagedStream* managedStream, long offset);
+typedef size_t            (*getLength_delegate)   (const SkManagedStream* managedStream);
+typedef SkManagedStream*  (*createNew_delegate)   (const SkManagedStream* managedStream);
+typedef void              (*destroy_delegate)     (size_t managedStream);
+
+// delegate declarations
+typedef bool     (*write_delegate)          (SkManagedWStream* managedStream, const void* buffer, size_t size);
+typedef void     (*flush_delegate)          (SkManagedWStream* managedStream);
+typedef size_t   (*bytesWritten_delegate)   (const SkManagedWStream* managedStream);
+typedef void     (*wdestroy_delegate)       (size_t managedStream);
+
+
+// managed stream wrapper
+class SkManagedStream : public SkStreamAsset {
+public:
+    SkManagedStream();
+    
+    virtual ~SkManagedStream();
+
+    static void setDelegates(const read_delegate pRead,
+                             const peek_delegate pPeek,
+                             const isAtEnd_delegate pIsAtEnd,
+                             const hasPosition_delegate pHasPosition,
+                             const hasLength_delegate pHasLength,
+                             const rewind_delegate pRewind,
+                             const getPosition_delegate pGetPosition,
+                             const seek_delegate pSeek,
+                             const move_delegate pMove,
+                             const getLength_delegate pGetLength,
+                             const createNew_delegate pCreateNew,
+                             const destroy_delegate pDestroy);
+    
+    size_t read(void* buffer, size_t size) override;
+    bool isAtEnd() const override;
+    bool hasPosition() const override;
+    bool hasLength() const override;
+    
+    size_t peek(void* buffer, size_t size) const override;
+    
+    bool rewind() override;
+    SkManagedStream* duplicate() const override;
+    
+    size_t getPosition() const override;
+    bool seek(size_t position) override;
+    bool move(long offset) override;
+    SkManagedStream* fork() const override;
+    
+    size_t getLength() const override;
+    
+private:
+    size_t address;
+
+    typedef SkStreamAsset INHERITED;
+};
+
+
+// managed wstream wrapper
+class SkManagedWStream : public SkWStream {
+public:
+    SkManagedWStream();
+
+    virtual ~SkManagedWStream();
+
+    static void setDelegates(const write_delegate pWrite,
+                             const flush_delegate pFlush,
+                             const bytesWritten_delegate pBytesWritten,
+                             const wdestroy_delegate pDestroy);
+    
+    bool write(const void* buffer, size_t size) override;
+    void flush() override;
+    size_t bytesWritten() const override;
+    
+private:
+    size_t address;
+    
+    typedef SkWStream INHERITED;
+};
+
+
+#endif

--- a/include/xamarin/WinRTCompat.h
+++ b/include/xamarin/WinRTCompat.h
@@ -1,0 +1,78 @@
+//
+//  WinRTCompat.h
+//
+//  Created by Matthew on 2016/06/20.
+//  Copyright © 2016 Xamarin. All rights reserved.
+//
+
+#ifndef WinRTCompat_h
+#define WinRTCompat_h
+
+#ifdef SK_BUILD_FOR_WINRT
+
+#include <Windows.h>
+
+#ifdef __cplusplus
+#define C_PLUS_PLUS_BEGIN_GUARD    extern "C" {
+#define C_PLUS_PLUS_END_GUARD      }
+#else
+#include <stdbool.h>
+#define C_PLUS_PLUS_BEGIN_GUARD
+#define C_PLUS_PLUS_END_GUARD
+#endif
+
+#include <wchar.h>
+
+C_PLUS_PLUS_BEGIN_GUARD
+
+#ifdef _M_ARM
+
+// This should have been not used, but as the code is designed for x86
+// and there is a RUNTIME check for simd, this has to exist. As the
+// runtime check will fail, and revert to a C implementation, this is 
+// not a problem to have a stub.
+
+// used in: deflate.c
+unsigned int _mm_crc32_u32(unsigned int crc, unsigned int v);
+
+#endif // _M_ARM
+
+// used in: dng_string.cpp
+int WINAPI CompareStringWCompat(_In_ LCID Locale, _In_ DWORD dwCmpFlags, _In_NLS_string_(cchCount1) PCNZWCH lpString1, _In_ int cchCount1, _In_NLS_string_(cchCount2) PCNZWCH lpString2, _In_ int cchCount2);
+// used in: dng_string.cpp
+UINT WINAPI GetACPCompat(void);
+// used in: dng_pthread.cpp
+HANDLE WINAPI OpenThreadCompat(_In_ DWORD dwDesiredAccess, _In_ BOOL bInheritHandle, _In_ DWORD dwThreadId);
+// used in: dng_utils.cpp
+DWORD  WINAPI GetTickCountCompat(VOID);
+// used in: dng_utils.cpp
+int WINAPI MessageBoxACompat(_In_opt_ HWND hWnd, _In_opt_ LPCSTR lpText, _In_opt_ LPCSTR lpCaption, _In_ UINT uType);
+// used in: dng_pthread.cpp
+DWORD WINAPI TlsAllocCompat(VOID);
+// used in: dng_pthread.cpp
+LPVOID WINAPI TlsGetValueCompat(_In_ DWORD dwTlsIndex);
+// used in: dng_pthread.cpp
+BOOL WINAPI TlsSetValueCompat(_In_ DWORD dwTlsIndex, _In_opt_ LPVOID lpTlsValue);
+// used in: dng_pthread.cpp
+BOOL WINAPI TlsFreeCompat(_In_ DWORD dwTlsIndex);
+// used in: jsimd_xxx.c
+char *getenvCompat(const char *name);
+
+// override any previous declaration with ours
+
+#define MessageBoxA MessageBoxACompat
+#define CompareStringW CompareStringWCompat
+#define GetACP GetACPCompat
+#define OpenThread OpenThreadCompat
+#define GetTickCount GetTickCountCompat
+#define TlsAlloc TlsAllocCompat
+#define TlsGetValue TlsGetValueCompat
+#define TlsSetValue TlsSetValueCompat
+#define TlsFree TlsFreeCompat
+#define getenv getenvCompat
+
+C_PLUS_PLUS_END_GUARD
+
+#endif // SK_BUILD_FOR_WINRT
+
+#endif // WinRTCompat_h

--- a/include/xamarin/sk_managedpixelserializer.h
+++ b/include/xamarin/sk_managedpixelserializer.h
@@ -22,7 +22,7 @@ typedef bool       (*sk_managedpixelserializer_use_delegate)    (sk_managedpixel
 typedef sk_data_t* (*sk_managedpixelserializer_encode_delegate) (sk_managedpixelserializer_t* serializer, const sk_pixmap_t* pixmap);
 
 
-SK_X_API sk_managedpixelserializer_t* sk_managedpixelserializer_new ();
+SK_X_API sk_managedpixelserializer_t* sk_managedpixelserializer_new (void);
 SK_X_API void sk_managedpixelserializer_set_delegates (
     const sk_managedpixelserializer_use_delegate pUse,
     const sk_managedpixelserializer_encode_delegate pEncode);

--- a/include/xamarin/sk_managedpixelserializer.h
+++ b/include/xamarin/sk_managedpixelserializer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef sk_managedpixelserializer_DEFINED
+#define sk_managedpixelserializer_DEFINED
+
+#include "sk_xamarin.h"
+
+#include "sk_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+
+typedef struct sk_managedpixelserializer_t sk_managedpixelserializer_t;
+
+
+typedef bool       (*sk_managedpixelserializer_use_delegate)    (sk_managedpixelserializer_t* serializer, const void* data, size_t len);
+typedef sk_data_t* (*sk_managedpixelserializer_encode_delegate) (sk_managedpixelserializer_t* serializer, const sk_pixmap_t* pixmap);
+
+
+SK_X_API sk_managedpixelserializer_t* sk_managedpixelserializer_new ();
+SK_X_API void sk_managedpixelserializer_set_delegates (
+    const sk_managedpixelserializer_use_delegate pUse,
+    const sk_managedpixelserializer_encode_delegate pEncode);
+
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/include/xamarin/sk_managedstream.h
+++ b/include/xamarin/sk_managedstream.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+// EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL
+// DO NOT USE -- FOR INTERNAL TESTING ONLY
+
+#ifndef sk_managedstream_DEFINED
+#define sk_managedstream_DEFINED
+
+#include "sk_xamarin.h"
+
+#include "sk_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+
+typedef struct sk_wstream_managedstream_t sk_wstream_managedstream_t;
+
+
+typedef bool   (*sk_managedwstream_write_delegate)        (sk_wstream_managedstream_t* cmanagedStream, const void* buffer, size_t size);
+typedef void   (*sk_managedwstream_flush_delegate)        (sk_wstream_managedstream_t* cmanagedStream);
+typedef size_t (*sk_managedwstream_bytesWritten_delegate) (const sk_wstream_managedstream_t* cmanagedStream);
+typedef void   (*sk_managedwstream_destroy_delegate)      (size_t cmanagedStream);
+
+
+SK_X_API sk_wstream_managedstream_t* sk_managedwstream_new ();
+SK_X_API void sk_managedwstream_destroy (sk_wstream_managedstream_t*);
+
+SK_X_API void sk_managedwstream_set_delegates (const sk_managedwstream_write_delegate pWrite,
+                                               const sk_managedwstream_flush_delegate pFlush,
+                                               const sk_managedwstream_bytesWritten_delegate pBytesWritten,
+                                               const sk_managedwstream_destroy_delegate pDestroy);
+
+
+typedef struct sk_stream_managedstream_t sk_stream_managedstream_t;
+
+
+typedef size_t                     (*sk_managedstream_read_delegate)         (sk_stream_managedstream_t* cmanagedStream, void* buffer, size_t size);
+typedef size_t                     (*sk_managedstream_peek_delegate)         (sk_stream_managedstream_t* cmanagedStream, void* buffer, size_t size);
+typedef bool                       (*sk_managedstream_isAtEnd_delegate)      (const sk_stream_managedstream_t* cmanagedStream);
+typedef bool                       (*sk_managedstream_hasPosition_delegate)  (const sk_stream_managedstream_t* cmanagedStream);
+typedef bool                       (*sk_managedstream_hasLength_delegate)    (const sk_stream_managedstream_t* cmanagedStream);
+typedef bool                       (*sk_managedstream_rewind_delegate)       (sk_stream_managedstream_t* cmanagedStream);
+typedef size_t                     (*sk_managedstream_getPosition_delegate)  (const sk_stream_managedstream_t* cmanagedStream);
+typedef bool                       (*sk_managedstream_seek_delegate)         (sk_stream_managedstream_t* cmanagedStream, size_t position);
+typedef bool                       (*sk_managedstream_move_delegate)         (sk_stream_managedstream_t* cmanagedStream, long offset);
+typedef size_t                     (*sk_managedstream_getLength_delegate)    (const sk_stream_managedstream_t* cmanagedStream);
+typedef sk_stream_managedstream_t* (*sk_managedstream_createNew_delegate)    (const sk_stream_managedstream_t* cmanagedStream);
+typedef void                       (*sk_managedstream_destroy_delegate)      (size_t cmanagedStream);
+
+
+// c API
+SK_X_API sk_stream_managedstream_t* sk_managedstream_new ();
+SK_X_API void sk_managedstream_destroy (sk_stream_managedstream_t*);
+
+SK_X_API void sk_managedstream_set_delegates (const sk_managedstream_read_delegate pRead,
+                                              const sk_managedstream_peek_delegate pPeek,
+                                              const sk_managedstream_isAtEnd_delegate pIsAtEnd,
+                                              const sk_managedstream_hasPosition_delegate pHasPosition,
+                                              const sk_managedstream_hasLength_delegate pHasLength,
+                                              const sk_managedstream_rewind_delegate pRewind,
+                                              const sk_managedstream_getPosition_delegate pGetPosition,
+                                              const sk_managedstream_seek_delegate pSeek,
+                                              const sk_managedstream_move_delegate pMove,
+                                              const sk_managedstream_getLength_delegate pGetLength,
+                                              const sk_managedstream_createNew_delegate pCreateNew,
+                                              const sk_managedstream_destroy_delegate pDestroy);
+
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/include/xamarin/sk_managedstream.h
+++ b/include/xamarin/sk_managedstream.h
@@ -27,7 +27,7 @@ typedef size_t (*sk_managedwstream_bytesWritten_delegate) (const sk_wstream_mana
 typedef void   (*sk_managedwstream_destroy_delegate)      (size_t cmanagedStream);
 
 
-SK_X_API sk_wstream_managedstream_t* sk_managedwstream_new ();
+SK_X_API sk_wstream_managedstream_t* sk_managedwstream_new (void);
 SK_X_API void sk_managedwstream_destroy (sk_wstream_managedstream_t*);
 
 SK_X_API void sk_managedwstream_set_delegates (const sk_managedwstream_write_delegate pWrite,
@@ -54,7 +54,7 @@ typedef void                       (*sk_managedstream_destroy_delegate)      (si
 
 
 // c API
-SK_X_API sk_stream_managedstream_t* sk_managedstream_new ();
+SK_X_API sk_stream_managedstream_t* sk_managedstream_new (void);
 SK_X_API void sk_managedstream_destroy (sk_stream_managedstream_t*);
 
 SK_X_API void sk_managedstream_set_delegates (const sk_managedstream_read_delegate pRead,

--- a/include/xamarin/sk_xamarin.h
+++ b/include/xamarin/sk_xamarin.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+// EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL EXPERIMENTAL
+// DO NOT USE -- FOR INTERNAL TESTING ONLY
+
+
+#ifndef sk_xamarin_DEFINED
+#define sk_xamarin_DEFINED
+
+#include "sk_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+#if defined(_WIN32)
+#  define SK_X_API __declspec(dllexport)
+#else
+#  define SK_X_API __attribute__((visibility("default")))
+#endif
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/src/xamarin/SkManagedPixelSerializer.cpp
+++ b/src/xamarin/SkManagedPixelSerializer.cpp
@@ -1,0 +1,28 @@
+//
+//  SkManagedPixelSerializer.cpp
+//
+//  Created by Matthew on 2017/08/18.
+//  Copyright © 2017 Xamarin. All rights reserved.
+//
+
+#include "SkManagedPixelSerializer.h"
+
+static use_delegate fUse = nullptr;
+static encode_delegate fEncode = nullptr;
+
+SkManagedPixelSerializer::SkManagedPixelSerializer() {
+}
+
+void SkManagedPixelSerializer::setDelegates(const use_delegate pUse, const encode_delegate pEncode)
+{
+    ::fUse = pUse;
+    ::fEncode = pEncode;
+}
+
+bool SkManagedPixelSerializer::onUseEncodedData(const void* data, size_t len) {
+    return ::fUse(this, data, len);
+}
+
+SkData* SkManagedPixelSerializer::onEncode(const SkPixmap& pixmap) {
+    return ::fEncode(this, pixmap);
+}

--- a/src/xamarin/SkManagedStream.cpp
+++ b/src/xamarin/SkManagedStream.cpp
@@ -1,0 +1,153 @@
+//
+//  SkManagedStream.cpp
+//
+//  Created by Matthew on 2016/01/08.
+//  Copyright © 2016 Xamarin. All rights reserved.
+//
+
+#include "SkManagedStream.h"
+
+
+// read stream
+static read_delegate fRead = nullptr;
+static peek_delegate fPeek = nullptr;
+static isAtEnd_delegate fIsAtEnd = nullptr;
+static hasPosition_delegate fHasPosition = nullptr;
+static hasLength_delegate fHasLength = nullptr;
+static rewind_delegate fRewind = nullptr;
+static getPosition_delegate fGetPosition = nullptr;
+static seek_delegate fSeek = nullptr;
+static move_delegate fMove = nullptr;
+static getLength_delegate fGetLength = nullptr;
+static createNew_delegate fCreateNew = nullptr;
+static destroy_delegate fDestroy = nullptr;
+
+// write stream
+static write_delegate fWrite = nullptr;
+static flush_delegate fFlush = nullptr;
+static bytesWritten_delegate fBytesWritten = nullptr;
+static wdestroy_delegate fWDestroy = nullptr;
+
+
+// the read stream
+
+SkManagedStream::SkManagedStream() {
+    this->address = (size_t)this;
+}
+
+SkManagedStream::~SkManagedStream() {
+    ::fDestroy(address);
+}
+
+void SkManagedStream::setDelegates(const read_delegate pRead,
+                                   const peek_delegate pPeek,
+                                   const isAtEnd_delegate pIsAtEnd,
+                                   const hasPosition_delegate pHasPosition,
+                                   const hasLength_delegate pHasLength,
+                                   const rewind_delegate pRewind,
+                                   const getPosition_delegate pGetPosition,
+                                   const seek_delegate pSeek,
+                                   const move_delegate pMove,
+                                   const getLength_delegate pGetLength,
+                                   const createNew_delegate pCreateNew,
+                                   const destroy_delegate pDestroy)
+{
+    ::fRead = (pRead);
+    ::fPeek = (pPeek);
+    ::fIsAtEnd = (pIsAtEnd);
+    ::fHasPosition = (pHasPosition);
+    ::fHasLength = (pHasLength);
+    ::fRewind = (pRewind);
+    ::fGetPosition = (pGetPosition);
+    ::fSeek = (pSeek);
+    ::fMove = (pMove);
+    ::fGetLength = (pGetLength);
+    ::fCreateNew = (pCreateNew);
+    ::fDestroy = (pDestroy);
+}
+
+
+size_t SkManagedStream::read(void* buffer, size_t size) {
+    return ::fRead(this, buffer, size);
+}
+
+size_t SkManagedStream::peek(void *buffer, size_t size) const {
+    SkManagedStream* nonConstThis = const_cast<SkManagedStream*>(this);
+    return ::fPeek(nonConstThis, buffer, size);
+}
+
+bool SkManagedStream::isAtEnd() const {
+    return ::fIsAtEnd(this);
+}
+
+bool SkManagedStream::hasPosition() const {
+    return ::fHasPosition(this);
+}
+
+bool SkManagedStream::hasLength() const {
+    return ::fHasLength(this);
+}
+
+bool SkManagedStream::rewind() {
+    return ::fRewind(this);
+}
+
+size_t SkManagedStream::getPosition() const {
+    return ::fGetPosition(this);
+}
+
+bool SkManagedStream::seek(size_t position) {
+    return ::fSeek(this, position);
+}
+
+bool SkManagedStream::move(long offset) {
+    return ::fMove(this, offset);
+}
+
+size_t SkManagedStream::getLength() const {
+    return ::fGetLength(this);
+}
+
+SkManagedStream* SkManagedStream::duplicate() const {
+    return ::fCreateNew(this);
+}
+
+SkManagedStream* SkManagedStream::fork() const {
+    std::unique_ptr<SkManagedStream> that(::fCreateNew(this));
+    that->seek(getPosition());
+    return that.release();
+}
+
+
+// the write stream
+
+SkManagedWStream::SkManagedWStream() {
+    this->address = (size_t)this;
+}
+
+SkManagedWStream::~SkManagedWStream() {
+    ::fWDestroy(address);
+}
+
+void SkManagedWStream::setDelegates(const write_delegate pWrite,
+                                    const flush_delegate pFlush,
+                                    const bytesWritten_delegate pBytesWritten,
+                                    const wdestroy_delegate pDestroy)
+{
+    ::fWrite = (pWrite);
+    ::fFlush = (pFlush);
+    ::fBytesWritten = (pBytesWritten);
+    ::fWDestroy = (pDestroy);
+}
+
+bool SkManagedWStream::write(const void* buffer, size_t size) {
+    return ::fWrite(this, buffer, size);
+}
+
+void SkManagedWStream::flush() {
+    ::fFlush(this);
+}
+
+size_t SkManagedWStream::bytesWritten() const {
+    return ::fBytesWritten(this);
+}

--- a/src/xamarin/SkiaKeeper.c
+++ b/src/xamarin/SkiaKeeper.c
@@ -42,9 +42,9 @@
 #include "sk_managedstream.h"
 #include "sk_managedpixelserializer.h"
 
-SK_X_API void** KeepSkiaCSymbols ();
+SK_X_API void** KeepSkiaCSymbols (void);
 
-void** KeepSkiaCSymbols ()
+void** KeepSkiaCSymbols (void)
 {
     static void* ret[] = {
         // Skia

--- a/src/xamarin/SkiaKeeper.c
+++ b/src/xamarin/SkiaKeeper.c
@@ -1,0 +1,87 @@
+//
+//  SkiaKeeper.c
+//
+//  Created by Bill Holmes on 11/23/15.
+//  Copyright © 2015 Xamarin. All rights reserved.
+//
+
+#include "sk_xamarin.h"
+
+// Skia
+#include "gr_context.h"
+#include "sk_bitmap.h"
+#include "sk_canvas.h"
+#include "sk_codec.h"
+#include "sk_colorfilter.h"
+#include "sk_colorspace.h"
+#include "sk_colortable.h"
+#include "sk_data.h"
+#include "sk_document.h"
+#include "sk_image.h"
+#include "sk_imagefilter.h"
+#include "sk_mask.h"
+#include "sk_maskfilter.h"
+#include "sk_matrix.h"
+#include "sk_paint.h"
+#include "sk_path.h"
+#include "sk_patheffect.h"
+#include "sk_picture.h"
+#include "sk_pixmap.h"
+#include "sk_pixelserializer.h"
+#include "sk_region.h"
+#include "sk_shader.h"
+#include "sk_stream.h"
+#include "sk_string.h"
+#include "sk_surface.h"
+#include "sk_svg.h"
+#include "sk_typeface.h"
+#include "sk_xml.h"
+#include "sk_vertices.h"
+
+// Xamarin
+#include "sk_managedstream.h"
+#include "sk_managedpixelserializer.h"
+
+SK_X_API void** KeepSkiaCSymbols ();
+
+void** KeepSkiaCSymbols ()
+{
+    static void* ret[] = {
+        // Skia
+        (void*)gr_context_create,
+        (void*)gr_glinterface_create_native_interface,
+        (void*)sk_bitmap_new,
+        (void*)sk_canvas_destroy,
+        (void*)sk_codec_min_buffered_bytes_needed,
+        (void*)sk_colorfilter_unref,
+        (void*)sk_colorspace_unref,
+        (void*)sk_colortable_unref,
+        (void*)sk_data_new_empty,
+        (void*)sk_document_unref,
+        (void*)sk_image_ref,
+        (void*)sk_imagefilter_croprect_new,
+        (void*)sk_mask_alloc_image,
+        (void*)sk_maskfilter_ref,
+        (void*)sk_matrix_set_identity,
+        (void*)sk_paint_new,
+        (void*)sk_path_new,
+        (void*)sk_path_effect_unref,
+        (void*)sk_picture_recorder_new,
+        (void*)sk_pixmap_destructor,
+        (void*)sk_pixelserializer_unref,
+        (void*)sk_region_new,
+        (void*)sk_shader_ref,
+        (void*)sk_stream_asset_destroy,
+        (void*)sk_string_new_empty,
+        (void*)sk_colortype_get_default_8888,
+        (void*)sk_svgcanvas_create,
+        (void*)sk_typeface_create_from_name,
+        (void*)sk_xmlstreamwriter_new,
+        (void*)sk_vertices_unref,
+
+        // Xamarin
+        (void*)sk_managedstream_new,
+        (void*)sk_managedpixelserializer_new,
+    };
+    return ret;
+}

--- a/src/xamarin/WinRTCompat.cpp
+++ b/src/xamarin/WinRTCompat.cpp
@@ -1,0 +1,78 @@
+//
+//  WinRTCompat.c
+//
+//  Created by Matthew Leibowitz on 06/09/16.
+//  Copyright © 2016 Xamarin. All rights reserved.
+//
+
+#include "WinRTCompat.h"
+
+#ifdef SK_BUILD_FOR_WINRT
+
+#include <windows.h>
+
+#ifdef _M_ARM
+
+unsigned int _mm_crc32_u32(unsigned int crc, unsigned int v)
+{
+	return 0;
+}
+
+#endif // _M_ARM
+
+DWORD WINAPI TlsAllocCompat(VOID)
+{
+	return ::FlsAlloc(NULL);
+}
+
+LPVOID WINAPI TlsGetValueCompat(_In_ DWORD dwTlsIndex)
+{
+	return ::FlsGetValue(dwTlsIndex);
+}
+
+BOOL WINAPI TlsSetValueCompat(_In_ DWORD dwTlsIndex, _In_opt_ LPVOID lpTlsValue)
+{
+	return ::FlsSetValue(dwTlsIndex, lpTlsValue);
+}
+
+BOOL WINAPI TlsFreeCompat(_In_ DWORD dwTlsIndex)
+{
+	return ::FlsFree(dwTlsIndex);
+}
+
+char *getenvCompat(const char *name)
+{
+	// there is no environment in WinRT
+	return NULL;
+}
+
+int WINAPI CompareStringWCompat(_In_ LCID Locale, _In_ DWORD dwCmpFlags, _In_NLS_string_(cchCount1) PCNZWCH lpString1, _In_ int cchCount1, _In_NLS_string_(cchCount2) PCNZWCH lpString2, _In_ int cchCount2)
+{
+	WCHAR localeName[LOCALE_NAME_MAX_LENGTH];
+	LCIDToLocaleName(Locale, localeName, LOCALE_NAME_MAX_LENGTH, 0);
+	return CompareStringEx(localeName, dwCmpFlags, lpString1, cchCount1, lpString2, cchCount2, NULL, NULL, NULL);
+}
+
+UINT WINAPI GetACPCompat(void)
+{
+	return CP_ACP;
+}
+
+HANDLE WINAPI OpenThreadCompat(_In_ DWORD dwDesiredAccess, _In_ BOOL bInheritHandle, _In_ DWORD dwThreadId)
+{
+	// TODO: implementation
+	return NULL;
+}
+
+DWORD WINAPI GetTickCountCompat(VOID)
+{
+	return (long)GetTickCount64();
+}
+
+int WINAPI MessageBoxACompat(_In_opt_ HWND hWnd, _In_opt_ LPCSTR lpText, _In_opt_ LPCSTR lpCaption, _In_ UINT uType)
+{
+	// TODO: implementation
+	return 0;
+}
+
+#endif // SK_BUILD_FOR_WINRT

--- a/src/xamarin/sk_managedpixelserializer.cpp
+++ b/src/xamarin/sk_managedpixelserializer.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "SkManagedPixelSerializer.h"
+
+#include "sk_managedpixelserializer.h"
+#include "sk_types_priv.h"
+
+
+static sk_managedpixelserializer_use_delegate    gUse;
+static sk_managedpixelserializer_encode_delegate gEncode;
+
+
+static inline sk_managedpixelserializer_t* ToManagedPixelSerializer(SkManagedPixelSerializer* cserializer) {
+    return reinterpret_cast<sk_managedpixelserializer_t*>(cserializer);
+}
+
+
+bool dUse(SkManagedPixelSerializer* cserializer, const void* data, size_t len)
+{
+    return gUse(ToManagedPixelSerializer(cserializer), data, len);
+}
+
+SkData* dEncode(SkManagedPixelSerializer* cserializer, const SkPixmap& pixmap)
+{
+    return AsData(gEncode(ToManagedPixelSerializer(cserializer), ToPixmap(&pixmap)));
+}
+
+
+sk_managedpixelserializer_t* sk_managedpixelserializer_new ()
+{
+    return ToManagedPixelSerializer (new SkManagedPixelSerializer ());
+}
+
+void sk_managedpixelserializer_set_delegates (
+    const sk_managedpixelserializer_use_delegate pUse, 
+    const sk_managedpixelserializer_encode_delegate pEncode)
+{
+    gUse = pUse;
+    gEncode = pEncode;
+
+    SkManagedPixelSerializer::setDelegates(dUse, dEncode);
+}
+

--- a/src/xamarin/sk_managedstream.cpp
+++ b/src/xamarin/sk_managedstream.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "SkManagedStream.h"
+
+#include "sk_managedstream.h"
+#include "sk_types_priv.h"
+
+
+static sk_managedwstream_write_delegate        gWrite;
+static sk_managedwstream_flush_delegate        gFlush;
+static sk_managedwstream_bytesWritten_delegate gBytesWritten;
+static sk_managedwstream_destroy_delegate      gWDestroy;
+
+static inline SkManagedWStream* AsManagedWStream(sk_wstream_managedstream_t* cstream) {
+    return reinterpret_cast<SkManagedWStream*>(cstream);
+}
+static inline sk_wstream_managedstream_t* ToManagedWStream(SkManagedWStream* stream) {
+    return reinterpret_cast<sk_wstream_managedstream_t*>(stream);
+}
+static inline const sk_wstream_managedstream_t* ToManagedWStream(const SkManagedWStream* stream) {
+    return reinterpret_cast<const sk_wstream_managedstream_t*>(stream);
+}
+
+bool dWrite(SkManagedWStream* managedStream, const void* buffer, size_t size)
+{
+    return gWrite(ToManagedWStream(managedStream), buffer, size);
+}
+void dFlush(SkManagedWStream* managedStream)
+{
+    gFlush(ToManagedWStream(managedStream));
+}
+size_t dBytesWritten(const SkManagedWStream* managedStream)
+{
+    return gBytesWritten(ToManagedWStream(managedStream));
+}
+void dWDestroy(size_t managedStream)
+{
+    gWDestroy(managedStream);
+}
+
+sk_wstream_managedstream_t* sk_managedwstream_new()
+{
+    return ToManagedWStream(new SkManagedWStream());
+}
+
+void sk_managedwstream_destroy(sk_wstream_managedstream_t* stream)
+{
+    delete AsManagedWStream(stream);
+}
+
+void sk_managedwstream_set_delegates(const sk_managedwstream_write_delegate pWrite,
+                                     const sk_managedwstream_flush_delegate pFlush,
+                                     const sk_managedwstream_bytesWritten_delegate pBytesWritten,
+                                     const sk_managedwstream_destroy_delegate pDestroy)
+{
+    gWrite = pWrite;
+    gFlush = pFlush;
+    gBytesWritten = pBytesWritten;
+    gWDestroy = pDestroy;
+
+    SkManagedWStream::setDelegates(dWrite, dFlush, dBytesWritten, dWDestroy);
+}
+
+
+static sk_managedstream_read_delegate         gRead;
+static sk_managedstream_peek_delegate         gPeek;
+static sk_managedstream_isAtEnd_delegate      gIsAtEnd;
+static sk_managedstream_hasPosition_delegate  gHasPosition;
+static sk_managedstream_hasLength_delegate    gHasLength;
+static sk_managedstream_rewind_delegate       gRewind;
+static sk_managedstream_getPosition_delegate  gGetPosition;
+static sk_managedstream_seek_delegate         gSeek;
+static sk_managedstream_move_delegate         gMove;
+static sk_managedstream_getLength_delegate    gGetLength;
+static sk_managedstream_createNew_delegate    gCreateNew;
+static sk_managedstream_destroy_delegate      gDestroy;
+
+
+static inline SkManagedStream* AsManagedStream(sk_stream_managedstream_t* cstream) {
+    return reinterpret_cast<SkManagedStream*>(cstream);
+}
+static inline sk_stream_managedstream_t* ToManagedStream(SkManagedStream* stream) {
+    return reinterpret_cast<sk_stream_managedstream_t*>(stream);
+}
+static inline const sk_stream_managedstream_t* ToManagedStream(const SkManagedStream* stream) {
+    return reinterpret_cast<const sk_stream_managedstream_t*>(stream);
+}
+
+
+size_t dRead(SkManagedStream* managedStream, void* buffer, size_t size)
+{
+    return gRead(ToManagedStream(managedStream), buffer, size);
+}
+size_t dPeek(SkManagedStream* managedStream, void* buffer, size_t size)
+{
+    return gPeek(ToManagedStream(managedStream), buffer, size);
+}
+bool dIsAtEnd(const SkManagedStream* managedStream)
+{
+    return gIsAtEnd(ToManagedStream(managedStream));
+}
+bool dHasPosition(const SkManagedStream* managedStream)
+{
+    return gHasPosition(ToManagedStream(managedStream));
+}
+bool dHasLength(const SkManagedStream* managedStream)
+{
+    return gHasLength(ToManagedStream(managedStream));
+}
+bool dRewind(SkManagedStream* managedStream)
+{
+    return gRewind(ToManagedStream(managedStream));
+}
+size_t dGetPosition(const SkManagedStream* managedStream)
+{
+    return gGetPosition(ToManagedStream(managedStream));
+}
+bool dSeek(SkManagedStream* managedStream, size_t position)
+{
+    return gSeek(ToManagedStream(managedStream), position);
+}
+bool dMove(SkManagedStream* managedStream, long offset)
+{
+    return gMove(ToManagedStream(managedStream), offset);
+}
+size_t dGetLength(const SkManagedStream* managedStream)
+{
+    return gGetLength(ToManagedStream(managedStream));
+}
+SkManagedStream* dCreateNew(const SkManagedStream* managedStream)
+{
+    return AsManagedStream(gCreateNew(ToManagedStream(managedStream)));
+}
+void dDestroy(size_t managedStream)
+{
+    gDestroy(managedStream);
+}
+
+
+sk_stream_managedstream_t* sk_managedstream_new ()
+{
+    return ToManagedStream (new SkManagedStream ());
+}
+
+void sk_managedstream_destroy (sk_stream_managedstream_t* stream)
+{
+    delete AsManagedStream (stream);
+}
+
+void sk_managedstream_set_delegates (const sk_managedstream_read_delegate pRead,
+                                     const sk_managedstream_peek_delegate pPeek,
+                                     const sk_managedstream_isAtEnd_delegate pIsAtEnd,
+                                     const sk_managedstream_hasPosition_delegate pHasPosition,
+                                     const sk_managedstream_hasLength_delegate pHasLength,
+                                     const sk_managedstream_rewind_delegate pRewind,
+                                     const sk_managedstream_getPosition_delegate pGetPosition,
+                                     const sk_managedstream_seek_delegate pSeek,
+                                     const sk_managedstream_move_delegate pMove,
+                                     const sk_managedstream_getLength_delegate pGetLength,
+                                     const sk_managedstream_createNew_delegate pCreateNew,
+                                     const sk_managedstream_destroy_delegate pDestroy)
+{
+    gRead = pRead;
+    gPeek = pPeek;
+    gIsAtEnd = pIsAtEnd;
+    gHasPosition = pHasPosition;
+    gHasLength = pHasLength;
+    gRewind = pRewind;
+    gGetPosition = pGetPosition;
+    gSeek = pSeek;
+    gMove = pMove;
+    gGetLength = pGetLength;
+    gCreateNew = pCreateNew;
+    gDestroy = pDestroy;
+
+    SkManagedStream::setDelegates(dRead, dPeek, dIsAtEnd, dHasPosition, dHasLength, dRewind, dGetPosition, dSeek, dMove, dGetLength, dCreateNew, dDestroy);
+}
+

--- a/src/xamarin/sk_xamarin.cpp
+++ b/src/xamarin/sk_xamarin.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Xamarin Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "SkCodec.h"
+
+#include "sk_xamarin.h"
+
+#include "sk_types_priv.h"
+
+#ifdef NEED_INIT_NEON
+
+namespace SkOpts {
+    void Init_neon() {}
+}
+
+#endif


### PR DESCRIPTION
Moving all native code into the native skia repository, including the Xamarin-specific files. In addition to the code, building the `SkiaSharp` target will spit out narive `libSkiaSharp` for Win32, UWP, Android and Linux.

Related to: https://github.com/mono/SkiaSharp/pull/472/