### PR TITLE
Update libwebp to 1.6.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -47,7 +47,7 @@ deps = {
   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@927aabfcd26897abb9776ecf2a6c38ea5bb52ab6",
   # "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@02f2b4f4699f0ef9111a6534f093b53732df4452",
-  "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@ca332209cb5567c9b249c86788cb2dbf8847e760",
+  "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
   # "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
   # "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
   # "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",

--- a/third_party/libwebp/BUILD.gn
+++ b/third_party/libwebp/BUILD.gn
@@ -175,6 +175,7 @@ if (skia_use_system_libwebp) {
       "../externals/libwebp/src/utils/quant_levels_utils.c",
       "../externals/libwebp/src/utils/random_utils.c",
       "../externals/libwebp/src/utils/rescaler_utils.c",
+      "../externals/libwebp/src/utils/palette.c",
       "../externals/libwebp/src/utils/thread_utils.c",
       "../externals/libwebp/src/utils/utils.c",
     ]


### PR DESCRIPTION
## Summary
Update libwebp from 1.3.2 to 1.6.0.

## Changes
- Update DEPS to libwebp v1.6.0 (4fa21912338357f89e4fd51cf2368325b59e9bd9)
- Add new `palette.c` source file to BUILD.gn

## libwebp 1.6.0 Release Notes
- **Security fix**: heap overflow in webpmux (`-get`/`-set`)
- Speed and compression improvements
- Histogram optimizations
- New AVX2 optimizations (optional, auto-enabled when available)
- Various bug fixes

## Testing
- ✅ Local macOS arm64 build succeeded
- ✅ All SkiaSharp tests passed (5340 passed)

## Links
- [libwebp v1.6.0 tag](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.6.0)
- [Changelog](https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.6.0/NEWS)