### PR TITLE
Add SKImage::makeRawShader to the C API

### DIFF
--- a/include/c/sk_image.h
+++ b/include/c/sk_image.h
@@ -33,6 +33,7 @@ SK_C_API sk_colortype_t sk_image_get_color_type(const sk_image_t* image);
 SK_C_API sk_colorspace_t* sk_image_get_colorspace(const sk_image_t* image);
 SK_C_API bool sk_image_is_alpha_only(const sk_image_t* image);
 SK_C_API sk_shader_t* sk_image_make_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix);
+SK_C_API sk_shader_t* sk_image_make_raw_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix);
 SK_C_API bool sk_image_peek_pixels(const sk_image_t* image, sk_pixmap_t* pixmap);
 SK_C_API bool sk_image_is_texture_backed(const sk_image_t* image);
 SK_C_API bool sk_image_is_lazy_generated(const sk_image_t* image);

--- a/src/c/sk_image.cpp
+++ b/src/c/sk_image.cpp
@@ -99,6 +99,14 @@ sk_shader_t* sk_image_make_shader(const sk_image_t* image, sk_shader_tilemode_t 
     return ToShader(AsImage(image)->makeShader((SkTileMode)tileX, (SkTileMode)tileY, *AsSamplingOptions(sampling), cmatrix ? &m : nullptr).release());
 }
 
+sk_shader_t* sk_image_make_raw_shader(const sk_image_t* image, sk_shader_tilemode_t tileX, sk_shader_tilemode_t tileY, const sk_sampling_options_t* sampling, const sk_matrix_t* cmatrix) {
+    SkMatrix m;
+    if (cmatrix) {
+        m = AsMatrix(cmatrix);
+    }
+    return ToShader(AsImage(image)->makeRawShader((SkTileMode)tileX, (SkTileMode)tileY, *AsSamplingOptions(sampling), cmatrix ? &m : nullptr).release());
+}
+
 bool sk_image_peek_pixels(const sk_image_t* image, sk_pixmap_t* pixmap) {
     return AsImage(image)->peekPixels(AsPixmap(pixmap));
 }


### PR DESCRIPTION
**Description of Change**

This PR adds the `SKImage::makeRawShader` API to the C layer.

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

Related to https://github.com/mono/SkiaSharp/issues/2338

**API Changes**

```cpp
sk_shader_t* sk_image_make_raw_shader(
    const sk_image_t* image, 
    sk_shader_tilemode_t tileX, 
    sk_shader_tilemode_t tileY, 
    const sk_sampling_options_t* sampling, 
    const sk_matrix_t* cmatrix);
```

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2748

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
