### PR TITLE
Adjust sk_maskfilter_new_blur_with_flags to implementation

### DIFF
--- a/include/c/sk_maskfilter.h
+++ b/include/c/sk_maskfilter.h
@@ -17,7 +17,7 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
 SK_C_API void sk_maskfilter_ref(sk_maskfilter_t*);
 SK_C_API void sk_maskfilter_unref(sk_maskfilter_t*);
 SK_C_API sk_maskfilter_t* sk_maskfilter_new_blur(sk_blurstyle_t, float sigma);
-SK_C_API sk_maskfilter_t* sk_maskfilter_new_blur_with_flags(sk_blurstyle_t, float sigma, const sk_rect_t* occluder, bool respectCTM);
+SK_C_API sk_maskfilter_t* sk_maskfilter_new_blur_with_flags(sk_blurstyle_t, float sigma, bool respectCTM);
 SK_C_API sk_maskfilter_t* sk_maskfilter_new_table(const uint8_t table[256]);
 SK_C_API sk_maskfilter_t* sk_maskfilter_new_gamma(float gamma);
 SK_C_API sk_maskfilter_t* sk_maskfilter_new_clip(uint8_t min, uint8_t max);


### PR DESCRIPTION
This changes aligns the header definition to the function implementation, which does not have the occluder parameter.