### PR TITLE
Update libjpeg-turbo to 3.0.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ deps = {
   "third_party/externals/icu"             : "https://chromium.googlesource.com/chromium/deps/icu.git@dbd3825b31041d782c5b504c59dcfb5ac7dda08c",
   "third_party/externals/imgui"           : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@9418dcb69355558f70de260483424412c5ca2fce",
   "third_party/externals/libgifcodec"     : "https://skia.googlesource.com/libgifcodec@d06d2a6d42baf6c0c91cacc28df2542a911d05fe",
-  "third_party/externals/libjpeg-turbo"   : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@22f1a22c99e9dde8cd3c72ead333f425c5a7aa77",
+  "third_party/externals/libjpeg-turbo"   : "https://github.com/libjpeg-turbo/libjpeg-turbo.git@6c87537f60941f3c265c339fe60d1e31d2a42ccf",
   "third_party/externals/libpng"          : "https://skia.googlesource.com/third_party/libpng.git@f135775ad4e5d4408d2e12ffcc71bb36e6b48551",
   "third_party/externals/libwebp"         : "https://chromium.googlesource.com/webm/libwebp.git@a8e366166ab57bb1b4aaf6739fc775515bc71b51",
   "third_party/externals/lua"             : "https://skia.googlesource.com/external/github.com/lua/lua.git@e354c6355e7f48e087678ec49e340ca0696725b1",

--- a/third_party/libjpeg-turbo/BUILD.gn
+++ b/third_party/libjpeg-turbo/BUILD.gn
@@ -21,13 +21,6 @@ if (skia_use_system_libjpeg_turbo) {
     ]
 
     defines = [
-      "TURBO_FOR_WINDOWS",
-
-      # Add support for arithmetic encoding (C_) and decoding (D_).
-      # This matches Android. Note that such JPEGs are likely rare, given lack of
-      # support by major browsers.
-      "C_ARITH_CODING_SUPPORTED=1",
-      "D_ARITH_CODING_SUPPORTED=1",
     ]
 
     if (!is_win || is_clang) {
@@ -42,11 +35,13 @@ if (skia_use_system_libjpeg_turbo) {
       "../externals/libjpeg-turbo/jccoefct.c",
       "../externals/libjpeg-turbo/jccolor.c",
       "../externals/libjpeg-turbo/jcdctmgr.c",
+      "../externals/libjpeg-turbo/jcdiffct.c",
       "../externals/libjpeg-turbo/jchuff.c",
       "../externals/libjpeg-turbo/jcinit.c",
+      "../externals/libjpeg-turbo/jclhuff.c",
+      "../externals/libjpeg-turbo/jclossls.c",
       "../externals/libjpeg-turbo/jcmainct.c",
       "../externals/libjpeg-turbo/jcmarker.c",
-      "../externals/libjpeg-turbo/jcmaster.c",
       "../externals/libjpeg-turbo/jcomapi.c",
       "../externals/libjpeg-turbo/jcparam.c",
       "../externals/libjpeg-turbo/jcphuff.c",
@@ -58,8 +53,11 @@ if (skia_use_system_libjpeg_turbo) {
       "../externals/libjpeg-turbo/jdcoefct.c",
       "../externals/libjpeg-turbo/jdcolor.c",
       "../externals/libjpeg-turbo/jddctmgr.c",
+      "../externals/libjpeg-turbo/jddiffct.c",
       "../externals/libjpeg-turbo/jdhuff.c",
       "../externals/libjpeg-turbo/jdinput.c",
+      "../externals/libjpeg-turbo/jdlhuff.c",
+      "../externals/libjpeg-turbo/jdlossls.c",
       "../externals/libjpeg-turbo/jdmainct.c",
       "../externals/libjpeg-turbo/jdmarker.c",
       "../externals/libjpeg-turbo/jdmaster.c",
@@ -77,7 +75,7 @@ if (skia_use_system_libjpeg_turbo) {
       "../externals/libjpeg-turbo/jidctred.c",
       "../externals/libjpeg-turbo/jmemmgr.c",
       "../externals/libjpeg-turbo/jmemnobs.c",
-      "../externals/libjpeg-turbo/jpeg_nbits_table.c",
+      # "../externals/libjpeg-turbo/jpeg_nbits_table.c",
       "../externals/libjpeg-turbo/jquant1.c",
       "../externals/libjpeg-turbo/jquant2.c",
       "../externals/libjpeg-turbo/jutils.c",
@@ -112,8 +110,6 @@ if (skia_use_system_libjpeg_turbo) {
           "../externals/libjpeg-turbo/simd/arm/aarch64/jsimd.c",
         ]
       }
-    } else {
-      sources += [ "../externals/libjpeg-turbo/jsimd_none.c" ]
     }
   }
 }

--- a/third_party/libjpeg-turbo/BUILD.gn
+++ b/third_party/libjpeg-turbo/BUILD.gn
@@ -14,75 +14,100 @@ if (skia_use_system_libjpeg_turbo) {
     libs = [ "jpeg" ]
   }
 } else {
+  libjpeg_include_dirs = [
+    ".",
+    "../externals/libjpeg-turbo",
+  ]
+  libjpeg16_sources = [
+    "../externals/libjpeg-turbo/jcapistd.c",
+    "../externals/libjpeg-turbo/jccolor.c",
+    "../externals/libjpeg-turbo/jcdiffct.c",
+    "../externals/libjpeg-turbo/jclossls.c",
+    "../externals/libjpeg-turbo/jcmainct.c",
+    "../externals/libjpeg-turbo/jcprepct.c",
+    "../externals/libjpeg-turbo/jcsample.c",
+    "../externals/libjpeg-turbo/jdapistd.c",
+    "../externals/libjpeg-turbo/jdcolor.c",
+    "../externals/libjpeg-turbo/jddiffct.c",
+    "../externals/libjpeg-turbo/jdlossls.c",
+    "../externals/libjpeg-turbo/jdmainct.c",
+    "../externals/libjpeg-turbo/jdpostct.c",
+    "../externals/libjpeg-turbo/jdsample.c",
+    "../externals/libjpeg-turbo/jutils.c",
+  ]
+  libjpeg12_sources = [
+    "../externals/libjpeg-turbo/jccoefct.c",
+    "../externals/libjpeg-turbo/jcdctmgr.c",
+    "../externals/libjpeg-turbo/jdcoefct.c",
+    "../externals/libjpeg-turbo/jddctmgr.c",
+    "../externals/libjpeg-turbo/jdmerge.c",
+    "../externals/libjpeg-turbo/jfdctfst.c",
+    "../externals/libjpeg-turbo/jfdctint.c",
+    "../externals/libjpeg-turbo/jidctflt.c",
+    "../externals/libjpeg-turbo/jidctfst.c",
+    "../externals/libjpeg-turbo/jidctint.c",
+    "../externals/libjpeg-turbo/jidctred.c",
+    "../externals/libjpeg-turbo/jquant1.c",
+    "../externals/libjpeg-turbo/jquant2.c",
+  ]
+  libjpeg_sources = [
+    "../externals/libjpeg-turbo/jcapimin.c",
+    "../externals/libjpeg-turbo/jchuff.c",
+    "../externals/libjpeg-turbo/jcicc.c",
+    "../externals/libjpeg-turbo/jcinit.c",
+    "../externals/libjpeg-turbo/jclhuff.c",
+    "../externals/libjpeg-turbo/jcmarker.c",
+    "../externals/libjpeg-turbo/jcmaster.c",
+    "../externals/libjpeg-turbo/jcomapi.c",
+    "../externals/libjpeg-turbo/jcparam.c",
+    "../externals/libjpeg-turbo/jcphuff.c",
+    "../externals/libjpeg-turbo/jctrans.c",
+    "../externals/libjpeg-turbo/jdapimin.c",
+    "../externals/libjpeg-turbo/jdatadst.c",
+    "../externals/libjpeg-turbo/jdatasrc.c",
+    "../externals/libjpeg-turbo/jdhuff.c",
+    "../externals/libjpeg-turbo/jdicc.c",
+    "../externals/libjpeg-turbo/jdinput.c",
+    "../externals/libjpeg-turbo/jdlhuff.c",
+    "../externals/libjpeg-turbo/jdmarker.c",
+    "../externals/libjpeg-turbo/jdmaster.c",
+    "../externals/libjpeg-turbo/jdphuff.c",
+    "../externals/libjpeg-turbo/jdtrans.c",
+    "../externals/libjpeg-turbo/jerror.c",
+    "../externals/libjpeg-turbo/jfdctflt.c",
+    "../externals/libjpeg-turbo/jmemmgr.c",
+    "../externals/libjpeg-turbo/jmemnobs.c",
+    "../externals/libjpeg-turbo/jaricom.c",
+    "../externals/libjpeg-turbo/jcarith.c",
+    "../externals/libjpeg-turbo/jdarith.c",
+  ]
+
+  source_set("libjpeg16") {
+    visibility = [ ":*" ]
+    defines = [ "BITS_IN_JSAMPLE=16" ]
+    include_dirs = libjpeg_include_dirs
+    sources = libjpeg16_sources
+  }
+
+  source_set("libjpeg12") {
+    visibility = [ ":*" ]
+    defines = [ "BITS_IN_JSAMPLE=12" ]
+    include_dirs = libjpeg_include_dirs
+    sources = libjpeg16_sources + libjpeg12_sources
+  }
+
   third_party("libjpeg") {
-    public_include_dirs = [
-      ".",
-      "../externals/libjpeg-turbo",
-    ]
+    public_include_dirs = libjpeg_include_dirs
 
-    defines = [
-    ]
-
+    defines = []
     if (!is_win || is_clang) {
       defines += [ "USE_CLZ_INTRINSIC" ]  # Cuts a 64K table.
     }
 
-    sources = [
-      "../externals/libjpeg-turbo/jaricom.c",
-      "../externals/libjpeg-turbo/jcapimin.c",
-      "../externals/libjpeg-turbo/jcapistd.c",
-      "../externals/libjpeg-turbo/jcarith.c",
-      "../externals/libjpeg-turbo/jccoefct.c",
-      "../externals/libjpeg-turbo/jccolor.c",
-      "../externals/libjpeg-turbo/jcdctmgr.c",
-      "../externals/libjpeg-turbo/jcdiffct.c",
-      "../externals/libjpeg-turbo/jchuff.c",
-      "../externals/libjpeg-turbo/jcinit.c",
-      "../externals/libjpeg-turbo/jclhuff.c",
-      "../externals/libjpeg-turbo/jclossls.c",
-      "../externals/libjpeg-turbo/jcmainct.c",
-      "../externals/libjpeg-turbo/jcmarker.c",
-      "../externals/libjpeg-turbo/jcomapi.c",
-      "../externals/libjpeg-turbo/jcparam.c",
-      "../externals/libjpeg-turbo/jcphuff.c",
-      "../externals/libjpeg-turbo/jcprepct.c",
-      "../externals/libjpeg-turbo/jcsample.c",
-      "../externals/libjpeg-turbo/jdapimin.c",
-      "../externals/libjpeg-turbo/jdapistd.c",
-      "../externals/libjpeg-turbo/jdarith.c",
-      "../externals/libjpeg-turbo/jdcoefct.c",
-      "../externals/libjpeg-turbo/jdcolor.c",
-      "../externals/libjpeg-turbo/jddctmgr.c",
-      "../externals/libjpeg-turbo/jddiffct.c",
-      "../externals/libjpeg-turbo/jdhuff.c",
-      "../externals/libjpeg-turbo/jdinput.c",
-      "../externals/libjpeg-turbo/jdlhuff.c",
-      "../externals/libjpeg-turbo/jdlossls.c",
-      "../externals/libjpeg-turbo/jdmainct.c",
-      "../externals/libjpeg-turbo/jdmarker.c",
-      "../externals/libjpeg-turbo/jdmaster.c",
-      "../externals/libjpeg-turbo/jdmerge.c",
-      "../externals/libjpeg-turbo/jdphuff.c",
-      "../externals/libjpeg-turbo/jdpostct.c",
-      "../externals/libjpeg-turbo/jdsample.c",
-      "../externals/libjpeg-turbo/jerror.c",
-      "../externals/libjpeg-turbo/jfdctflt.c",
-      "../externals/libjpeg-turbo/jfdctfst.c",
-      "../externals/libjpeg-turbo/jfdctint.c",
-      "../externals/libjpeg-turbo/jidctflt.c",
-      "../externals/libjpeg-turbo/jidctfst.c",
-      "../externals/libjpeg-turbo/jidctint.c",
-      "../externals/libjpeg-turbo/jidctred.c",
-      "../externals/libjpeg-turbo/jmemmgr.c",
-      "../externals/libjpeg-turbo/jmemnobs.c",
-      # "../externals/libjpeg-turbo/jpeg_nbits_table.c",
-      "../externals/libjpeg-turbo/jquant1.c",
-      "../externals/libjpeg-turbo/jquant2.c",
-      "../externals/libjpeg-turbo/jutils.c",
-    ]
+    sources = libjpeg16_sources + libjpeg12_sources + libjpeg_sources
 
     if (!is_win && (current_cpu == "arm" || current_cpu == "arm64")) {
-      defines += [ "NEON_INTRINSICS" ]
+      defines += [ "NEON_INTRINSICS", "WITH_SIMD" ]
       sources += [
         "../externals/libjpeg-turbo/simd/arm/jccolor-neon.c",
         "../externals/libjpeg-turbo/simd/arm/jcgray-neon.c",
@@ -111,5 +136,10 @@ if (skia_use_system_libjpeg_turbo) {
         ]
       }
     }
+
+    deps = [
+      ":libjpeg16",
+      ":libjpeg12",
+    ]
   }
 }

