### PR TITLE
Update to new GrDirectContext::MakeMetal API

### DIFF
--- a/src/gpu/ganesh/GrDirectContext.cpp
+++ b/src/gpu/ganesh/GrDirectContext.cpp
@@ -1235,10 +1235,9 @@ sk_sp<GrDirectContext> GrDirectContext::MakeMetal(void* device, void* queue) {
 // remove include/gpu/mtl/GrMtlBackendContext.h, above, when removed
 sk_sp<GrDirectContext> GrDirectContext::MakeMetal(void* device, void* queue,
                                                   const GrContextOptions& options) {
-    sk_sp<GrDirectContext> direct(new GrDirectContext(GrBackendApi::kMetal, options));
     GrMtlBackendContext backendContext = {};
-    backendContext.fDevice.reset(device);
-    backendContext.fQueue.reset(queue);
+    backendContext.fDevice.retain(device);
+    backendContext.fQueue.retain(queue);
 
     return GrDirectContext::MakeMetal(backendContext, options);
 }


### PR DESCRIPTION
**Description of Change**

Update to new GrDirectContext::MakeMetal API for m124 and later.

Also, use retain for setting the pointers to prevent GrMtlBackendContext disposing the command queue.

**SkiaSharp Issue**

* https://github.com/mono/SkiaSharp/issues/3178

Fixes: https://github.com/mono/SkiaSharp/issues/3178

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/3258

* https://github.com/mono/SkiaSharp/pull/3258

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [X] Rebased on top of `skiasharp` at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation
