### PR TITLE
Implement Vulkan bindings for m80.

### DIFF
--- a/include/c/gr_context.h
+++ b/include/c/gr_context.h
@@ -46,21 +46,10 @@ SK_C_API void gr_glinterface_unref(const gr_glinterface_t* glInterface);
 SK_C_API bool gr_glinterface_validate(const gr_glinterface_t* glInterface);
 SK_C_API bool gr_glinterface_has_extension(const gr_glinterface_t* glInterface, const char* extension);
 
-// GrVkInterface
-
-SK_C_API gr_vkinterface_t* gr_vkinterface_make(vk_getinstanceprocaddr_t* vkGetInstanceProcAddr,
-                                               vk_getdeviceprocaddr_t* vkGetDeviceProcAddr,
-                                               vk_instance_t* vkInstance,
-                                               vk_device_t* vkDevice,
-                                               uint32_t extensionFlags);
-
-SK_C_API void gr_vkinterface_unref(gr_vkinterface_t* grVkInterface);
-
-SK_C_API bool gr_vkinterface_validate(const gr_vkinterface_t* grVkInterface, uint32_t extensionsFlags);
-
 // GrVkBackendContext
 
-SK_C_API gr_vkbackendcontext_t* gr_vkbackendcontext_assemble(vk_instance_t* vkInstance,
+SK_C_API gr_vkbackendcontext_t* gr_vkbackendcontext_assemble(void* ctx,
+                                                             vk_instance_t* vkInstance,
                                                              vk_physical_device_t* vkPhysicalDevice,
                                                              vk_device_t* vkDevice,
                                                              vk_queue_t* vkQueue,
@@ -68,9 +57,9 @@ SK_C_API gr_vkbackendcontext_t* gr_vkbackendcontext_assemble(vk_instance_t* vkIn
                                                              uint32_t minAPIVersion,
                                                              uint32_t extensions,
                                                              uint32_t features,
-                                                             gr_vkinterface_t* grVkInterface);
+                                                             gr_vk_get_proc getProc);
 
-SK_C_API void gr_vkbackendcontext_unref(gr_vkbackendcontext_t* grVkBackendContext);
+SK_C_API void gr_vkbackendcontext_delete(gr_vkbackendcontext_t* grVkBackendContext);
 
 
 // GrBackendTexture

--- a/include/c/gr_context.h
+++ b/include/c/gr_context.h
@@ -18,7 +18,7 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
 // GrContext
 
 SK_C_API gr_context_t* gr_context_make_gl(const gr_glinterface_t* glInterface);
-SK_C_API gr_context_t* gr_context_make_vulkan(const gr_vkbackendcontext_t* vkBackendContext);
+SK_C_API gr_context_t* gr_context_make_vulkan(gr_vk_backendcontext_t vkBackendContext);
 
 // TODO: the overloads with GrContextOptions
 // TODO: the Metal context
@@ -46,21 +46,12 @@ SK_C_API void gr_glinterface_unref(const gr_glinterface_t* glInterface);
 SK_C_API bool gr_glinterface_validate(const gr_glinterface_t* glInterface);
 SK_C_API bool gr_glinterface_has_extension(const gr_glinterface_t* glInterface, const char* extension);
 
-// GrVkBackendContext
+// GrVkExtensions
 
-SK_C_API gr_vkbackendcontext_t* gr_vkbackendcontext_assemble(void* ctx,
-                                                             vk_instance_t* vkInstance,
-                                                             vk_physical_device_t* vkPhysicalDevice,
-                                                             vk_device_t* vkDevice,
-                                                             vk_queue_t* vkQueue,
-                                                             uint32_t graphicsQueueIndex,
-                                                             uint32_t minAPIVersion,
-                                                             uint32_t extensions,
-                                                             uint32_t features,
-                                                             gr_vk_get_proc getProc);
-
-SK_C_API void gr_vkbackendcontext_delete(gr_vkbackendcontext_t* grVkBackendContext);
-
+SK_C_API gr_vk_extensions_t* gr_vk_extensions_new();
+SK_C_API void gr_vk_extensions_delete(gr_vk_extensions_t* extensions);
+SK_C_API void gr_vk_extensions_init(gr_vk_extensions_t* extensions, gr_vk_get_proc getProc, void* userData, vk_instance_t* instance, vk_physical_device_t* physDev, uint32_t instanceExtensionCount, const char** instanceExtensions, uint32_t deviceExtensionCount, const char** deviceExtensions);
+SK_C_API bool gr_vk_extensions_has_extension(gr_vk_extensions_t* extensions, const char* ext, uint32_t minVersion);
 
 // GrBackendTexture
 

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -676,32 +676,47 @@ typedef struct {
 } gr_gl_framebufferinfo_t;
 
 typedef struct gr_vkbackendcontext_t gr_vkbackendcontext_t;
-typedef struct gr_vkinterface_t gr_vkinterface_t;
 
 typedef struct {
     uint64_t  fMemory;
     uint64_t  fOffset;
     uint64_t  fSize;
     uint32_t  fFlags;
+    intptr_t  fBackendMemory;
     bool      _private_fUsesSystemHeap;
 } gr_vk_alloc_t;
 
-typedef struct {
-    uint64_t       fImage;
-    gr_vk_alloc_t  fAlloc;
-    uint32_t       fImageTiling;
-    uint32_t       fImageLayout;
-    uint32_t       fFormat;
-    uint32_t       fLevelCount;
-} gr_vk_imageinfo_t;
+typedef struct gr_vk_ycbcr_conversion_info_t {
+    uint32_t fFormat;
+    uint64_t fExternalFormat;
+    uint32_t fYcbcrModel;
+    uint32_t fYcbcrRange;
+    uint32_t fXChromaOffset;
+    uint32_t fYChromaOffset;
+    uint32_t fChromaFilter;
+    uint32_t fForceExplicitReconstruction;
+    uint32_t fFormatFeatures;
+} gr_vk_ycbcr_conversion_info_t;
 
-typedef struct vk_getinstanceprocaddr_t vk_getinstanceprocaddr_t;
-typedef struct vk_getdeviceprocaddr_t vk_getdeviceprocaddr_t;
+typedef struct {
+    uint64_t                        fImage;
+    gr_vk_alloc_t                   fAlloc;
+    uint32_t                        fImageTiling;
+    uint32_t                        fImageLayout;
+    uint32_t                        fFormat;
+    uint32_t                        fLevelCount;
+    uint32_t                        fCurrentQueueFamily;
+    bool                            fProtected;
+    gr_vk_ycbcr_conversion_info_t   fYcbcrConversionInfo;
+} gr_vk_imageinfo_t;
 
 typedef struct vk_instance_t vk_instance_t;
 typedef struct vk_physical_device_t vk_physical_device_t;
 typedef struct vk_device_t vk_device_t;
 typedef struct vk_queue_t vk_queue_t;
+
+typedef void (*gr_vk_func_ptr)(void);
+typedef gr_vk_func_ptr (*gr_vk_get_proc)(void* ctx, const char* name, vk_instance_t* instance, vk_device_t* device);
 
 typedef enum {
     DIFFERENCE_SK_PATHOP,

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -38,6 +38,10 @@
     #endif
 #endif
 
+#if defined(_WIN32)
+    #define VKAPI_CALL __stdcall
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////////////
 
 SK_C_PLUS_PLUS_BEGIN_GUARD
@@ -675,28 +679,63 @@ typedef struct {
     unsigned int fFormat;
 } gr_gl_framebufferinfo_t;
 
-typedef struct gr_vkbackendcontext_t gr_vkbackendcontext_t;
+typedef struct vk_instance_t vk_instance_t;
+typedef struct gr_vkinterface_t gr_vkinterface_t;
+typedef struct vk_physical_device_t vk_physical_device_t;
+typedef struct vk_physical_device_features_t vk_physical_device_features_t;
+typedef struct vk_physical_device_features_2_t vk_physical_device_features_2_t;
+typedef struct vk_device_t vk_device_t;
+typedef struct vk_queue_t vk_queue_t;
+
+typedef struct gr_vk_extensions_t gr_vk_extensions_t;
+typedef struct gr_vk_memory_allocator_t gr_vk_memory_allocator_t;
+
+typedef void(VKAPI_CALL *gr_vk_func_ptr)(void);
+typedef gr_vk_func_ptr (*gr_vk_get_proc)(void* ctx, const char* name, vk_instance_t* instance, vk_device_t* device);
 
 typedef struct {
-    uint64_t  fMemory;
-    uint64_t  fOffset;
-    uint64_t  fSize;
-    uint32_t  fFlags;
-    intptr_t  fBackendMemory;
-    bool      _private_fUsesSystemHeap;
+    vk_instance_t*                          fInstance;
+    vk_physical_device_t*                   fPhysicalDevice;
+    vk_device_t*                            fDevice;
+    vk_queue_t*                             fQueue;
+    uint32_t                                fGraphicsQueueIndex;
+    uint32_t                                fMinAPIVersion;
+    uint32_t                                fInstanceVersion;
+    uint32_t                                fMaxAPIVersion;
+    uint32_t                                fExtensions;
+    const gr_vk_extensions_t*               fVkExtensions;
+    uint32_t                                fFeatures;
+    const vk_physical_device_features_t*    fDeviceFeatures;
+    const vk_physical_device_features_2_t*  fDeviceFeatures2;
+    gr_vk_memory_allocator_t*               fMemoryAllocator;
+    gr_vk_get_proc                          fGetProc;
+    intptr_t                                fGetProcContext;
+    bool                                    fOwnsInstanceAndDevice;
+    bool                                    fProtectedContext;
+} gr_vk_backendcontext_t;
+
+typedef intptr_t gr_vk_backendmemory_t;
+
+typedef struct {
+    uint64_t               fMemory;
+    uint64_t               fOffset;
+    uint64_t               fSize;
+    uint32_t               fFlags;
+    gr_vk_backendmemory_t  fBackendMemory;
+    bool                   _private_fUsesSystemHeap;
 } gr_vk_alloc_t;
 
-typedef struct gr_vk_ycbcr_conversion_info_t {
-    uint32_t fFormat;
-    uint64_t fExternalFormat;
-    uint32_t fYcbcrModel;
-    uint32_t fYcbcrRange;
-    uint32_t fXChromaOffset;
-    uint32_t fYChromaOffset;
-    uint32_t fChromaFilter;
-    uint32_t fForceExplicitReconstruction;
-    uint32_t fFormatFeatures;
-} gr_vk_ycbcr_conversion_info_t;
+typedef struct {
+    uint32_t  fFormat;
+    uint64_t  fExternalFormat;
+    uint32_t  fYcbcrModel;
+    uint32_t  fYcbcrRange;
+    uint32_t  fXChromaOffset;
+    uint32_t  fYChromaOffset;
+    uint32_t  fChromaFilter;
+    uint32_t  fForceExplicitReconstruction;
+    uint32_t  fFormatFeatures;
+} gr_vk_ycbcrconversioninfo_t;
 
 typedef struct {
     uint64_t                        fImage;
@@ -707,16 +746,13 @@ typedef struct {
     uint32_t                        fLevelCount;
     uint32_t                        fCurrentQueueFamily;
     bool                            fProtected;
-    gr_vk_ycbcr_conversion_info_t   fYcbcrConversionInfo;
+    gr_vk_ycbcrconversioninfo_t     fYcbcrConversionInfo;
 } gr_vk_imageinfo_t;
 
 typedef struct vk_instance_t vk_instance_t;
 typedef struct vk_physical_device_t vk_physical_device_t;
 typedef struct vk_device_t vk_device_t;
 typedef struct vk_queue_t vk_queue_t;
-
-typedef void (*gr_vk_func_ptr)(void);
-typedef gr_vk_func_ptr (*gr_vk_get_proc)(void* ctx, const char* name, vk_instance_t* instance, vk_device_t* device);
 
 typedef enum {
     DIFFERENCE_SK_PATHOP,

--- a/src/c/gr_context.cpp
+++ b/src/c/gr_context.cpp
@@ -25,6 +25,7 @@
 #    define SK_ONLY_GPU(...) SK_FIRST_ARG(__VA_ARGS__)
 #    if SK_VULKAN
 #        include "include/gpu/vk/GrVkBackendContext.h"
+#        include "include/gpu/vk/GrVkExtensions.h"
 #        define SK_ONLY_VULKAN(...) SK_FIRST_ARG(__VA_ARGS__)
 #    else
 #        define SK_ONLY_VULKAN(...) SK_SKIP_ARG(__VA_ARGS__)
@@ -44,8 +45,8 @@ gr_context_t* gr_context_make_gl(const gr_glinterface_t* glInterface) {
     return SK_ONLY_GPU(ToGrContext(GrContext::MakeGL(sk_ref_sp(AsGrGLInterface(glInterface))).release()), nullptr);
 }
 
-gr_context_t* gr_context_make_vulkan(const gr_vkbackendcontext_t* vkBackendContext) {
-    return SK_ONLY_VULKAN(ToGrContext(GrContext::MakeVulkan(*AsGrVkBackendContext(vkBackendContext)).release()), nullptr);
+gr_context_t* gr_context_make_vulkan(const gr_vk_backendcontext_t vkBackendContext) {
+    return SK_ONLY_VULKAN(ToGrContext(GrContext::MakeVulkan(AsGrVkBackendContext(&vkBackendContext)).release()), nullptr);
 }
 
 void gr_context_unref(gr_context_t* context) {
@@ -119,46 +120,29 @@ bool gr_glinterface_has_extension(const gr_glinterface_t* glInterface, const cha
     return SK_ONLY_GPU(AsGrGLInterface(glInterface)->hasExtension(extension), false);
 }
 
-// GrVkBackendContext
+// GrVkExtensions
 
-gr_vkbackendcontext_t* gr_vkbackendcontext_assemble(void* ctx,
-                                                    vk_instance_t* vkInstance,
-                                                    vk_physical_device_t* vkPhysicalDevice,
-                                                    vk_device_t* vkDevice,
-                                                    vk_queue_t* vkQueue,
-                                                    uint32_t graphicsQueueIndex,
-                                                    uint32_t minAPIVersion,
-                                                    uint32_t extensions,
-                                                    uint32_t features,
-                                                    gr_vk_get_proc getProc) {
-    SK_ONLY_VULKAN(
-        GrVkBackendContext* grVkBackendContext = new GrVkBackendContext();
-
-        grVkBackendContext->fInstance = reinterpret_cast<VkInstance>(vkInstance);
-        grVkBackendContext->fPhysicalDevice = reinterpret_cast<VkPhysicalDevice>(vkPhysicalDevice);
-        grVkBackendContext->fDevice = reinterpret_cast<VkDevice>(vkDevice);
-        grVkBackendContext->fQueue = reinterpret_cast<VkQueue>(vkQueue);
-        grVkBackendContext->fGraphicsQueueIndex = graphicsQueueIndex;
-        grVkBackendContext->fMinAPIVersion = minAPIVersion;
-        grVkBackendContext->fExtensions = extensions;
-        grVkBackendContext->fFeatures = features;
-        grVkBackendContext->fOwnsInstanceAndDevice = false;
-        grVkBackendContext->fGetProc = [=](const char* name, VkInstance instance, VkDevice device)
-        {
-            auto proc = getProc(ctx,
-                          name,
-                          reinterpret_cast<vk_instance_t*>(instance),
-                          reinterpret_cast<vk_device_t*>(device));
-
-            return reinterpret_cast<PFN_vkVoidFunction>(proc);
-        };
-    );
-
-    return SK_ONLY_VULKAN(ToGrVkBackendContext(grVkBackendContext), nullptr);
+gr_vk_extensions_t* gr_vk_extensions_new() {
+    return SK_ONLY_VULKAN(ToGrVkExtensions(new GrVkExtensions()), nullptr);
 }
 
-void gr_vkbackendcontext_delete(gr_vkbackendcontext_t* grVkBackendContext) {
-    SK_ONLY_VULKAN(delete AsGrVkBackendContext(grVkBackendContext));
+void gr_vk_extensions_delete(gr_vk_extensions_t* extensions) {
+    SK_ONLY_VULKAN(delete AsGrVkExtensions(extensions));
+}
+
+void gr_vk_extensions_init(gr_vk_extensions_t* extensions, gr_vk_get_proc getProc, void* userData, vk_instance_t* instance, vk_physical_device_t* physDev, uint32_t instanceExtensionCount, const char** instanceExtensions, uint32_t deviceExtensionCount, const char** deviceExtensions) {
+    SK_ONLY_VULKAN(AsGrVkExtensions(extensions)->init(
+        [userData, getProc](const char* name, VkInstance instance, VkDevice device) -> PFN_vkVoidFunction {
+            return getProc(userData, name, ToVkInstance(instance), ToVkDevice(device));
+        },
+        AsVkInstance(instance),
+        AsVkPhysicalDevice(physDev),
+        instanceExtensionCount, instanceExtensions,
+        deviceExtensionCount, deviceExtensions));
+}
+
+bool gr_vk_extensions_has_extension(gr_vk_extensions_t* extensions, const char* ext, uint32_t minVersion) {
+    return SK_ONLY_VULKAN(AsGrVkExtensions(extensions)->hasExtension(ext, minVersion), nullptr);
 }
 
 // GrBackendTexture

--- a/src/c/sk_structs.cpp
+++ b/src/c/sk_structs.cpp
@@ -78,6 +78,7 @@ static_assert (sizeof (gr_gl_textureinfo_t) == sizeof (GrGLTextureInfo), ASSERT_
 #if SK_VULKAN
 static_assert (sizeof (gr_vk_alloc_t) == sizeof (GrVkAlloc), ASSERT_MSG(GrVkAlloc, gr_vk_alloc_t));
 static_assert (sizeof (gr_vk_imageinfo_t) == sizeof (GrVkImageInfo), ASSERT_MSG(GrVkImageInfo, gr_vk_imageinfo_t));
+static_assert (sizeof(gr_vk_ycbcrconversioninfo_t) == sizeof(GrVkYcbcrConversionInfo), ASSERT_MSG(GrVkYcbcrConversionInfo, gr_vk_ycbcrconversioninfo_t));
 #endif
 #endif
 

--- a/src/c/sk_structs.cpp
+++ b/src/c/sk_structs.cpp
@@ -31,7 +31,7 @@
 #include "include/gpu/gl/GrGLTypes.h"
 
 #if SK_VULKAN
-#include "vk/GrVkTypes.h"
+#include "include/gpu/vk/GrVkTypes.h"
 #endif
 
 #endif

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -130,7 +130,6 @@ DEF_STRUCT_MAP(GrGLFramebufferInfo, gr_gl_framebufferinfo_t, GrGLFramebufferInfo
 DEF_STRUCT_MAP(GrGLInterface, gr_glinterface_t, GrGLInterface)
 
 DEF_STRUCT_MAP(GrVkBackendContext, gr_vkbackendcontext_t, GrVkBackendContext)
-DEF_STRUCT_MAP(GrVkInterface, gr_vkinterface_t, GrVkInterface)
 DEF_STRUCT_MAP(GrVkImageInfo, gr_vk_imageinfo_t, GrVkImageInfo)
 
 #include "include/core/SkCanvas.h"

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -110,6 +110,8 @@ DEF_CLASS_MAP(GrContext, gr_context_t, GrContext)
 DEF_CLASS_MAP(GrBackendTexture, gr_backendtexture_t, GrBackendTexture)
 DEF_CLASS_MAP(GrBackendRenderTarget, gr_backendrendertarget_t, GrBackendRenderTarget)
 
+DEF_CLASS_MAP(GrVkExtensions, gr_vk_extensions_t, GrVkExtensions)
+
 DEF_STRUCT_MAP(skcms_ICCProfile, sk_colorspace_icc_profile_t, ColorSpaceIccProfile)
 DEF_STRUCT_MAP(SkColorSpacePrimaries, sk_colorspace_primaries_t, ColorSpacePrimaries)
 DEF_STRUCT_MAP(skcms_TransferFunction, sk_colorspace_transfer_fn_t, ColorSpaceTransferFn)
@@ -129,7 +131,7 @@ DEF_STRUCT_MAP(GrGLTextureInfo, gr_gl_textureinfo_t, GrGLTextureInfo)
 DEF_STRUCT_MAP(GrGLFramebufferInfo, gr_gl_framebufferinfo_t, GrGLFramebufferInfo)
 DEF_STRUCT_MAP(GrGLInterface, gr_glinterface_t, GrGLInterface)
 
-DEF_STRUCT_MAP(GrVkBackendContext, gr_vkbackendcontext_t, GrVkBackendContext)
+DEF_STRUCT_MAP(GrVkYcbcrConversionInfo, gr_vk_ycbcrconversioninfo_t, GrVkYcbcrConversionInfo)
 DEF_STRUCT_MAP(GrVkImageInfo, gr_vk_imageinfo_t, GrVkImageInfo)
 
 #include "include/core/SkCanvas.h"
@@ -276,5 +278,59 @@ static inline SkPDF::Metadata AsDocumentPDFMetadata(const sk_document_pdf_metada
     md.fEncodingQuality = metadata->fEncodingQuality;
     return md;
 }
+
+#if SK_SUPPORT_GPU
+// GPU specific
+
+#if SK_VULKAN
+#define DEF_MAP_VK(VkType, vk_type)                 \
+    static inline VkType As##VkType(vk_type* t) {   \
+        return reinterpret_cast<VkType>(t);         \
+    }                                               \
+    static inline vk_type* To##VkType(VkType t) {   \
+        return reinterpret_cast<vk_type*>(t);       \
+    }
+
+#include "include/gpu/vk/GrVkTypes.h"
+#include "include/gpu/vk/GrVkBackendContext.h"
+
+DEF_MAP_VK(VkInstance, vk_instance_t);
+DEF_MAP_VK(VkDevice, vk_device_t);
+DEF_MAP_VK(VkPhysicalDevice, vk_physical_device_t);
+DEF_MAP_VK(VkQueue, vk_queue_t);
+DEF_MAP(VkPhysicalDeviceFeatures, vk_physical_device_features_t, VkPhysicalDeviceFeatures);
+DEF_MAP(VkPhysicalDeviceFeatures2, vk_physical_device_features_2_t, VkPhysicalDeviceFeatures2);
+DEF_MAP(GrVkMemoryAllocator, gr_vk_memory_allocator_t, GrVkMemoryAllocator);
+
+static GrVkBackendContext AsGrVkBackendContext(const gr_vk_backendcontext_t* context) {
+    GrVkBackendContext ctx;
+    ctx.fInstance = AsVkInstance(context->fInstance);
+    ctx.fPhysicalDevice = AsVkPhysicalDevice(context->fPhysicalDevice);
+    ctx.fDevice = AsVkDevice(context->fDevice);
+    ctx.fQueue = AsVkQueue(context->fQueue);
+    ctx.fGraphicsQueueIndex = context->fGraphicsQueueIndex;
+    ctx.fMinAPIVersion = context->fMinAPIVersion;
+    ctx.fInstanceVersion = context->fInstanceVersion;
+    ctx.fMaxAPIVersion = context->fMaxAPIVersion;
+    ctx.fExtensions = context->fExtensions;
+    ctx.fVkExtensions = AsGrVkExtensions(context->fVkExtensions);
+    ctx.fFeatures = context->fFeatures;
+    ctx.fDeviceFeatures = AsVkPhysicalDeviceFeatures(context->fDeviceFeatures);
+    ctx.fDeviceFeatures2 = AsVkPhysicalDeviceFeatures2(context->fDeviceFeatures2);
+    ctx.fMemoryAllocator = sk_ref_sp(AsGrVkMemoryAllocator(context->fMemoryAllocator));
+    if (context->fGetProc != nullptr) {
+        ctx.fGetProc = [context](const char* name, VkInstance instance,
+                                 VkDevice device) -> PFN_vkVoidFunction {
+            return context->fGetProc(reinterpret_cast<void*>(context->fGetProcContext), name,
+                                     ToVkInstance(instance), ToVkDevice(device));
+        };
+    }
+    ctx.fOwnsInstanceAndDevice = context->fOwnsInstanceAndDevice;
+    ctx.fProtectedContext = context->fProtectedContext ? GrProtected::kYes : GrProtected::kNo;
+    return ctx;
+}
+
+#endif // SK_VULKAN
+#endif // SK_SUPPORT_GPU
 
 #endif


### PR DESCRIPTION
This updates Vulkan bindings from m68 to m80.

One major change is that m80 made `GrVkInterface` internal and now most of the config is passed via `GrVkBackendContext` that also is no longer a ref-counted object.