### PR TITLE
Fix configuration of expat 2.6.3

### DIFF
--- a/third_party/expat/include/expat_config/expat_config.h
+++ b/third_party/expat/include/expat_config/expat_config.h
@@ -11,3 +11,4 @@
 #define XML_CONTEXT_BYTES 1024
 #define XML_DTD 1
 #define XML_NS 1
+#define XML_GE 1


### PR DESCRIPTION
Follow up to https://github.com/mono/skia/pull/134, to define a missing macro.