### PR TITLE
SkResources is skia_component not static_library

### DIFF
--- a/modules/skresources/BUILD.gn
+++ b/modules/skresources/BUILD.gn
@@ -9,15 +9,12 @@ config("public_config") {
   include_dirs = [ "include" ]
 }
 
-static_library("skresources") {
+skia_component("skresources") {
+  check_includes = false
   import("skresources.gni")
   public_configs = [ ":public_config" ]
-  public = skia_skresources_public
   sources = skia_skresources_sources
-  configs += [
-    "../../:skia_private",
-    "../../:skia_library",
-  ]
+  configs = [ "../../:skia_private" ]
   deps = [
     "../..:skia",
     "../../experimental/ffmpeg:video_decoder",


### PR DESCRIPTION
**Description of Change**

In new Xcode versions, the duplicate symbols are failing the build.

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/2675

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2703

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
