### PR TITLE
fix: Don't dereference null surface props

### DIFF
--- a/src/c/sk_image.cpp
+++ b/src/c/sk_image.cpp
@@ -60,7 +60,7 @@ sk_image_t* sk_image_new_from_picture(sk_picture_t* picture, const sk_isize_t* d
     if (cmatrix) {
         m = AsMatrix(cmatrix);
     }
-    return ToImage(SkImages::DeferredFromPicture(sk_ref_sp(AsPicture(picture)), *AsISize(dimensions), cmatrix ? &m : nullptr, AsPaint(paint), useFloatingPointBitDepth ? SkImages::BitDepth::kF16 : SkImages::BitDepth::kU8, sk_ref_sp(AsColorSpace(colorSpace)), *AsSurfaceProps(props)).release());
+    return ToImage(SkImages::DeferredFromPicture(sk_ref_sp(AsPicture(picture)), *AsISize(dimensions), cmatrix ? &m : nullptr, AsPaint(paint), useFloatingPointBitDepth ? SkImages::BitDepth::kF16 : SkImages::BitDepth::kU8, sk_ref_sp(AsColorSpace(colorSpace)), props ? (*AsSurfaceProps(props)).release()) : {});
 }
 
 int sk_image_get_width(const sk_image_t* cimage) {


### PR DESCRIPTION
**Description of Change**

This change fixes a null reference when invoking SKImage.FromPicture with a null parameter

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

Related to https://github.com/mono/SkiaSharp/issues/<issue-number>

**API Changes**

None.

**Behavioral Changes**

None.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/<pr-number>

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
