### PR TITLE
Add R-Tree overload of beginRecording

### DIFF
--- a/include/c/sk_picture.h
+++ b/include/c/sk_picture.h
@@ -19,7 +19,7 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
 SK_C_API sk_picture_recorder_t* sk_picture_recorder_new(void);
 SK_C_API void sk_picture_recorder_delete(sk_picture_recorder_t*);
 SK_C_API sk_canvas_t* sk_picture_recorder_begin_recording(sk_picture_recorder_t*, const sk_rect_t*);
-SK_C_API sk_canvas_t* sk_picture_recorder_begin_recording_with_bbox_hierarchy(sk_picture_recorder_t*, const sk_rect_t*, sk_bbh_factory_t*);
+SK_C_API sk_canvas_t* sk_picture_recorder_begin_recording_with_bbh_factory(sk_picture_recorder_t*, const sk_rect_t*, sk_bbh_factory_t*);
 SK_C_API sk_picture_t* sk_picture_recorder_end_recording(sk_picture_recorder_t*);
 SK_C_API sk_drawable_t* sk_picture_recorder_end_recording_as_drawable(sk_picture_recorder_t*);
 SK_C_API sk_canvas_t* sk_picture_get_recording_canvas(sk_picture_recorder_t* crec);

--- a/include/c/sk_picture.h
+++ b/include/c/sk_picture.h
@@ -14,12 +14,17 @@
 
 SK_C_PLUS_PLUS_BEGIN_GUARD
 
+// SkPictureRecorder
+
 SK_C_API sk_picture_recorder_t* sk_picture_recorder_new(void);
 SK_C_API void sk_picture_recorder_delete(sk_picture_recorder_t*);
 SK_C_API sk_canvas_t* sk_picture_recorder_begin_recording(sk_picture_recorder_t*, const sk_rect_t*);
+SK_C_API sk_canvas_t* sk_picture_recorder_begin_recording_with_bbox_hierarchy(sk_picture_recorder_t*, const sk_rect_t*, sk_bbh_factory_t*);
 SK_C_API sk_picture_t* sk_picture_recorder_end_recording(sk_picture_recorder_t*);
 SK_C_API sk_drawable_t* sk_picture_recorder_end_recording_as_drawable(sk_picture_recorder_t*);
 SK_C_API sk_canvas_t* sk_picture_get_recording_canvas(sk_picture_recorder_t* crec);
+
+// SkPicture
 
 SK_C_API void sk_picture_ref(sk_picture_t*);
 SK_C_API void sk_picture_unref(sk_picture_t*);
@@ -34,6 +39,11 @@ SK_C_API sk_picture_t* sk_picture_deserialize_from_memory(void* buffer, size_t l
 SK_C_API void sk_picture_playback(const sk_picture_t* picture, sk_canvas_t* canvas);
 SK_C_API int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested);
 SK_C_API size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture);
+
+// SkRTreeFactory
+
+SK_C_API sk_rtree_factory_t* sk_rtree_factory_new(void);
+SK_C_API void sk_rtree_factory_delete(sk_rtree_factory_t*);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -250,7 +250,7 @@ typedef struct sk_bbh_factory_t sk_bbh_factory_t;
     for culling invisible calls recorded by a sk_picture_recorder_t. Inherits
     from sk_bbh_factory_t.
 */
-typedef struct sk_rtree_factory_t sk_retree_factory_t;
+typedef struct sk_rtree_factory_t sk_rtree_factory_t;
 /**
     A sk_shader_t specifies the source color(s) for what is being drawn. If a
     paint has no shader, then the paint's color is used. If the paint

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -239,6 +239,19 @@ typedef struct sk_picture_t sk_picture_t;
 */
 typedef struct sk_picture_recorder_t sk_picture_recorder_t;
 /**
+    A sk_bbh_factory_t generates an sk_bbox_hierarchy as a display optimization
+    for culling invisible calls recorded by a sk_picture_recorder. It may
+    be passed in to sk_picture_recorder_begin_recording_with_bbox_hierarchy,
+    typically as an instance of the subclass sk_rtree_factory_t.
+*/
+typedef struct sk_bbh_factory_t sk_bbh_factory_t;
+/**
+    A sk_rtree_factory_t generates a sk_rtree as a display optimization
+    for culling invisible calls recorded by a sk_picture_recorder_t. Inherits
+    from sk_bbh_factory_t.
+*/
+typedef struct sk_rtree_factory_t sk_retree_factory_t;
+/**
     A sk_shader_t specifies the source color(s) for what is being drawn. If a
     paint has no shader, then the paint's color is used. If the paint
     has a shader, then the shader's color(s) are use instead, but they

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -241,7 +241,7 @@ typedef struct sk_picture_recorder_t sk_picture_recorder_t;
 /**
     A sk_bbh_factory_t generates an sk_bbox_hierarchy as a display optimization
     for culling invisible calls recorded by a sk_picture_recorder. It may
-    be passed in to sk_picture_recorder_begin_recording_with_bbox_hierarchy,
+    be passed in to sk_picture_recorder_begin_recording_with_bbh_factory,
     typically as an instance of the subclass sk_rtree_factory_t.
 */
 typedef struct sk_bbh_factory_t sk_bbh_factory_t;

