### PR TITLE
added sk_graphics_set_open_type_svg_decoder_factory_to_default

### DIFF
--- a/include/c/sk_graphics.h
+++ b/include/c/sk_graphics.h
@@ -37,6 +37,9 @@ SK_C_API size_t sk_graphics_set_resource_cache_total_byte_limit(size_t newLimit)
 SK_C_API size_t sk_graphics_get_resource_cache_single_allocation_byte_limit(void);
 SK_C_API size_t sk_graphics_set_resource_cache_single_allocation_byte_limit(size_t newLimit);
 
+// open type svg decoder factory
+SK_C_API bool sk_graphics_set_open_type_svg_decoder_factory_to_default();
+
 // dump
 SK_C_API void sk_graphics_dump_memory_statistics(sk_tracememorydump_t* dump);
 

--- a/src/c/sk_graphics.cpp
+++ b/src/c/sk_graphics.cpp
@@ -9,6 +9,10 @@
 
 #include "include/core/SkGraphics.h"
 
+#if defined(SK_ENABLE_SVG)
+#include "modules/svg/include/SkSVGOpenTypeSVGDecoder.h"
+#endif
+
 #include "include/c/sk_graphics.h"
 
 #include "src/c/sk_types_priv.h"
@@ -71,6 +75,14 @@ size_t sk_graphics_get_resource_cache_single_allocation_byte_limit(void) {
 
 size_t sk_graphics_set_resource_cache_single_allocation_byte_limit(size_t newLimit) {
     return SkGraphics::SetResourceCacheSingleAllocationByteLimit(newLimit);
+}
+
+bool sk_graphics_set_open_type_svg_decoder_factory_to_default() {
+#if defined(SK_ENABLE_SVG)
+	SkGraphics::SetOpenTypeSVGDecoderFactory(SkSVGOpenTypeSVGDecoder::Make);
+	return true;
+#endif
+	return false;
 }
 
 void sk_graphics_dump_memory_statistics(sk_tracememorydump_t* dump) {


### PR DESCRIPTION
**Description of Change**
Added function to set a default open type svg decoder

**SkiaSharp Issue**

Related to [Issue 2939](https://github.com/mono/SkiaSharp/issues/2939)

**API Changes**

Added: 
- `bool sk_graphics_set_open_type_svg_decoder_factory_to_default()`

**Behavioral Changes**

None.

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
