### PR TITLE
Bump expat to version 2.6.3

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ deps = {
   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
   "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@a0bca08de07c7d7651047bedc0b653cfaaa4f2ae",
   # "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@4a48a752e6a8bef6f222622f2b4926d5eb3bdeb3",
-  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@624da0f593bb8d7e146b9f42b06d8e6c80d032a3",
   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@d857bd535b6c7e877f262a9b61ed21ee11b35dab",
   "third_party/externals/harfbuzz"               : "https://github.com/harfbuzz/harfbuzz.git@894a1f72ee93a1fd8dc1d9218cb3fd8f048be29a",
   "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -46,7 +46,7 @@ def git_repos_from_deps(ws = "@"):
     new_git_repository(
         name = "expat",
         build_file = ws + "//bazel/external/expat:BUILD.bazel",
-        commit = "441f98d02deafd9b090aea568282b28f66a50e36",
+        commit = "624da0f593bb8d7e146b9f42b06d8e6c80d032a3",
         remote = "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git",
     )
 

--- a/third_party/expat/include/expat_config/expat_config.h
+++ b/third_party/expat/include/expat_config/expat_config.h
@@ -16,6 +16,9 @@
 /* Define to 1 if you have the `arc4random_buf' function. */
 /* #define HAVE_ARC4RANDOM_BUF 1 */
 
+/* define if the compiler supports basic C++11 syntax */
+#define HAVE_CXX11 1
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
@@ -74,13 +77,13 @@
 #define PACKAGE "expat"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "expat-bugs@libexpat.org"
+#define PACKAGE_BUGREPORT "https://github.com/libexpat/libexpat/issues"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "expat"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "expat 2.5.0"
+#define PACKAGE_STRING "expat 2.6.3"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "expat"
@@ -89,7 +92,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.5.0"
+#define PACKAGE_VERSION "2.6.3"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for


### PR DESCRIPTION
Expat v2.6.3 fixes a number of CVE issues:

   * https://nvd.nist.gov/vuln/detail/CVE-2024-28757
   * https://nvd.nist.gov/vuln/detail/CVE-2024-45490
   * https://nvd.nist.gov/vuln/detail/CVE-2024-45491
   * https://nvd.nist.gov/vuln/detail/CVE-2024-45492

Update to 2.6.3 from 2.5.0.  Version of expat used here is the same the upstream
skia repository uses at this point.

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
