### PR TITLE
Bind Skottie's Animation Builder

### DIFF
--- a/gn/core.gni
+++ b/gn/core.gni
@@ -215,6 +215,7 @@ skia_core_sources = [
   "$_src/c/sk_vertices.cpp",
   "$_src/c/gr_context.cpp",
   "$_src/c/skottie_animation.cpp",
+  "$_src/c/skresources_resource_provider.cpp",
   "$_src/c/sksg_invalidation_controller.cpp",
 
   "$_include/private/SkBitmaskEnum.h",

--- a/gn/core.gni
+++ b/gn/core.gni
@@ -214,6 +214,7 @@ skia_core_sources = [
   "$_src/c/sk_types_priv.h",
   "$_src/c/sk_vertices.cpp",
   "$_src/c/gr_context.cpp",
+  "$_src/c/sk_linker.cpp",
   "$_src/c/skottie_animation.cpp",
   "$_src/c/skresources_resource_provider.cpp",
   "$_src/c/sksg_invalidation_controller.cpp",

--- a/include/c/sk_linker.h
+++ b/include/c/sk_linker.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Microsoft Corporation. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef sk_linker_DEFINED
+#define sk_linker_DEFINED
+
+#include "include/c/sk_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+SK_C_API void sk_linker_keep_alive(void);
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -1092,6 +1092,10 @@ typedef struct {
     size_t fAnimatorCount;
 } skottie_animation_builder_stats_t;
 
+typedef struct skresources_image_asset_t skresources_image_asset_t;
+typedef struct skresources_multi_frame_image_asset_t skresources_multi_frame_image_asset_t;
+typedef struct skresources_external_track_asset_t skresources_external_track_asset_t;
+
 typedef struct skresources_resource_provider_t skresources_resource_provider_t;
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -1078,6 +1078,22 @@ typedef enum {
     DISABLE_TOP_LEVEL_CLIPPING = 0x02,
 } skottie_animation_renderflags_t;
 
+typedef enum {
+    NONE_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0,
+    DEFER_IMAGE_LOADING_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0x01,
+    PREFER_EMBEDDED_FONTS_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0x02,
+} skottie_animation_builder_flags_t;
+
+typedef struct {
+    float fTotalLoadTimeMS;
+    float fJsonParseTimeMS;
+    float fSceneParseTimeMS;
+    size_t fJsonSize;
+    size_t fAnimatorCount;
+} skottie_animation_builder_stats_t;
+
+typedef struct skresources_resource_provider_t skresources_resource_provider_t;
+
 SK_C_PLUS_PLUS_END_GUARD
 
 #endif

--- a/include/c/skottie_animation.h
+++ b/include/c/skottie_animation.h
@@ -17,6 +17,7 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
 /*
  * skottie::Animation
  */
+
 SK_C_API void skottie_animation_keepalive(void);
 
 SK_C_API skottie_animation_t* skottie_animation_make_from_string(const char* data, size_t length);
@@ -43,6 +44,24 @@ SK_C_API double skottie_animation_get_out_point(skottie_animation_t *instance);
 
 SK_C_API void skottie_animation_get_version(skottie_animation_t *instance, sk_string_t* version);
 SK_C_API void skottie_animation_get_size(skottie_animation_t *instance, sk_size_t* size);
+
+
+/*
+ * skottie::Animation::Builder
+ */
+
+SK_C_API skottie_animation_builder_t* skottie_animation_builder_new(skottie_animation_builder_flags_t flags);
+
+SK_C_API void skottie_animation_builder_delete(skottie_animation_builder_t *instance);
+
+SK_C_API void skottie_animation_builder_get_stats(skottie_animation_builder_t* instance, skottie_animation_builder_stats_t* stats);
+SK_C_API void skottie_animation_builder_set_resource_provider(skottie_animation_builder_t* instance, skottie_resource_provider_t* resourceProvider);
+SK_C_API void skottie_animation_builder_set_font_manager(skottie_animation_builder_t* instance, sk_fontmgr_t* fontManager);
+
+SK_C_API skottie_animation_t* skottie_animation_builder_make_from_stream(skottie_animation_builder_t* instance, sk_stream_t* stream);
+SK_C_API skottie_animation_t* skottie_animation_builder_make_from_file(skottie_animation_builder_t* instance, const char* path);
+SK_C_API skottie_animation_t* skottie_animation_builder_make_from_string(skottie_animation_builder_t* instance, const char* data, size_t length);
+SK_C_API skottie_animation_t* skottie_animation_builder_make_from_data(skottie_animation_builder_t* instance, const char* data, size_t length);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/skottie_animation.h
+++ b/include/c/skottie_animation.h
@@ -18,8 +18,6 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
  * skottie::Animation
  */
 
-SK_C_API void skottie_animation_keepalive(void);
-
 SK_C_API skottie_animation_t* skottie_animation_make_from_string(const char* data, size_t length);
 SK_C_API skottie_animation_t* skottie_animation_make_from_data(const char* data, size_t length);
 SK_C_API skottie_animation_t* skottie_animation_make_from_stream(sk_stream_t* stream);

--- a/include/c/skresources_resource_provider.h
+++ b/include/c/skresources_resource_provider.h
@@ -18,7 +18,12 @@ SK_C_API void skresources_resource_provider_ref(skresources_resource_provider_t*
 SK_C_API void skresources_resource_provider_unref(skresources_resource_provider_t* instance);
 SK_C_API void skresources_resource_provider_delete(skresources_resource_provider_t *instance);
 
-SK_C_API skresources_resource_provider_t* skresources_file_resource_provider_make(const char* base_dir, size_t length, bool predecode);
+SK_C_API sk_data_t* skresources_resource_provider_load(skresources_resource_provider_t *instance, const char* path, const char* name);
+SK_C_API skresources_image_asset_t* skresources_resource_provider_load_image_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id);
+SK_C_API skresources_external_track_asset_t* skresources_resource_provider_load_audio_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id);
+SK_C_API sk_typeface_t* skresources_resource_provider_load_typeface(skresources_resource_provider_t *instance, const char* name, const char* url);
+
+SK_C_API skresources_resource_provider_t* skresources_file_resource_provider_make(sk_string_t* base_dir, bool predecode);
 SK_C_API skresources_resource_provider_t* skresources_caching_resource_provider_proxy_make(skresources_resource_provider_t* rp);
 SK_C_API skresources_resource_provider_t* skresources_data_uri_resource_provider_proxy_make(skresources_resource_provider_t* rp, bool predecode);
 

--- a/include/c/skresources_resource_provider.h
+++ b/include/c/skresources_resource_provider.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 Google Inc.
+ * Copyright 2015 Xamarin Inc.
+ * Copyright 2017 Microsoft Corporation. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef skresources_resource_provider_DEFINED
+#define skresources_resource_provider_DEFINED
+
+#include "include/c/sk_types.h"
+
+SK_C_PLUS_PLUS_BEGIN_GUARD
+
+SK_C_API void skresources_resource_provider_ref(skresources_resource_provider_t* instance);
+SK_C_API void skresources_resource_provider_unref(skresources_resource_provider_t* instance);
+SK_C_API void skresources_resource_provider_delete(skresources_resource_provider_t *instance);
+
+SK_C_API skresources_resource_provider_t* skresources_file_resource_provider_make(const char* base_dir, size_t length, bool predecode);
+SK_C_API skresources_resource_provider_t* skresources_caching_resource_provider_proxy_make(skresources_resource_provider_t* rp);
+SK_C_API skresources_resource_provider_t* skresources_data_uri_resource_provider_proxy_make(skresources_resource_provider_t* rp, bool predecode);
+
+SK_C_PLUS_PLUS_END_GUARD
+
+#endif

--- a/src/c/sk_enums.cpp
+++ b/src/c/sk_enums.cpp
@@ -363,6 +363,10 @@ static_assert ((int)SkRRect::Corner::kLowerLeft_Corner    == (int)LOWER_LEFT_SK_
 static_assert ((int)skottie::Animation::kSkipTopLevelIsolation      == (int)SKIP_TOP_LEVEL_ISOLATION,      ASSERT_MSG(skottie::Animation, skottie_animation_renderflags_t));
 static_assert ((int)skottie::Animation::kDisableTopLevelClipping    == (int)DISABLE_TOP_LEVEL_CLIPPING,    ASSERT_MSG(skottie::Animation, skottie_animation_renderflags_t));
 
+// skottie_animation_renderflags_t
+static_assert ((int)skottie::Animation::Builder::Flags::kDeferImageLoading      == (int)DEFER_IMAGE_LOADING_SKOTTIE_ANIMATION_BUILDER_FLAGS,      ASSERT_MSG(skottie::Animation::Builder::Flags, skottie_animation_builder_flags_t));
+static_assert ((int)skottie::Animation::Builder::Flags::kPreferEmbeddedFonts    == (int)PREFER_EMBEDDED_FONTS_SKOTTIE_ANIMATION_BUILDER_FLAGS,    ASSERT_MSG(skottie::Animation::Builder::Flags, skottie_animation_builder_flags_t));
+
 // sk_runtimeeffect_uniform_type_t
 static_assert ((int)SkRuntimeEffect::Uniform::Type::kFloat      == (int)FLOAT_SK_RUNTIMEEFFECT_UNIFORM_TYPE,      ASSERT_MSG(SkRuntimeEffect::Uniform::Type, sk_runtimeeffect_uniform_type_t));
 static_assert ((int)SkRuntimeEffect::Uniform::Type::kFloat2     == (int)FLOAT2_SK_RUNTIMEEFFECT_UNIFORM_TYPE,     ASSERT_MSG(SkRuntimeEffect::Uniform::Type, sk_runtimeeffect_uniform_type_t));

--- a/src/c/sk_linker.cpp
+++ b/src/c/sk_linker.cpp
@@ -1,0 +1,25 @@
+#include "include/c/sk_linker.h"
+
+#include "src/c/sk_types_priv.h"
+
+#include "include/core/SkCubicMap.h"
+#include "include/utils/SkAnimCodecPlayer.h"
+
+#include "src/utils/SkJSON.h"
+#include "src/utils/SkOSPath.h"
+
+void sk_linker_keep_alive(void) {
+    // This function is needed on Tizen to ensure required types are kept alive
+    // It is not meant to be executed.
+
+    skjson::ObjectValue* a = nullptr;
+    auto r = (*a)["tmp"].getType();
+
+    SkCubicMap* b = nullptr;
+    (*b).computeYFromX((int)r);
+
+    SkAnimCodecPlayer* c = nullptr;
+    (*c).seek((uint32_t)123);
+
+    SkOSPath::Join(nullptr, nullptr);
+}

--- a/src/c/sk_structs.cpp
+++ b/src/c/sk_structs.cpp
@@ -75,6 +75,8 @@ static_assert (sizeof (sk_sampling_options_t) == sizeof (SkSamplingOptions), ASS
 static_assert (sizeof (sk_runtimeeffect_uniform_t) == sizeof (SkRuntimeEffect::Uniform), ASSERT_MSG(SkRuntimeEffect::Uniform, sk_runtimeeffect_uniform_t));
 static_assert (sizeof (sk_runtimeeffect_child_t) == sizeof (SkRuntimeEffect::Child), ASSERT_MSG(SkRuntimeEffect::Child, sk_runtimeeffect_child_t));
 
+static_assert (sizeof (skottie_animation_builder_stats_t) == sizeof (skottie::Animation::Builder::Stats), ASSERT_MSG(skottie::Animation::Builder::Stats, skottie_animation_builder_stats_t));
+
 #if defined(SK_GANESH)
 static_assert (sizeof (gr_gl_framebufferinfo_t) == sizeof (GrGLFramebufferInfo), ASSERT_MSG(GrGLFramebufferInfo, gr_gl_framebufferinfo_t));
 static_assert (sizeof (gr_gl_textureinfo_t) == sizeof (GrGLTextureInfo), ASSERT_MSG(GrGLTextureInfo, gr_gl_textureinfo_t));

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -378,6 +378,8 @@ static inline SkPDF::Metadata AsDocumentPDFMetadata(const sk_document_pdf_metada
 
 #include "modules/skottie/include/Skottie.h"
 DEF_CLASS_MAP_WITH_NS(skottie, Animation, skottie_animation_t, SkottieAnimation)
+DEF_CLASS_MAP_WITH_NS(skottie::Animation, Builder, skottie_animation_builder_t, SkottieAnimationBuilder)
+DEF_MAP(skottie::Animation::Builder::Stats, skottie_animation_builder_stats_t, SkottieAnimationBuilderStats)
 
 DEF_CLASS_MAP_WITH_NS(skottie, ResourceProvider, skottie_resource_provider_t, SkottieResourceProvider)
 DEF_CLASS_MAP_WITH_NS(skottie, PropertyObserver, skottie_property_observer_t, SkottiePropertyObserver)
@@ -386,6 +388,9 @@ DEF_CLASS_MAP_WITH_NS(skottie, MarkerObserver, skottie_marker_observer_t, Skotti
 
 #include "modules/sksg/include/SkSGInvalidationController.h"
 DEF_CLASS_MAP_WITH_NS(sksg, InvalidationController, sksg_invalidation_controller_t, SksgInvalidationController)
+
+#include "modules/skresources/include/SkResources.h"
+DEF_CLASS_MAP_WITH_NS(skresources, ResourceProvider, skresources_resource_provider_t, SkResourcesResourceProvider)
 
 #if defined(SK_GANESH)
 // GPU specific

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -391,6 +391,9 @@ DEF_CLASS_MAP_WITH_NS(sksg, InvalidationController, sksg_invalidation_controller
 
 #include "modules/skresources/include/SkResources.h"
 DEF_CLASS_MAP_WITH_NS(skresources, ResourceProvider, skresources_resource_provider_t, SkResourcesResourceProvider)
+DEF_CLASS_MAP_WITH_NS(skresources, ImageAsset, skresources_image_asset_t, SkResourcesImageAsset)
+DEF_CLASS_MAP_WITH_NS(skresources, MultiFrameImageAsset, skresources_multi_frame_image_asset_t, SkResourcesMultiFrameImageAsset)
+DEF_CLASS_MAP_WITH_NS(skresources, ExternalTrackAsset, skresources_external_track_asset_t, SkResourcesExternalTrackAsset)
 
 #if defined(SK_GANESH)
 // GPU specific

--- a/src/c/skottie_animation.cpp
+++ b/src/c/skottie_animation.cpp
@@ -5,23 +5,9 @@
 
 #include "src/c/sk_types_priv.h"
 
-#include "src/utils/SkJSON.h"
-#include "include/core/SkCubicMap.h"
-
 /*
  * skottie::Animation
  */
-
-void skottie_animation_keepalive(void) {
-    // This function is needed on Tizen to ensure required types are kept alive
-    // It is not meant to be executed.
-
-    skjson::ObjectValue* a = nullptr;
-    auto r = (*a)["tmp"].getType();
-
-    SkCubicMap* b = nullptr;
-    (*b).computeYFromX((int)r);
-}
 
 void skottie_animation_ref(skottie_animation_t* instance) {
     SkSafeRef(AsSkottieAnimation(instance));

--- a/src/c/skottie_animation.cpp
+++ b/src/c/skottie_animation.cpp
@@ -8,6 +8,10 @@
 #include "src/utils/SkJSON.h"
 #include "include/core/SkCubicMap.h"
 
+/*
+ * skottie::Animation
+ */
+
 void skottie_animation_keepalive(void) {
     // This function is needed on Tizen to ensure required types are kept alive
     // It is not meant to be executed.
@@ -89,4 +93,45 @@ void skottie_animation_get_version(skottie_animation_t *instance, sk_string_t* v
 
 void skottie_animation_get_size(skottie_animation_t *instance, sk_size_t* size) {
     *size = ToSize(AsSkottieAnimation(instance)->size());
+}
+
+
+/*
+ * skottie::Animation::Builder
+ */
+
+skottie_animation_builder_t* skottie_animation_builder_new(skottie_animation_builder_flags_t flags) {
+    return ToSkottieAnimationBuilder(new skottie::Animation::Builder((skottie::Animation::Builder::Flags)flags));
+}
+
+void skottie_animation_builder_delete(skottie_animation_builder_t *instance) {
+    delete AsSkottieAnimationBuilder(instance);
+}
+
+void skottie_animation_builder_get_stats(skottie_animation_builder_t* instance, skottie_animation_builder_stats_t* stats) {
+    *stats = ToSkottieAnimationBuilderStats(AsSkottieAnimationBuilder(instance)->getStats());
+}
+
+void skottie_animation_builder_set_resource_provider(skottie_animation_builder_t* instance, skottie_resource_provider_t* resourceProvider) {
+    AsSkottieAnimationBuilder(instance)->setResourceProvider(sk_ref_sp(AsSkottieResourceProvider(resourceProvider)));
+}
+
+void skottie_animation_builder_set_font_manager(skottie_animation_builder_t* instance, sk_fontmgr_t* fontManager) {
+    AsSkottieAnimationBuilder(instance)->setFontManager(sk_ref_sp(AsFontMgr(fontManager)));
+}
+
+skottie_animation_t* skottie_animation_builder_make_from_stream(skottie_animation_builder_t* instance, sk_stream_t* stream) {
+    return ToSkottieAnimation(AsSkottieAnimationBuilder(instance)->make(AsStream(stream)).release());
+}
+
+skottie_animation_t* skottie_animation_builder_make_from_file(skottie_animation_builder_t* instance, const char* path) {
+    return ToSkottieAnimation(AsSkottieAnimationBuilder(instance)->makeFromFile(path).release());
+}
+
+skottie_animation_t* skottie_animation_builder_make_from_string(skottie_animation_builder_t* instance, const char* data, size_t length) {
+    return ToSkottieAnimation(AsSkottieAnimationBuilder(instance)->make(data, length).release());
+}
+
+skottie_animation_t* skottie_animation_builder_make_from_data(skottie_animation_builder_t* instance, const char* data, size_t length) {
+    return ToSkottieAnimation(AsSkottieAnimationBuilder(instance)->make(data, length).release());
 }

--- a/src/c/skresources_resource_provider.cpp
+++ b/src/c/skresources_resource_provider.cpp
@@ -1,0 +1,24 @@
+#include "modules/skresources/include/SkResources.h"
+#include "include/c/skresources_resource_provider.h"
+
+#include "src/c/sk_types_priv.h"
+
+void skresources_resource_provider_ref(skresources_resource_provider_t* instance) {
+    SkSafeRef(AsSkResourcesResourceProvider(instance));
+}
+void skresources_resource_provider_unref(skresources_resource_provider_t* instance) {
+    SkSafeUnref(AsSkResourcesResourceProvider(instance));
+}
+void skresources_resource_provider_delete(skresources_resource_provider_t *instance) {
+    delete AsSkResourcesResourceProvider(instance);
+}
+
+skresources_resource_provider_t* skresources_file_resource_provider_make(const char* base_dir, size_t length, bool predecode){
+    return ToSkResourcesResourceProvider(skresources::FileResourceProvider::Make(SkString(base_dir, length), predecode).release());
+}
+skresources_resource_provider_t* skresources_caching_resource_provider_proxy_make(skresources_resource_provider_t* rp) {
+    return ToSkResourcesResourceProvider(skresources::CachingResourceProvider::Make(sk_ref_sp(AsSkResourcesResourceProvider(rp))).release());
+}
+skresources_resource_provider_t* skresources_data_uri_resource_provider_proxy_make(skresources_resource_provider_t* rp, bool predecode) {
+    return ToSkResourcesResourceProvider(skresources::DataURIResourceProviderProxy::Make(sk_ref_sp(AsSkResourcesResourceProvider(rp)), predecode).release());
+}

--- a/src/c/skresources_resource_provider.cpp
+++ b/src/c/skresources_resource_provider.cpp
@@ -13,8 +13,21 @@ void skresources_resource_provider_delete(skresources_resource_provider_t *insta
     delete AsSkResourcesResourceProvider(instance);
 }
 
-skresources_resource_provider_t* skresources_file_resource_provider_make(const char* base_dir, size_t length, bool predecode){
-    return ToSkResourcesResourceProvider(skresources::FileResourceProvider::Make(SkString(base_dir, length), predecode).release());
+sk_data_t* skresources_resource_provider_load(skresources_resource_provider_t *instance, const char* path, const char* name) {
+    return ToData(AsSkResourcesResourceProvider(instance)->load(path, name).release());
+}
+skresources_image_asset_t* skresources_resource_provider_load_image_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id) {
+    return ToSkResourcesImageAsset(AsSkResourcesResourceProvider(instance)->loadImageAsset(path, name, id).release());
+}
+skresources_external_track_asset_t* skresources_resource_provider_load_audio_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id) {
+    return ToSkResourcesExternalTrackAsset(AsSkResourcesResourceProvider(instance)->loadAudioAsset(path, name, id).release());
+}
+sk_typeface_t* skresources_resource_provider_load_typeface(skresources_resource_provider_t *instance, const char* name, const char* url) {
+    return ToTypeface(AsSkResourcesResourceProvider(instance)->loadTypeface(name, url).release());
+}
+
+skresources_resource_provider_t* skresources_file_resource_provider_make(sk_string_t* base_dir, bool predecode){
+    return ToSkResourcesResourceProvider(skresources::FileResourceProvider::Make(AsString(*base_dir), predecode).release());
 }
 skresources_resource_provider_t* skresources_caching_resource_provider_proxy_make(skresources_resource_provider_t* rp) {
     return ToSkResourcesResourceProvider(skresources::CachingResourceProvider::Make(sk_ref_sp(AsSkResourcesResourceProvider(rp))).release());

--- a/src/xamarin/SkiaKeeper.c
+++ b/src/xamarin/SkiaKeeper.c
@@ -23,6 +23,7 @@
 #include "include/c/sk_graphics.h"
 #include "include/c/sk_image.h"
 #include "include/c/sk_imagefilter.h"
+#include "include/c/sk_linker.h"
 #include "include/c/sk_maskfilter.h"
 #include "include/c/sk_matrix.h"
 #include "include/c/sk_paint.h"
@@ -97,7 +98,6 @@ void** KeepSkiaCSymbols (void)
         // Animation
         (void*)skottie_animation_make_from_stream,
         (void*)sksg_invalidation_controller_new,
-        (void*)skottie_animation_keepalive,
         (void*)skresources_resource_provider_ref,
 
         // Xamarin
@@ -105,6 +105,9 @@ void** KeepSkiaCSymbols (void)
         (void*)sk_managedstream_new,
         (void*)sk_manageddrawable_new,
         (void*)sk_managedtracememorydump_new,
+
+        // Linker
+        (void*)sk_linker_keep_alive,
     };
     return ret;
 }

--- a/src/xamarin/SkiaKeeper.c
+++ b/src/xamarin/SkiaKeeper.c
@@ -45,6 +45,7 @@
 // Skottie
 #include "include/c/skottie_animation.h"
 #include "include/c/sksg_invalidation_controller.h"
+#include "include/c/skresources_resource_provider.h"
 
 
 // Xamarin
@@ -97,6 +98,7 @@ void** KeepSkiaCSymbols (void)
         (void*)skottie_animation_make_from_stream,
         (void*)sksg_invalidation_controller_new,
         (void*)skottie_animation_keepalive,
+        (void*)skresources_resource_provider_ref,
 
         // Xamarin
         (void*)sk_compatpaint_new,


### PR DESCRIPTION
**Description of Change**

This PR adds a few of the essential APIs to enable loading embedded files in the Lottie animation. Currently, there is just the support for file-based and data URI-based assets.

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/2173

**API Changes**

```cpp
typedef enum {
    NONE_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0,
    DEFER_IMAGE_LOADING_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0x01,
    PREFER_EMBEDDED_FONTS_SKOTTIE_ANIMATION_BUILDER_FLAGS = 0x02,
} skottie_animation_builder_flags_t;

typedef struct {
    float fTotalLoadTimeMS;
    float fJsonParseTimeMS;
    float fSceneParseTimeMS;
    size_t fJsonSize;
    size_t fAnimatorCount;
} skottie_animation_builder_stats_t;

SK_C_API skottie_animation_builder_t* skottie_animation_builder_new(skottie_animation_builder_flags_t flags);
SK_C_API void skottie_animation_builder_delete(skottie_animation_builder_t *instance);
SK_C_API void skottie_animation_builder_get_stats(skottie_animation_builder_t* instance, skottie_animation_builder_stats_t* stats);
SK_C_API void skottie_animation_builder_set_resource_provider(skottie_animation_builder_t* instance, skottie_resource_provider_t* resourceProvider);
SK_C_API void skottie_animation_builder_set_font_manager(skottie_animation_builder_t* instance, sk_fontmgr_t* fontManager);
SK_C_API skottie_animation_t* skottie_animation_builder_make_from_stream(skottie_animation_builder_t* instance, sk_stream_t* stream);
SK_C_API skottie_animation_t* skottie_animation_builder_make_from_file(skottie_animation_builder_t* instance, const char* path);
SK_C_API skottie_animation_t* skottie_animation_builder_make_from_string(skottie_animation_builder_t* instance, const char* data, size_t length);
SK_C_API skottie_animation_t* skottie_animation_builder_make_from_data(skottie_animation_builder_t* instance, const char* data, size_t length);

SK_C_API void skresources_resource_provider_ref(skresources_resource_provider_t* instance);
SK_C_API void skresources_resource_provider_unref(skresources_resource_provider_t* instance);
SK_C_API void skresources_resource_provider_delete(skresources_resource_provider_t *instance);
SK_C_API sk_data_t* skresources_resource_provider_load(skresources_resource_provider_t *instance, const char* path, const char* name);
SK_C_API skresources_image_asset_t* skresources_resource_provider_load_image_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id);
SK_C_API skresources_external_track_asset_t* skresources_resource_provider_load_audio_asset(skresources_resource_provider_t *instance, const char* path, const char* name, const char* id);
SK_C_API sk_typeface_t* skresources_resource_provider_load_typeface(skresources_resource_provider_t *instance, const char* name, const char* url);
SK_C_API skresources_resource_provider_t* skresources_file_resource_provider_make(sk_string_t* base_dir, bool predecode);
SK_C_API skresources_resource_provider_t* skresources_caching_resource_provider_proxy_make(skresources_resource_provider_t* rp);
SK_C_API skresources_resource_provider_t* skresources_data_uri_resource_provider_proxy_make(skresources_resource_provider_t* rp, bool predecode);
```

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2630

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
