### PR TITLE
Update brotli to 1.2.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -24,7 +24,7 @@ vars = {
 deps = {
   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
   # "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@1cab871c220744402b887e73ff86aaf8f7f97fa0",
-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@028fb5a23661f123017c060daa546b55cf4bde29",
   "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
   # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
   # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.

--- a/third_party/brotli/BUILD.gn
+++ b/third_party/brotli/BUILD.gn
@@ -19,6 +19,7 @@ third_party("brotli") {
     "../externals/brotli/c/dec/bit_reader.c",
     "../externals/brotli/c/dec/decode.c",
     "../externals/brotli/c/dec/huffman.c",
+    "../externals/brotli/c/dec/prefix.c",
     "../externals/brotli/c/dec/state.c",
   ]
 }


### PR DESCRIPTION
## Summary

Update brotli from v1.0.9 to v1.2.0 to fix CVE-2025-6176.

## Security

**CVE-2025-6176** (HIGH 7.5): Denial of Service via decompression bomb. Specially crafted Brotli-compressed data can decompress to enormous sizes, exhausting memory.

## Changes

- Updated DEPS to point to brotli v1.2.0 (028fb5a23661f123017c060daa546b55cf4bde29)

## Testing

- macOS arm64 build: ✅ Passed
- Console tests: ✅ 5340 passed

## SkiaSharp Issue

Related to security audit findings.

## Required SkiaSharp PR

https://github.com/mono/SkiaSharp/pull/3469