### PR TITLE
DEPS: commented out obviously unneeded dependencies for Linux-only build, ~5GiB in total

### DIFF
--- a/build/linux-self-hosted/DEPS
+++ b/build/linux-self-hosted/DEPS
@@ -1,0 +1,81 @@
+use_relative_paths = True
+
+vars = {
+  # Three lines of non-changing comments so that
+  # the commit queue can handle CLs rolling different
+  # dependencies without interference from each other.
+  'sk_tool_revision': 'git_revision:97f14b3b6c39e716df838991a156f67df0f785a8',
+
+  # ninja CIPD package version.
+  # https://chrome-infra-packages.appspot.com/p/infra/3pp/tools/ninja
+  'ninja_version': 'version:2@1.8.2.chromium.3',
+}
+
+# If you modify this file, you will need to regenerate the Bazel version of this file (bazel/deps.bzl).
+# To do so, run:
+#     bazelisk run //bazel/deps_parser
+#
+# To apply the changes for the GN build, you will need to resync the git repositories using:
+#     ./tools/git-sync-deps
+deps = {
+  "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+  #"third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@3f633521356d65679acaba2918c014fcbd8c0a5e",
+  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+  #"third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+  #"third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@cd1fb6876701b89ced4e101bf8da422ee4d364ec",
+  #"third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@ee69aa00ee8536f61db6a451f3858745cf587de6",
+  #"third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0944e71f4b2cb9a871bcbe353f95e889b64a611a",
+  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@cb436cf0142b4cbe47aae94223443df7f82e2920",
+  "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@a0bca08de07c7d7651047bedc0b653cfaaa4f2ae",
+  #"third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@4a48a752e6a8bef6f222622f2b4926d5eb3bdeb3",
+  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+  "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@d857bd535b6c7e877f262a9b61ed21ee11b35dab",
+  "third_party/externals/harfbuzz"               : "https://github.com/harfbuzz/harfbuzz.git@4584bcdc326564829d3cee3572386c90e4fd1974",
+  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+  #"third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",
+  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+  "third_party/externals/libavif"                : "https://github.com/AOMediaCodec/libavif.git@f49462dc93784bf34148715eee36ab6697ca0b35",
+  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@0fb779c1e169fe6c229cd1fa9cc6ea6feeb441da",
+  "third_party/externals/libjpeg-turbo"          : "https://github.com/libjpeg-turbo/libjpeg-turbo.git@6c87537f60941f3c265c339fe60d1e31d2a42ccf",
+  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+  "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@f135775ad4e5d4408d2e12ffcc71bb36e6b48551",
+  "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@fd7b5d48464475408d32d2611bdb6947d4246b97",
+  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+  "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+  #"third_party/externals/sfntly"                 : "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git@b55ff303ea2f9e26702b514cf6a3196a2e3e2974",
+  #"third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@f549d5e6c6635ec8b75fb544a6bdc9f48bfb1dd3",
+  "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@7de5cc00de50e71a3aab22dea52fbb7ff4efceb6",
+  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+  "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@8a3971e5e9c5cddc437d1cf5e4ac1ed0728d6a49",
+  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@12542fc6fc05000e04742daf93892a0b10edbe80",
+  "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@bdbfd019be6952fd8fa9bd5606a8798a7530c853",
+  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@e7c6084fd1d6d6f5ac393e842728d8be309688ca",
+  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@ef2630ad9c647b90863cb0915701d54725733968",
+  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@9e61870ecbd32514113b467e0a0c46f60ed222c7",
+  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@80b010b1e1b08c1f092fb2bfa337faadf8ea1ba3",
+  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+  "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@a0041ac0310b3156b963e2f2bea09245f25ec073",
+  "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@3ca9f16f02950edffa391ec19cea856090158e9e",
+
+  'bin': {
+    'packages': [
+      {
+        'package': 'skia/tools/sk/${{platform}}',
+        'version': Var('sk_tool_revision'),
+      },
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'dep_type': 'cipd',
+  },
+}


### PR DESCRIPTION
**Description of Change**

do not needlessly download ~5GiB of data that is not actually needed

**API Changes**

None.

**Behavioral Changes**

None.

**PR Checklist**

- [* ] Rebased on top of `skiasharp` at time of PR
- [* ] Changes adhere to coding standard
- [ ] Updated documentation - https://github.com/mono/SkiaSharp/wiki/Building-on-Linux should be updated

EDIT: it seems these dependencies are in fact needed for a general build.
the pull request now instead adds a new DEPS file in build/linux-self-hosted/DEPS.

if https://github.com/mono/SkiaSharp/wiki/Building-on-Linux is updated to add
`cp build/linux-self-hosted/DEPS DEPS` before `python tools/git-sync-deps`, this will
save downloading ~5GiB of unused dependencies