### PR TITLE
Enable GL on Windows ARM

### DIFF
--- a/src/gpu/ganesh/gl/win/GrGLMakeNativeInterface_win.cpp
+++ b/src/gpu/ganesh/gl/win/GrGLMakeNativeInterface_win.cpp
@@ -13,12 +13,6 @@
 #include "include/gpu/gl/GrGLInterface.h"
 #include "src/gpu/ganesh/gl/GrGLUtil.h"
 
-#if defined(_M_ARM64)
-
-sk_sp<const GrGLInterface> GrGLMakeNativeInterface() { return nullptr; }
-
-#else
-
 typedef HGLRC (WINAPI *WGLGetCurrentContextProc)(VOID);
 typedef PROC (WINAPI *WGLGetProcAddressProc)(LPCSTR name);
 
@@ -108,7 +102,5 @@ sk_sp<const GrGLInterface> GrGLMakeNativeInterface() {
     }
     return nullptr;
 }
-
-#endif // ARM64
 
 #endif//defined(SK_BUILD_FOR_WIN)

--- a/src/utils/win/SkWGL_win.cpp
+++ b/src/utils/win/SkWGL_win.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "include/core/SkTypes.h"
-#if defined(SK_BUILD_FOR_WIN) && !defined(_M_ARM64) && !defined(WINUWP)
+#if defined(SK_BUILD_FOR_WIN) && !defined(WINUWP)
 
 #include "src/utils/win/SkWGL.h"
 


### PR DESCRIPTION
**Description of Change**


This PR just removes the code that prevents OpenGL from working on Windows ARM. 

This was initially done in https://github.com/mono/skia/commit/0c75727f0148cafc6653d7d94b3633889ffde7db. The reason for this was there was no OpenGL on ARM. However, recently, there is a way: https://apps.microsoft.com/detail/9nqpsl29bfff

The reason we can just remove this code is because we don't actually link with opengl32 directly and instead load it at runtime. 

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/3155

**API Changes**

None.

**Behavioral Changes**

None.


**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/3189

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
