### PR TITLE
Update libwebp to 1.6.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -47,7 +47,7 @@ deps = {
   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@927aabfcd26897abb9776ecf2a6c38ea5bb52ab6",
   # "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@02f2b4f4699f0ef9111a6534f093b53732df4452",
-  "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@ca332209cb5567c9b249c86788cb2dbf8847e760",
+  "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
   # "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
   # "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
   # "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",

--- a/third_party/libwebp/BUILD.gn
+++ b/third_party/libwebp/BUILD.gn
@@ -171,6 +171,7 @@ if (skia_use_system_libwebp) {
       "../externals/libwebp/src/utils/filters_utils.c",
       "../externals/libwebp/src/utils/huffman_encode_utils.c",
       "../externals/libwebp/src/utils/huffman_utils.c",
+      "../externals/libwebp/src/utils/palette.c",
       "../externals/libwebp/src/utils/quant_levels_dec_utils.c",
       "../externals/libwebp/src/utils/quant_levels_utils.c",
       "../externals/libwebp/src/utils/random_utils.c",

--- a/third_party/libwebp/BUILD.gn
+++ b/third_party/libwebp/BUILD.gn
@@ -28,24 +28,12 @@ if (skia_use_system_libwebp) {
     ]
   }
 
-  # Disable AVX2 support for now. libwebp 1.6.0 added AVX2 optimizations but
-  # enabling them requires adding new source files (lossless_avx2.c, lossless_enc_avx2.c).
-  # The -mno-avx2 flag prevents the compiler from defining __AVX2__ which would
-  # otherwise trigger AVX2 code paths without the required source files.
-  # Added in libwebp: https://github.com/webmproject/libwebp/commit/f2b3f527
-  # Tracking issue: https://github.com/mono/SkiaSharp/issues/3464
-  config("libwebp_no_avx2") {
-    if (current_cpu == "x86" || current_cpu == "x64") {
-      cflags = [ "-mno-avx2" ]
-    }
-  }
-
   third_party("libwebp_sse41") {
     public_include_dirs = [
       "../externals/libwebp/src",
       "../externals/libwebp",
     ]
-    configs = [ ":libwebp_defines", ":libwebp_no_avx2" ]
+    configs = [ ":libwebp_defines" ]
     sources = [
       "../externals/libwebp/src/dsp/alpha_processing_sse41.c",
       "../externals/libwebp/src/dsp/dec_sse41.c",
@@ -61,18 +49,37 @@ if (skia_use_system_libwebp) {
     }
   }
 
+  # AVX2 optimizations for lossless WebP encoding/decoding.
+  # Added in libwebp 1.6.0: https://github.com/webmproject/libwebp/commit/f2b3f527
+  # Uses runtime CPU detection - only executes AVX2 code on CPUs that support it.
+  third_party("libwebp_avx2") {
+    public_include_dirs = [
+      "../externals/libwebp/src",
+      "../externals/libwebp",
+    ]
+    configs = [ ":libwebp_defines" ]
+    sources = [
+      "../externals/libwebp/src/dsp/lossless_avx2.c",
+      "../externals/libwebp/src/dsp/lossless_enc_avx2.c",
+    ]
+    if ((current_cpu == "x86" || current_cpu == "x64") &&
+        (!is_win || is_clang)) {
+      cflags_c = [ "-mavx2" ]
+    }
+  }
+
   third_party("libwebp") {
     public_include_dirs = [
       "../externals/libwebp/src",
       "../externals/libwebp",
     ]
 
-    deps = [ ":libwebp_sse41" ]
+    deps = [ ":libwebp_sse41", ":libwebp_avx2" ]
     if (is_android) {
       deps += [ "//third_party/cpu-features" ]
     }
 
-    configs = [ ":libwebp_defines", ":libwebp_no_avx2" ]
+    configs = [ ":libwebp_defines" ]
     sources = [
       "../externals/libwebp/sharpyuv/sharpyuv.c",
       "../externals/libwebp/sharpyuv/sharpyuv_cpu.c",

--- a/third_party/libwebp/BUILD.gn
+++ b/third_party/libwebp/BUILD.gn
@@ -28,12 +28,24 @@ if (skia_use_system_libwebp) {
     ]
   }
 
+  # Disable AVX2 support for now. libwebp 1.6.0 added AVX2 optimizations but
+  # enabling them requires adding new source files (lossless_avx2.c, lossless_enc_avx2.c).
+  # The -mno-avx2 flag prevents the compiler from defining __AVX2__ which would
+  # otherwise trigger AVX2 code paths without the required source files.
+  # Added in libwebp: https://github.com/webmproject/libwebp/commit/f2b3f527
+  # Tracking issue: https://github.com/mono/SkiaSharp/issues/3464
+  config("libwebp_no_avx2") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
+      cflags = [ "-mno-avx2" ]
+    }
+  }
+
   third_party("libwebp_sse41") {
     public_include_dirs = [
       "../externals/libwebp/src",
       "../externals/libwebp",
     ]
-    configs = [ ":libwebp_defines" ]
+    configs = [ ":libwebp_defines", ":libwebp_no_avx2" ]
     sources = [
       "../externals/libwebp/src/dsp/alpha_processing_sse41.c",
       "../externals/libwebp/src/dsp/dec_sse41.c",
@@ -60,7 +72,7 @@ if (skia_use_system_libwebp) {
       deps += [ "//third_party/cpu-features" ]
     }
 
-    configs = [ ":libwebp_defines" ]
+    configs = [ ":libwebp_defines", ":libwebp_no_avx2" ]
     sources = [
       "../externals/libwebp/sharpyuv/sharpyuv.c",
       "../externals/libwebp/sharpyuv/sharpyuv_cpu.c",


### PR DESCRIPTION
**Description of Change**

Update libwebp from v1.3.2 to v1.6.0

**Changes**
- Update DEPS with new commit hash (4fa21912338357f89e4fd51cf2368325b59e9bd9)
- Add `src/utils/palette.c` to BUILD.gn (new file in v1.6.0)

**Highlights from v1.4.0 - v1.6.0:**
- Security hardening and increased fuzzing coverage
- Additional AVX2, SSE2 optimizations
- Fix heap overflow in webpmux
- Lossless encoder improvements
- Various bug and warning fixes

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/3055

**API Changes**

None (binary compatible).

**Behavioral Changes**

None.

**Required SkiaSharp PR**

https://github.com/mono/SkiaSharp/pull/3461

**PR Checklist**

- [x] Rebased on top of skiasharp at time of PR
- [x] Changes adhere to coding standard