### PR TITLE
Expose more SkPicture and SkDrawable APIs

### DIFF
--- a/include/c/sk_drawable.h
+++ b/include/c/sk_drawable.h
@@ -21,6 +21,7 @@ SK_C_API void sk_drawable_get_bounds (sk_drawable_t*, sk_rect_t*);
 SK_C_API void sk_drawable_draw (sk_drawable_t*, sk_canvas_t*, const sk_matrix_t*);
 SK_C_API sk_picture_t* sk_drawable_new_picture_snapshot(sk_drawable_t*);
 SK_C_API void sk_drawable_notify_drawing_changed (sk_drawable_t*);
+SK_C_API size_t sk_drawable_approximate_bytes_used(sk_drawable_t*);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_picture.h
+++ b/include/c/sk_picture.h
@@ -31,6 +31,9 @@ SK_C_API void sk_picture_serialize_to_stream(const sk_picture_t* picture, sk_wst
 SK_C_API sk_picture_t* sk_picture_deserialize_from_stream(sk_stream_t* stream);
 SK_C_API sk_picture_t* sk_picture_deserialize_from_data(sk_data_t* data);
 SK_C_API sk_picture_t* sk_picture_deserialize_from_memory(void* buffer, size_t length);
+SK_C_API void sk_picture_playback(const sk_picture_t* picture, sk_canvas_t* canvas);
+SK_C_API int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested);
+SK_C_API size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/src/c/sk_drawable.cpp
+++ b/src/c/sk_drawable.cpp
@@ -47,3 +47,7 @@ void sk_drawable_notify_drawing_changed(sk_drawable_t* d)
 {
     AsDrawable(d)->notifyDrawingChanged();
 }
+
+size_t sk_drawable_approximate_bytes_used(sk_drawable_t* d) {
+    return AsDrawable(d)->approximateBytesUsed();
+}

--- a/src/c/sk_picture.cpp
+++ b/src/c/sk_picture.cpp
@@ -83,3 +83,15 @@ sk_picture_t* sk_picture_deserialize_from_data(sk_data_t* data) {
 sk_picture_t* sk_picture_deserialize_from_memory(void* buffer, size_t length) {
     return ToPicture(SkPicture::MakeFromData(buffer, length).release());
 }
+
+void sk_picture_playback(const sk_picture_t* picture, sk_canvas_t* canvas) {
+    AsPicture(picture)->playback(AsCanvas(canvas));
+}
+
+int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested) {
+    return AsPicture(picture)->approximateOpCount(nested);
+}
+
+size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture) {
+    return AsPicture(picture)->approximateBytesUsed();
+}


### PR DESCRIPTION
**Description of Change**

Add a few more APIs for `SkPicture`. 

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

Related to https://github.com/mono/SkiaSharp/issues/2881

**API Changes**


```cpp
size_t sk_drawable_approximate_bytes_used(sk_drawable_t* drawable);

void sk_picture_playback(const sk_picture_t* picture, sk_canvas_t* canvas);
int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested);
size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture);
```

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2883

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