--- a/src/c/sk_picture.cpp
+++ b/src/c/sk_picture.cpp
@@ -16,6 +16,8 @@
 
 #include "src/c/sk_types_priv.h"
 
+// SkPictureRecorder
+
 sk_picture_recorder_t* sk_picture_recorder_new(void) {
     return ToPictureRecorder(new SkPictureRecorder);
 }
@@ -26,6 +28,10 @@ void sk_picture_recorder_delete(sk_picture_recorder_t* crec) {
 
 sk_canvas_t* sk_picture_recorder_begin_recording(sk_picture_recorder_t* crec, const sk_rect_t* cbounds) {
     return ToCanvas(AsPictureRecorder(crec)->beginRecording(*AsRect(cbounds)));
+}
+
+sk_canvas_t* sk_picture_recorder_begin_recording_with_bbh_factory(sk_picture_recorder_t* crec, const sk_rect_t* cbounds, sk_bbh_factory_t* factory) {
+    return ToCanvas(AsPictureRecorder(crec)->beginRecording(*AsRect(cbounds), AsBBHFactory(factory)));
 }
 
 sk_picture_t* sk_picture_recorder_end_recording(sk_picture_recorder_t* crec) {
@@ -39,6 +45,8 @@ sk_drawable_t* sk_picture_recorder_end_recording_as_drawable(sk_picture_recorder
 sk_canvas_t* sk_picture_get_recording_canvas(sk_picture_recorder_t* crec) {
     return ToCanvas(AsPictureRecorder(crec)->getRecordingCanvas());
 }
+
+// SkPicture
 
 void sk_picture_ref(sk_picture_t* cpic) {
     SkSafeRef(AsPicture(cpic));
@@ -94,4 +102,14 @@ int sk_picture_approximate_op_count(const sk_picture_t* picture, bool nested) {
 
 size_t sk_picture_approximate_bytes_used(const sk_picture_t* picture) {
     return AsPicture(picture)->approximateBytesUsed();
+}
+
+// SkRTreeFactory
+
+sk_rtree_factory_t* sk_rtree_factory_new(void) {
+    return ToRTreeFactory(new SkRTreeFactory);
+}
+
+void sk_rtree_factory_delete(sk_rtree_factory_t* factory) {
+    delete AsRTreeFactory(factory);
 }

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -97,6 +97,7 @@
 #define DEF_MAP_WITH_NS(Ns, SkType, sk_type, Name)             \
     DEF_MAP_DECL(SkType, sk_type, Name, , Ns)
 
+DEF_CLASS_MAP(SkBBHFactory, sk_bbh_factory_t, BBHFactory)
 DEF_CLASS_MAP(SkBitmap, sk_bitmap_t, Bitmap)
 DEF_CLASS_MAP(SkCanvas, sk_canvas_t, Canvas)
 DEF_CLASS_MAP(SkCodec, sk_codec_t, Codec)
@@ -131,6 +132,7 @@ DEF_CLASS_MAP(SkPictureRecorder, sk_picture_recorder_t, PictureRecorder)
 DEF_CLASS_MAP(SkPixmap, sk_pixmap_t, Pixmap)
 DEF_CLASS_MAP(SkRegion, sk_region_t, Region)
 DEF_CLASS_MAP(SkRRect, sk_rrect_t, RRect)
+DEF_CLASS_MAP(SkRTreeFactory, sk_rtree_factory_t, RTreeFactory)
 DEF_CLASS_MAP(SkRuntimeEffect, sk_runtimeeffect_t, RuntimeEffect)
 DEF_CLASS_MAP(SkShader, sk_shader_t, Shader)
 DEF_CLASS_MAP(SkStream, sk_stream_t, Stream)


### PR DESCRIPTION
**Description of Change**

Add the R-Tree overload of `SkPicture::beginRecording`. 

Only the construction and destruction of the sole implementation of `SkBBHFactory` (the `SkRTreeFactory` class) is exposed. This is really an opaque type in skia and clients would create their own implementations if they wanted. However, this PR does not provide the API to do this since it is fairly complicated and not many use cases. It can be added later.

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

Related to https://github.com/mono/SkiaSharp/issues/2372

**API Changes**

```cpp
sk_canvas_t* sk_picture_recorder_begin_recording_with_bbox_hierarchy(sk_picture_recorder_t*, const sk_rect_t*, sk_bbh_factory_t*);

sk_rtree_factory_t* sk_rtree_factory_new(void);
void sk_rtree_factory_delete(sk_rtree_factory_t*);
```

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/2889

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