--- a/third_party/libjpeg-turbo/BUILD.gn
+++ b/third_party/libjpeg-turbo/BUILD.gn
@@ -14,6 +14,11 @@ if (skia_use_system_libjpeg_turbo) {
     libs = [ "jpeg" ]
   }
 } else {
+  use_simd_optimizations = false
+  if (!is_win && (current_cpu == "arm" || current_cpu == "arm64")) {
+    use_simd_optimizations = true
+  }
+
   libjpeg_include_dirs = [
     ".",
     "../externals/libjpeg-turbo",
@@ -77,14 +82,17 @@ if (skia_use_system_libjpeg_turbo) {
     "../externals/libjpeg-turbo/jfdctflt.c",
     "../externals/libjpeg-turbo/jmemmgr.c",
     "../externals/libjpeg-turbo/jmemnobs.c",
-    "../externals/libjpeg-turbo/jaricom.c",
-    "../externals/libjpeg-turbo/jcarith.c",
-    "../externals/libjpeg-turbo/jdarith.c",
+    "../externals/libjpeg-turbo/jaricom.c", # WITH_ARITH_ENC or WITH_ARITH_DEC
+    "../externals/libjpeg-turbo/jcarith.c", # WITH_ARITH_ENC
+    "../externals/libjpeg-turbo/jdarith.c", # WITH_ARITH_DEC
   ]
 
   source_set("libjpeg16") {
     visibility = [ ":*" ]
     defines = [ "BITS_IN_JSAMPLE=16" ]
+    if (!use_simd_optimizations) {
+      defines += [ "CPU_NO_SIMD" ]
+    }
     include_dirs = libjpeg_include_dirs
     sources = libjpeg16_sources
   }
@@ -92,8 +100,46 @@ if (skia_use_system_libjpeg_turbo) {
   source_set("libjpeg12") {
     visibility = [ ":*" ]
     defines = [ "BITS_IN_JSAMPLE=12" ]
+    if (!use_simd_optimizations) {
+      defines += [ "CPU_NO_SIMD" ]
+    }
     include_dirs = libjpeg_include_dirs
     sources = libjpeg16_sources + libjpeg12_sources
+  }
+
+  source_set("libjpegsimd") {
+    visibility = [ ":*" ]
+    defines = [ "NEON_INTRINSICS" ]
+    include_dirs = libjpeg_include_dirs
+    include_dirs += [
+      "../externals/libjpeg-turbo/simd/arm",
+    ]
+    sources = [
+      "../externals/libjpeg-turbo/simd/arm/jccolor-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jcgray-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jcphuff-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jcsample-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jdcolor-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jdmerge-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jdsample-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jfdctfst-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jfdctint-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jidctfst-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jidctint-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jidctred-neon.c",
+      "../externals/libjpeg-turbo/simd/arm/jquanti-neon.c",
+    ]
+    if (current_cpu == "arm") {
+      sources += [
+        "../externals/libjpeg-turbo/simd/arm/aarch32/jchuff-neon.c",
+        "../externals/libjpeg-turbo/simd/arm/aarch32/jsimd.c",
+      ]
+    } else if (current_cpu == "arm64") {
+      sources += [
+        "../externals/libjpeg-turbo/simd/arm/aarch64/jchuff-neon.c",
+        "../externals/libjpeg-turbo/simd/arm/aarch64/jsimd.c",
+      ]
+    }
   }
 
   third_party("libjpeg") {
@@ -103,43 +149,20 @@ if (skia_use_system_libjpeg_turbo) {
     if (!is_win || is_clang) {
       defines += [ "USE_CLZ_INTRINSIC" ]  # Cuts a 64K table.
     }
+    if (!use_simd_optimizations) {
+      defines += [ "CPU_NO_SIMD" ]
+    }
 
     sources = libjpeg16_sources + libjpeg12_sources + libjpeg_sources
-
-    if (!is_win && (current_cpu == "arm" || current_cpu == "arm64")) {
-      defines += [ "NEON_INTRINSICS", "WITH_SIMD" ]
-      sources += [
-        "../externals/libjpeg-turbo/simd/arm/jccolor-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jcgray-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jcphuff-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jcsample-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jdcolor-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jdmerge-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jdsample-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jfdctfst-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jfdctint-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jidctfst-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jidctint-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jidctred-neon.c",
-        "../externals/libjpeg-turbo/simd/arm/jquanti-neon.c",
-      ]
-      include_dirs = [ "../externals/libjpeg-turbo/simd/arm" ]
-      if (current_cpu == "arm") {
-        sources += [
-          "../externals/libjpeg-turbo/simd/arm/aarch32/jchuff-neon.c",
-          "../externals/libjpeg-turbo/simd/arm/aarch32/jsimd.c",
-        ]
-      } else if (current_cpu == "arm64") {
-        sources += [
-          "../externals/libjpeg-turbo/simd/arm/aarch64/jchuff-neon.c",
-          "../externals/libjpeg-turbo/simd/arm/aarch64/jsimd.c",
-        ]
-      }
-    }
 
     deps = [
       ":libjpeg16",
       ":libjpeg12",
     ]
+    if (use_simd_optimizations) {
+      deps += [
+        ":libjpegsimd",
+      ]
+    }
   }
 }

--- a/third_party/libjpeg-turbo/jconfig.h
+++ b/third_party/libjpeg-turbo/jconfig.h
@@ -18,8 +18,10 @@
 /* Support in-memory source/destination managers */
 #define MEM_SRCDST_SUPPORTED 1
 
+#ifndef CPU_NO_SIMD
 /* Use accelerated SIMD routines when using 8-bit samples */
-// #define WITH_SIMD 1
+#define WITH_SIMD 1
+#endif
 
 /* This version of libjpeg-turbo supports run-time selection of data precision,
  * so BITS_IN_JSAMPLE is no longer used to specify the data precision at build

--- a/third_party/libjpeg-turbo/jconfig.h
+++ b/third_party/libjpeg-turbo/jconfig.h
@@ -19,7 +19,7 @@
 #define MEM_SRCDST_SUPPORTED 1
 
 /* Use accelerated SIMD routines when using 8-bit samples */
-#define WITH_SIMD 1
+// #define WITH_SIMD 1
 
 /* This version of libjpeg-turbo supports run-time selection of data precision,
  * so BITS_IN_JSAMPLE is no longer used to specify the data precision at build

--- a/third_party/libjpeg-turbo/jconfig.h
+++ b/third_party/libjpeg-turbo/jconfig.h
@@ -1,0 +1,60 @@
+/* Version ID for the JPEG library.
+ * Might be useful for tests like "#if JPEG_LIB_VERSION >= 60".
+ */
+#define JPEG_LIB_VERSION  62
+
+/* libjpeg-turbo version */
+#define LIBJPEG_TURBO_VERSION  3.0.0
+
+/* libjpeg-turbo version in integer form */
+#define LIBJPEG_TURBO_VERSION_NUMBER  3000000
+
+/* Support arithmetic encoding when using 8-bit samples */
+#define C_ARITH_CODING_SUPPORTED 1
+
+/* Support arithmetic decoding when using 8-bit samples */
+#define D_ARITH_CODING_SUPPORTED 1
+
+/* Support in-memory source/destination managers */
+#define MEM_SRCDST_SUPPORTED 1
+
+/* Use accelerated SIMD routines when using 8-bit samples */
+#define WITH_SIMD 1
+
+/* This version of libjpeg-turbo supports run-time selection of data precision,
+ * so BITS_IN_JSAMPLE is no longer used to specify the data precision at build
+ * time.  However, some downstream software expects the macro to be defined.
+ * Since 12-bit data precision is an opt-in feature that requires explicitly
+ * calling 12-bit-specific libjpeg API functions and using 12-bit-specific data
+ * types, the unmodified portion of the libjpeg API still behaves as if it were
+ * built for 8-bit precision, and JSAMPLE is still literally an 8-bit data
+ * type.  Thus, it is correct to define BITS_IN_JSAMPLE to 8 here.
+ */
+#ifndef BITS_IN_JSAMPLE
+#define BITS_IN_JSAMPLE  8
+#endif
+
+#ifdef _WIN32
+
+#undef RIGHT_SHIFT_IS_UNSIGNED
+
+/* Define "boolean" as unsigned char, not int, per Windows custom */
+#ifndef __RPCNDR_H__            /* don't conflict if rpcndr.h already read */
+typedef unsigned char boolean;
+#endif
+#define HAVE_BOOLEAN            /* prevent jmorecfg.h from redefining it */
+
+/* Define "INT32" as int, not long, per Windows custom */
+#if !(defined(_BASETSD_H_) || defined(_BASETSD_H))   /* don't conflict if basetsd.h already read */
+typedef short INT16;
+typedef signed int INT32;
+#endif
+#define XMD_H                   /* prevent jmorecfg.h from redefining it */
+
+#else
+
+/* Define if your (broken) compiler shifts signed values as if they were
+   unsigned. */
+/* #undef RIGHT_SHIFT_IS_UNSIGNED */
+
+#endif

--- a/third_party/libjpeg-turbo/jconfigint.h
+++ b/third_party/libjpeg-turbo/jconfigint.h
@@ -89,6 +89,6 @@
 #define D_ARITH_CODING_SUPPORTED 1
 
 /* Use accelerated SIMD routines. */
-#define WITH_SIMD 1
+// #define WITH_SIMD 1
 
 #endif

--- a/third_party/libjpeg-turbo/jconfigint.h
+++ b/third_party/libjpeg-turbo/jconfigint.h
@@ -88,7 +88,9 @@
 /* Support arithmetic decoding */
 #define D_ARITH_CODING_SUPPORTED 1
 
+#ifndef CPU_NO_SIMD
 /* Use accelerated SIMD routines. */
-// #define WITH_SIMD 1
+#define WITH_SIMD 1
+#endif
 
 #endif

--- a/third_party/libjpeg-turbo/jconfigint.h
+++ b/third_party/libjpeg-turbo/jconfigint.h
@@ -1,0 +1,94 @@
+/* libjpeg-turbo build number */
+#define BUILD  ""
+
+/* Compiler's inline keyword */
+#undef inline
+
+/* How to obtain function inlining. */
+#ifndef INLINE
+#if defined(__GNUC__)
+#define INLINE  inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define INLINE  __forceinline
+#else
+#define INLINE
+#endif
+#endif
+
+/* How to obtain thread-local storage */
+#if defined(_MSC_VER) && (defined(_WIN32) || defined(_WIN64))
+#define THREAD_LOCAL  __declspec(thread)
+#else
+#define THREAD_LOCAL  __thread
+#endif
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME  "libjpeg-turbo"
+
+/* Version number of package */
+#define VERSION  "3.0.0"
+
+/* The size of `size_t', as computed by sizeof. */
+#include <stdint.h>
+#if __WORDSIZE==64 || defined(_WIN64)
+#define SIZEOF_SIZE_T  8
+#else
+#define SIZEOF_SIZE_T  4
+#endif
+
+/* Define if your compiler has __builtin_ctzl() and sizeof(unsigned long) == sizeof(size_t). */
+#if defined(__GNUC__)
+#define HAVE_BUILTIN_CTZL
+#endif
+
+/* Define to 1 if you have the <intrin.h> header file. */
+#if defined(_MSC_VER)
+#define HAVE_INTRIN_H  1
+#endif
+
+#if defined(_MSC_VER) && defined(HAVE_INTRIN_H)
+#if (SIZEOF_SIZE_T == 8)
+#define HAVE_BITSCANFORWARD64
+#elif (SIZEOF_SIZE_T == 4)
+#define HAVE_BITSCANFORWARD
+#endif
+#endif
+
+#if defined(__has_attribute)
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH __attribute__((fallthrough));
+#else
+#define FALLTHROUGH
+#endif
+#else
+#define FALLTHROUGH
+#endif
+
+/*
+ * Define BITS_IN_JSAMPLE as either
+ *   8   for 8-bit sample values (the usual setting)
+ *   12  for 12-bit sample values
+ * Only 8 and 12 are legal data precisions for lossy JPEG according to the
+ * JPEG standard, and the IJG code does not support anything else!
+ */
+
+#ifndef BITS_IN_JSAMPLE
+#define BITS_IN_JSAMPLE  8      /* use 8 or 12 */
+#endif
+
+#undef C_ARITH_CODING_SUPPORTED
+#undef D_ARITH_CODING_SUPPORTED
+#undef WITH_SIMD
+
+#if BITS_IN_JSAMPLE == 8
+
+/* Support arithmetic encoding */
+#define C_ARITH_CODING_SUPPORTED 1
+
+/* Support arithmetic decoding */
+#define D_ARITH_CODING_SUPPORTED 1
+
+/* Use accelerated SIMD routines. */
+#define WITH_SIMD 1
+
+#endif

--- a/third_party/libjpeg-turbo/jversion.h
+++ b/third_party/libjpeg-turbo/jversion.h
@@ -1,0 +1,55 @@
+/*
+ * jversion.h
+ *
+ * This file was part of the Independent JPEG Group's software:
+ * Copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+ * libjpeg-turbo Modifications:
+ * Copyright (C) 2010, 2012-2023, D. R. Commander.
+ * For conditions of distribution and use, see the accompanying README.ijg
+ * file.
+ *
+ * This file contains software version identification.
+ */
+
+
+#if JPEG_LIB_VERSION >= 80
+
+#define JVERSION        "8d  15-Jan-2012"
+
+#elif JPEG_LIB_VERSION >= 70
+
+#define JVERSION        "7  27-Jun-2009"
+
+#else
+
+#define JVERSION        "6b  27-Mar-1998"
+
+#endif
+
+/*
+ * NOTE: It is our convention to place the authors in the following order:
+ * - libjpeg-turbo authors (2009-) in descending order of the date of their
+ *   most recent contribution to the project, then in ascending order of the
+ *   date of their first contribution to the project, then in alphabetical
+ *   order
+ * - Upstream authors in descending order of the date of the first inclusion of
+ *   their code
+ */
+
+#define JCOPYRIGHT \
+  "Copyright (C) 2009-2023 D. R. Commander\n" \
+  "Copyright (C) 2015, 2020 Google, Inc.\n" \
+  "Copyright (C) 2019-2020 Arm Limited\n" \
+  "Copyright (C) 2015-2016, 2018 Matthieu Darbois\n" \
+  "Copyright (C) 2011-2016 Siarhei Siamashka\n" \
+  "Copyright (C) 2015 Intel Corporation\n" \
+  "Copyright (C) 2013-2014 Linaro Limited\n" \
+  "Copyright (C) 2013-2014 MIPS Technologies, Inc.\n" \
+  "Copyright (C) 2009, 2012 Pierre Ossman for Cendio AB\n" \
+  "Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies)\n" \
+  "Copyright (C) 1999-2006 MIYASAKA Masaru\n" \
+  "Copyright (C) 1999 Ken Murchison\n" \
+  "Copyright (C) 1991-2020 Thomas G. Lane, Guido Vollbeding"
+
+#define JCOPYRIGHT_SHORT \
+  "Copyright (C) 1991-2023 The libjpeg-turbo Project and many others"

--- a/third_party/libjpeg-turbo/neon-compat.h
+++ b/third_party/libjpeg-turbo/neon-compat.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2020-2021, Arm Limited.  All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#define HAVE_VLD1_S16_X3
+#define HAVE_VLD1_U16_X2
+#define HAVE_VLD1Q_U8_X4
+
+/* Define compiler-independent count-leading-zeros and byte-swap macros */
+#if defined(_MSC_VER) && !defined(__clang__)
+#define BUILTIN_CLZ(x)  _CountLeadingZeros(x)
+#define BUILTIN_CLZLL(x)  _CountLeadingZeros64(x)
+#define BUILTIN_BSWAP64(x)  _byteswap_uint64(x)
+#elif defined(__clang__) || defined(__GNUC__)
+#define BUILTIN_CLZ(x)  __builtin_clz(x)
+#define BUILTIN_CLZLL(x)  __builtin_clzll(x)
+#define BUILTIN_BSWAP64(x)  __builtin_bswap64(x)
+#else
+#error "Unknown compiler"
+#endif


### PR DESCRIPTION
**Description of Change**

This PR updates the `libjpeg-turbo` external dependency to the latest v3.0.0

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/2578

**API Changes**

None.

**Behavioral Changes**

None.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2583

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
