### PR TITLE
Fix CI after VS updates

### DIFF
--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -29,6 +29,7 @@ declare_args() {
 
   win_vc = ""
   win_toolchain_version = ""
+  win_vcvars_version = ""
 
   clang_win = ""
   clang_win_version = ""
@@ -158,8 +159,17 @@ if (is_win) {
   if (win_vc == "") {
     win_vc = exec_script("//gn/find_msvc.py", [], "trim string")
   }
-  if (win_vc != "" && win_toolchain_version == "") {
-    win_toolchain_version = exec_script("//gn/highest_version_dir.py", [ "$win_vc/Tools/MSVC", "[0-9]{2}\.[0-9]{2}\.[0-9]{5}" ], "trim string")
+  if (win_vc != "") {
+    if (win_toolchain_version == "") {
+      if (win_vcvars_version != "") {
+        win_toolchain_version = exec_script("//gn/highest_version_dir.py", [ "$win_vc/Tools/MSVC", "$win_vcvars_version[0-9]{1}\.[0-9]{5}" ], "trim string")
+      } else {
+        win_toolchain_version = exec_script("//gn/highest_version_dir.py", [ "$win_vc/Tools/MSVC", "[0-9]{2}\.[0-9]{2}\.[0-9]{5}" ], "trim string")
+      }
+    }
+    if (win_vcvars_version == "") {
+      win_vcvars_version = exec_script("//gn/get_vcvars_version.py", [ win_toolchain_version ], "trim string")
+    }
   }
   if (win_sdk == "") {
     win_sdk = exec_script("//gn/find_winsdk.py", [], "trim string")

--- a/gn/get_vcvars_version.py
+++ b/gn/get_vcvars_version.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys
+
+sdk_version = sys.argv[1]
+
+print(sdk_version[0:4])

--- a/gn/toolchain/BUILD.gn
+++ b/gn/toolchain/BUILD.gn
@@ -98,7 +98,7 @@ toolchain("msvc") {
   if (is_winrt) {
     _target += " uwp"
   }
-  _target += " " + win_sdk_version + " -vcvars_ver=14.2"
+  _target += " " + win_sdk_version + " -vcvars_ver=" + win_vcvars_version
 
   _vcvarsall = "$win_vc/Auxiliary/Build/vcvarsall.bat"
   env_setup = "cmd /c set __VSCMD_ARG_NO_LOGO=1 && set VSCMD_START_DIR=%CD% && \"$_vcvarsall\" $_target && "


### PR DESCRIPTION
**Description of Change**

Some tools updated and we are not ready for it. The VC toolset 14.3 requires LLVM 13, so we need to go back down.

Part of https://github.com/mono/SkiaSharp/pull/2047