### PR TITLE
Support ARM64 simulators

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -37,7 +37,7 @@ if (is_ios && !is_maccatalyst && xcode_sysroot == "") {
   } else {
     sdk = "iphone"
   }
-  if (target_cpu == "x86" || target_cpu == "x64") {
+  if (ios_use_simulator) {
     sdk += "simulator"
   } else {
     sdk += "os"
@@ -278,9 +278,13 @@ config("default") {
         _arch_flags = [
           "-arch",
           "arm64",
-          "-arch",
-          "arm64e",
         ]
+        if (!ios_use_simulator) {
+          _arch_flags += [
+            "-arch",
+            "arm64e",
+          ] 
+        }
       }
     } else if (target_cpu == "x86") {
       _arch_flags = [
@@ -342,6 +346,14 @@ config("default") {
     } else {
       cflags += [ "-mios-version-min=$min_ios_version" ]
       ldflags += [ "-Wl,ios_version_min=$min_ios_version" ]
+      if (ios_use_simulator) {
+        cflags += [
+          "-target", "$target_cpu-apple-ios$min_ios_version-simulator",
+        ]
+        ldflags += [
+          "-target", "$target_cpu-apple-ios$min_ios_version-simulator",
+        ]
+      }
     }
   }
 

--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -47,6 +47,9 @@ declare_args() {
   min_watchos_version = "2.0"
   min_macos_version = "10.8"
   min_maccatalyst_version = "13.0"
+
+  ios_use_simulator =
+      target_os == "ios" && (target_cpu == "x86" || target_cpu == "x64")
 }
 declare_args() {
   is_debug = !is_official_build

--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -49,7 +49,8 @@ declare_args() {
   min_maccatalyst_version = "13.0"
 
   ios_use_simulator =
-      target_os == "ios" && (target_cpu == "x86" || target_cpu == "x64")
+    (target_os == "ios" || target_os == "tvos" || target_os == "watchos") &&
+    (target_cpu == "x86" || target_cpu == "x64")
 }
 declare_args() {
   is_debug = !is_official_build

--- a/gn/ios.gni
+++ b/gn/ios.gni
@@ -196,7 +196,7 @@ if (is_ios) {
       }
 
       # should only code sign when running on a device, not the simulator
-      if (target_cpu != "x64") {
+      if (!ios_use_simulator) {
         code_signing_script = "//gn/codesign_ios.py"
         code_signing_sources = [ "$target_gen_dir/$app_name" ]
         code_signing_outputs = [


### PR DESCRIPTION
This PR adds support for building iOS simulator apps on an ARM64 machine. The existing logic assumes x86/x64 is simulator and arm* is device. With the Apple chips, arm64 is now both device and simulator.