### PR TITLE
Update libexpat to v2.6.4

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ deps = {
   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
   "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
   #"third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
-  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@624da0f593bb8d7e146b9f42b06d8e6c80d032a3",
+  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@2691aff4304a6d7e053199c205620136481b9dd1",
   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@2d9fce53d4ce89f36075168282fcdd7289e082f9",
   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@2b3631a866b3077d9d675caa4ec9010b342b5a7c",
   "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",


### PR DESCRIPTION
**Description of Change**

Updates the skia dependency libexpat to the latest tagged: 2.6.4

Previously was a tag v2.6.3+ (3 non code commits)

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

https://github.com/mono/SkiaSharp/pull/3056

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
