### PR TITLE
Remove the strip symbols flag

### DIFF
--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -817,7 +817,7 @@ config("optimize") {
     if (is_mac || is_ios) {
       ldflags += [ "-dead_strip" ]
     } else {
-      ldflags += [ "-s", "-Wl,--gc-sections" ]
+      ldflags += [ "-Wl,--gc-sections" ]
     }
     if (target_cpu == "wasm") {
       # The compiler asks us to add an optimization flag to both cflags


### PR DESCRIPTION
**Description of Change**

Reverts the change that strips the symbols during the build. We want to keep them and strip after so we can use the symbols.

Part of https://github.com/mono/SkiaSharp/pull/3374