### PR TITLE
Ignore new warnings introduced by clang 10

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -362,6 +362,10 @@ config("warnings") {
     cflags += [
       "-Weverything",
       "-Wno-unknown-warning-option",  # Let older Clangs ignore newer Clangs' warnings.
+      
+      # clang 10 fixes
+      "-Wno-anon-enum-enum-conversion",
+      "-Wno-sizeof-array-div",
     ]
 
     if (target_cpu == "arm" && is_ios) {


### PR DESCRIPTION
Clang 10 introduced some new warnings that caused the build to fail. This disables those warnings.