### PR TITLE
remove set_sources_assignment_filter

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3086,8 +3086,6 @@ skiasharp_build("SkiaSharp") {
     ":skia",
   ]
 
-  # clear the sources and add explicitly
-  set_sources_assignment_filter([])
   sources = [
     "src/xamarin/sk_compatpaint.cpp",
     "src/xamarin/sk_manageddrawable.cpp",


### PR DESCRIPTION
I don't think this is used anymore, I'm able to build without it, and it breaks compatibility with newer gn