### PR TITLE
Cherry-pick upsteam bug fix to expose codec registration methods

### DIFF
--- a/include/codec/SkAvifDecoder.h
+++ b/include/codec/SkAvifDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkBmpDecoder.h
+++ b/include/codec/SkBmpDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkCodec.h
+++ b/include/codec/SkCodec.h
@@ -1021,7 +1021,7 @@ using MakeFromStreamCallback = std::unique_ptr<SkCodec> (*)(std::unique_ptr<SkSt
                                                             SkCodec::Result*,
                                                             DecodeContext);
 
-struct Decoder {
+struct SK_API Decoder {
     // By convention, we use all lowercase letters and go with the primary filename extension.
     // For example "png", "jpg", "ico", "webp", etc
     std::string id;
@@ -1033,7 +1033,7 @@ struct Decoder {
 // SkCodec::MakeFromStream. If a decoder with the same id already exists, this new decoder
 // will replace the existing one (in the same position). This is not thread-safe, so make sure all
 // initialization is done before the first call.
-void Register(Decoder d);
+void SK_API Register(Decoder d);
 }
 
 #endif // SkCodec_DEFINED

--- a/include/codec/SkGifDecoder.h
+++ b/include/codec/SkGifDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkIcoDecoder.h
+++ b/include/codec/SkIcoDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkJpegDecoder.h
+++ b/include/codec/SkJpegDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkJpegxlDecoder.h
+++ b/include/codec/SkJpegxlDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkPngDecoder.h
+++ b/include/codec/SkPngDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkRawDecoder.h
+++ b/include/codec/SkRawDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkWbmpDecoder.h
+++ b/include/codec/SkWbmpDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/include/codec/SkWebpDecoder.h
+++ b/include/codec/SkWebpDecoder.h
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/core/SkRefCnt.h"
+#include "include/private/base/SkAPI.h"
 
 class SkData;
 class SkStream;

--- a/src/codec/SkAvifCodec.cpp
+++ b/src/codec/SkAvifCodec.cpp
@@ -7,6 +7,7 @@
 
 #include "src/codec/SkAvifCodec.h"
 
+#include "include/codec/SkAvifDecoder.h"
 #include "include/codec/SkCodec.h"
 #include "include/codec/SkCodecAnimation.h"
 #include "include/core/SkColorType.h"

--- a/src/codec/SkBmpCodec.cpp
+++ b/src/codec/SkBmpCodec.cpp
@@ -7,6 +7,7 @@
 
 #include "src/codec/SkBmpCodec.h"
 
+#include "include/codec/SkBmpDecoder.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImageInfo.h"
 #include "include/core/SkRefCnt.h"

--- a/src/codec/SkIcoCodec.cpp
+++ b/src/codec/SkIcoCodec.cpp
@@ -7,6 +7,7 @@
 
 #include "src/codec/SkIcoCodec.h"
 
+#include "include/codec/SkIcoDecoder.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImageInfo.h"
 #include "include/core/SkRefCnt.h"

--- a/src/codec/SkJpegCodec.cpp
+++ b/src/codec/SkJpegCodec.cpp
@@ -8,6 +8,7 @@
 #include "src/codec/SkJpegCodec.h"
 
 #include "include/codec/SkCodec.h"
+#include "include/codec/SkJpegDecoder.h"
 #include "include/core/SkAlphaType.h"
 #include "include/core/SkColorType.h"
 #include "include/core/SkData.h"

--- a/src/codec/SkJpegxlCodec.cpp
+++ b/src/codec/SkJpegxlCodec.cpp
@@ -8,6 +8,7 @@
 #include "src/codec/SkJpegxlCodec.h"
 
 #include "include/codec/SkCodec.h"
+#include "include/codec/SkJpegxlDecoder.h"
 #include "include/core/SkColorType.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImageInfo.h"
@@ -465,7 +466,7 @@ const SkFrameHolder* SkJpegxlCodec::getFrameHolder() const {
 // TODO(eustas): implement
 // SkSampler* SkJpegxlCodec::getSampler(bool /*createIfNecessary*/) { return nullptr; }
 
-namespace SkJpegDecoder {
+namespace SkJpegxlDecoder {
 bool IsJpegxl(const void* data, size_t len) {
     return SkJpegxlCodec::IsJpegxl(data, len);
 }

--- a/src/codec/SkPngCodec.cpp
+++ b/src/codec/SkPngCodec.cpp
@@ -8,6 +8,7 @@
 #include "src/codec/SkPngCodec.h"
 
 #include "include/codec/SkPngChunkReader.h"
+#include "include/codec/SkPngDecoder.h"
 #include "include/core/SkAlphaType.h"
 #include "include/core/SkColor.h"
 #include "include/core/SkColorType.h"

--- a/src/codec/SkRawCodec.cpp
+++ b/src/codec/SkRawCodec.cpp
@@ -8,6 +8,7 @@
 #include "src/codec/SkRawCodec.h"
 
 #include "include/codec/SkCodec.h"
+#include "include/codec/SkRawDecoder.h"
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkData.h"
 #include "include/core/SkImageInfo.h"

--- a/src/codec/SkWbmpCodec.cpp
+++ b/src/codec/SkWbmpCodec.cpp
@@ -8,6 +8,7 @@
 #include "src/codec/SkWbmpCodec.h"
 
 #include "include/codec/SkCodec.h"
+#include "include/codec/SkWbmpDecoder.h"
 #include "include/codec/SkEncodedImageFormat.h"
 #include "include/core/SkColorType.h"
 #include "include/core/SkData.h"

--- a/src/codec/SkWebpCodec.cpp
+++ b/src/codec/SkWebpCodec.cpp
@@ -9,6 +9,7 @@
 
 #include "include/codec/SkCodec.h"
 #include "include/codec/SkCodecAnimation.h"
+#include "include/codec/SkWebpDecoder.h"
 #include "include/core/SkAlphaType.h"
 #include "include/core/SkBitmap.h"
 #include "include/core/SkColorType.h"

--- a/src/codec/SkWuffsCodec.cpp
+++ b/src/codec/SkWuffsCodec.cpp
@@ -8,6 +8,7 @@
 #include "include/codec/SkCodec.h"
 #include "include/codec/SkCodecAnimation.h"
 #include "include/codec/SkEncodedImageFormat.h"
+#include "include/codec/SkGifDecoder.h"
 #include "include/core/SkAlphaType.h"
 #include "include/core/SkBitmap.h"
 #include "include/core/SkBlendMode.h"


### PR DESCRIPTION
**Description of Change**

Cherry pick of google/skia@ec70dfbaa2e99ae34cc40bebe7c59e3b87d31eaf

This commit exports `SkCodec::Register` from the library. The method accepts a C++ object so can't be easily wrapped in C#, but exposing it costs nothing and does at least enable users of SkiaSharp to register codecs by creating a native library. We want to do exactly this in our product.

**SkiaSharp Issue**

Fixes mono/skiasharp#2992

**API Changes**

Added:
- `SkCodec::Register`
- `SKCodec::Decoder`

**Behavioral Changes**

None.

**Required SkiaSharp PR**

None.

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
