### PR TITLE
Added support for getPostScriptName to SkTypeface

### DIFF
--- a/include/c/sk_typeface.h
+++ b/include/c/sk_typeface.h
@@ -40,6 +40,7 @@ SK_C_API int sk_typeface_get_units_per_em(const sk_typeface_t* typeface);
 SK_C_API bool sk_typeface_get_kerning_pair_adjustments(const sk_typeface_t* typeface, const uint16_t glyphs[], int count, int32_t adjustments[]);
 // TODO: createFamilyNameIterator
 SK_C_API sk_string_t* sk_typeface_get_family_name(const sk_typeface_t* typeface);
+SK_C_API sk_string_t* sk_typeface_get_post_script_name(const sk_typeface_t* typeface);
 SK_C_API sk_stream_asset_t* sk_typeface_open_stream(const sk_typeface_t* typeface, int* ttcIndex);
 
 

--- a/src/c/sk_typeface.cpp
+++ b/src/c/sk_typeface.cpp
@@ -116,6 +116,12 @@ sk_string_t* sk_typeface_get_family_name(const sk_typeface_t* typeface) {
     return ToString(family_name);
 }
 
+sk_string_t* sk_typeface_get_post_script_name(const sk_typeface_t* typeface) {
+    SkString* ps_name = new SkString();
+    AsTypeface(typeface)->getPostScriptName(ps_name);
+    return ToString(ps_name);
+}
+
 sk_stream_asset_t* sk_typeface_open_stream(const sk_typeface_t* typeface, int* ttcIndex) {
     return ToStreamAsset(AsTypeface(typeface)->openStream(ttcIndex).release());
 }


### PR DESCRIPTION
**Description of Change**

Added a binding for the getPostScriptName method on SkTypeface

**SkiaSharp Issue**

No issue.  Just missing binding.

**API Changes**

None.

Added: 
- `sk_string_t* sk_typeface_get_post_script_name(const sk_typeface_t* typeface)`

**Behavioral Changes**

None.

**Required SkiaSharp PR**

[https://github.com/mono/SkiaSharp/pull/3261](https://github.com/mono/SkiaSharp/pull/3261)

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
