### PR TITLE
Update libjpeg_turbo to the latest commit

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -40,7 +40,7 @@ deps = {
   "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@f49462dc93784bf34148715eee36ab6697ca0b35",
   "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@0fb779c1e169fe6c229cd1fa9cc6ea6feeb441da",
   "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
-  "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@9b894306ec3b28cea46e84c32b56773a98c483da",
+  "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@927aabfcd26897abb9776ecf2a6c38ea5bb52ab6",
   "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@f135775ad4e5d4408d2e12ffcc71bb36e6b48551",
   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@ca332209cb5567c9b249c86788cb2dbf8847e760",


### PR DESCRIPTION
**Description of Change**

Update libjpeg_turbo to the latest commit: 2.1.5.1+commits

Previously was also 2.1.5.1+commits

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

https://github.com/mono/SkiaSharp/pull/3060

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
