### PR TITLE
Add Spectre mitigation flag.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -134,10 +134,26 @@ config("skia_library") {
   defines = [ "SKIA_IMPLEMENTATION=1" ]
 }
 
+# Spectre mitigation config
+config("spectre_mitigation") {
+  visibility = [ "./*" ]
+  # Spectre mitigation for Windows builds
+  if (is_win) {
+    if (is_clang) {
+      # Clang Spectre mitigation flag
+      cflags = [ "-mretpoline" ]  # Spectre V2 mitigation
+    } else {
+      # MSVC Spectre mitigation flag
+      cflags = [ "/Qspectre" ]
+    }
+  }
+}
+
 skia_library_configs = [
   ":skia_public",
   ":skia_private",
   ":skia_library",
+  ":spectre_mitigation",
 ]
 
 # Use for CPU-specific Skia code that needs particular compiler flags.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -147,6 +147,19 @@ config("spectre_mitigation") {
       cflags = [ "/Qspectre" ]
     }
   }
+  # Spectre mitigation for Linux builds
+  else if (is_linux) {
+    if (is_clang) {
+      # Clang Spectre mitigation flag (Clang 5.0+)
+      cflags = [ "-mretpoline" ]  # Spectre V2 mitigation
+    } else {
+      # GCC Spectre mitigation flags (GCC 7.3+)
+      cflags = [
+        "-mindirect-branch=thunk",  # Convert indirect branches to thunks
+        "-mindirect-branch-register",  # Also convert indirect jumps via registers
+      ]
+    }
+  }
 }
 
 skia_library_configs = [

--- a/modules/skcms/BUILD.gn
+++ b/modules/skcms/BUILD.gn
@@ -11,7 +11,7 @@ static_library("skcms") {
     cflags += [ "-std=c11" ]
   }
 
-  configs += [ "../../:spectre_mitigation" ]
+  configs += [ "//:spectre_mitigation" ]
 
   public = skcms_public_headers
   sources = skcms_sources

--- a/modules/skcms/BUILD.gn
+++ b/modules/skcms/BUILD.gn
@@ -11,6 +11,8 @@ static_library("skcms") {
     cflags += [ "-std=c11" ]
   }
 
+  configs += [ "../../:spectre_mitigation" ]
+
   public = skcms_public_headers
   sources = skcms_sources
 }

--- a/modules/skottie/BUILD.gn
+++ b/modules/skottie/BUILD.gn
@@ -20,7 +20,10 @@ if (skia_enable_skottie) {
     public_configs = [ ":public_config" ]
     public = skia_skottie_public
     sources = skia_skottie_sources
-    configs = [ "../../:skia_private" ]
+    configs = [
+      "../../:skia_private",
+      "../../:spectre_mitigation",
+    ]
     deps = [
       "../..:skia",
       "../skresources",

--- a/modules/skresources/BUILD.gn
+++ b/modules/skresources/BUILD.gn
@@ -14,7 +14,10 @@ skia_component("skresources") {
   import("skresources.gni")
   public_configs = [ ":public_config" ]
   sources = skia_skresources_sources
-  configs = [ "../../:skia_private" ]
+  configs = [
+    "../../:skia_private",
+    "../../:spectre_mitigation",
+  ]
   deps = [
     "../..:skia",
     "../../experimental/ffmpeg:video_decoder",

--- a/modules/sksg/BUILD.gn
+++ b/modules/sksg/BUILD.gn
@@ -14,7 +14,10 @@ skia_component("sksg") {
   import("sksg.gni")
   public_configs = [ ":public_config" ]
   sources = skia_sksg_sources
-  configs = [ "../../:skia_private" ]
+  configs = [
+    "../../:skia_private",
+    "../../:spectre_mitigation",
+  ]
   deps = [ "../..:skia" ]
 }
 

--- a/modules/skshaper/BUILD.gn
+++ b/modules/skshaper/BUILD.gn
@@ -55,7 +55,10 @@ if (skia_enable_skshaper) {
         "//third_party/harfbuzz",
       ]
     }
-    configs += [ "../../:skia_private" ]
+    configs += [
+      "../../:skia_private",
+      "../../:spectre_mitigation",
+    ]
   }
 
   if (defined(is_skia_standalone) && skia_enable_tools) {

--- a/third_party/d3d12allocator/BUILD.gn
+++ b/third_party/d3d12allocator/BUILD.gn
@@ -11,5 +11,7 @@ import("../third_party.gni")
 third_party("d3d12allocator") {
   public_include_dirs = [ "../externals/d3d12allocator/src" ]
 
+  configs = [ "//:spectre_mitigation" ]
+
   sources = [ "../externals/d3d12allocator/src/D3D12MemAlloc.cpp" ]
 }

--- a/third_party/dng_sdk/BUILD.gn
+++ b/third_party/dng_sdk/BUILD.gn
@@ -15,6 +15,7 @@ third_party("dng_sdk") {
   configs = [
     "//gn/portable:add_exceptions",
     "//gn/portable:add_rtti",
+    "//:spectre_mitigation",
   ]
 
   public_defines = [ "qDNGBigEndian=0" ]

--- a/third_party/expat/BUILD.gn
+++ b/third_party/expat/BUILD.gn
@@ -17,6 +17,8 @@ if (skia_use_system_expat) {
   third_party("expat") {
     _src = "../externals/expat"
 
+    configs = [ "//:spectre_mitigation" ]
+
     public_defines = [ "XML_STATIC" ]
 
     public_include_dirs = [

--- a/third_party/libjpeg-turbo/BUILD.gn
+++ b/third_party/libjpeg-turbo/BUILD.gn
@@ -20,6 +20,8 @@ if (skia_use_system_libjpeg_turbo) {
       "../externals/libjpeg-turbo",
     ]
 
+    configs = [ "//:spectre_mitigation" ]
+
     defines = [
       "TURBO_FOR_WINDOWS",
 

--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -20,6 +20,8 @@ if (skia_use_system_libpng) {
       "../externals/libpng",
     ]
 
+    configs = [ "//:spectre_mitigation" ]
+
     defines = [ "PNG_SET_OPTION_SUPPORTED" ]
     deps = [ "//third_party/zlib" ]
     sources = [

--- a/third_party/libwebp/BUILD.gn
+++ b/third_party/libwebp/BUILD.gn
@@ -33,7 +33,10 @@ if (skia_use_system_libwebp) {
       "../externals/libwebp/src",
       "../externals/libwebp",
     ]
-    configs = [ ":libwebp_defines" ]
+    configs = [ 
+      ":libwebp_defines",
+      "//:spectre_mitigation"
+      ]
     sources = [
       "../externals/libwebp/src/dsp/alpha_processing_sse41.c",
       "../externals/libwebp/src/dsp/dec_sse41.c",
@@ -54,7 +57,10 @@ if (skia_use_system_libwebp) {
       "../externals/libwebp/src",
       "../externals/libwebp",
     ]
-    configs = [ ":libwebp_defines" ]
+    configs = [
+      ":libwebp_defines",
+      "//:spectre_mitigation",
+    ]
     sources = [
       "../externals/libwebp/src/dsp/lossless_avx2.c",
       "../externals/libwebp/src/dsp/lossless_enc_avx2.c",
@@ -76,7 +82,10 @@ if (skia_use_system_libwebp) {
       deps += [ "//third_party/cpu-features" ]
     }
 
-    configs = [ ":libwebp_defines" ]
+    configs = [
+      ":libwebp_defines",
+      "//:spectre_mitigation",
+    ]
     sources = [
       "../externals/libwebp/sharpyuv/sharpyuv.c",
       "../externals/libwebp/sharpyuv/sharpyuv_cpu.c",

--- a/third_party/piex/BUILD.gn
+++ b/third_party/piex/BUILD.gn
@@ -11,6 +11,8 @@ import("../third_party.gni")
 third_party("piex") {
   public_include_dirs = [ "../externals/piex" ]
 
+  configs = [ "//:spectre_mitigation" ]
+
   defines = [ "BREAK_IF_DEBUGGING_AND_OUT_OF_RANGE" ]
 
   sources = [

--- a/third_party/spirv-cross/BUILD.gn
+++ b/third_party/spirv-cross/BUILD.gn
@@ -9,6 +9,8 @@ third_party("spirv_cross") {
   ]
   public_defines = [ "SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS" ]
 
+  configs = [ "//:spectre_mitigation" ]
+
   sources = rebase_path([
                           "GLSL.std.450.h",
                           "spirv.hpp",

--- a/third_party/vulkanmemoryallocator/BUILD.gn
+++ b/third_party/vulkanmemoryallocator/BUILD.gn
@@ -14,6 +14,7 @@ config("vulkanmemoryallocator_public") {
 
 source_set("vulkanmemoryallocator") {
   public_configs = [ ":vulkanmemoryallocator_public" ]
+  configs += [ "../../:spectre_mitigation" ]
 
   include_dirs = [ "../../include/third_party/vulkan" ]
 

--- a/third_party/vulkanmemoryallocator/BUILD.gn
+++ b/third_party/vulkanmemoryallocator/BUILD.gn
@@ -14,7 +14,7 @@ config("vulkanmemoryallocator_public") {
 
 source_set("vulkanmemoryallocator") {
   public_configs = [ ":vulkanmemoryallocator_public" ]
-  configs += [ "../../:spectre_mitigation" ]
+  configs += [ "//:spectre_mitigation" ]
 
   include_dirs = [ "../../include/third_party/vulkan" ]
 

--- a/third_party/wuffs/BUILD.gn
+++ b/third_party/wuffs/BUILD.gn
@@ -8,6 +8,8 @@ import("../third_party.gni")
 third_party("wuffs") {
   public_include_dirs = [ "../externals/wuffs/release/c" ]
 
+  configs = [ "//:spectre_mitigation" ]
+
   defines = [
     # Copy/pasting from "../externals/wuffs/release/c/wuffs-*.c":
     #

--- a/third_party/zlib/BUILD.gn
+++ b/third_party/zlib/BUILD.gn
@@ -58,7 +58,7 @@ if (skia_use_system_zlib) {
 
   source_set("zlib_adler32_simd") {
     visibility = [ ":*" ]
-    configs += [ ":zlib_simd_config", "../../:spectre_mitigation" ]
+    configs += [ ":zlib_simd_config", "//:spectre_mitigation" ]
     if (use_x86_x64_optimizations) {
       defines = [ "ADLER32_SIMD_SSSE3" ]
       if (!is_win || is_clang) {
@@ -104,7 +104,7 @@ if (skia_use_system_zlib) {
 
   source_set("zlib_inflate_chunk_simd") {
     visibility = [ ":*" ]
-    configs += [ ":zlib_simd_config", "../../:spectre_mitigation" ]
+    configs += [ ":zlib_simd_config", "//:spectre_mitigation" ]
     if (use_x86_x64_optimizations) {
       defines = [ "INFLATE_CHUNK_SIMD_SSE2" ]
       if (current_cpu == "x64") {

--- a/third_party/zlib/BUILD.gn
+++ b/third_party/zlib/BUILD.gn
@@ -58,7 +58,7 @@ if (skia_use_system_zlib) {
 
   source_set("zlib_adler32_simd") {
     visibility = [ ":*" ]
-    configs += [ ":zlib_simd_config" ]
+    configs += [ ":zlib_simd_config", "../../:spectre_mitigation" ]
     if (use_x86_x64_optimizations) {
       defines = [ "ADLER32_SIMD_SSSE3" ]
       if (!is_win || is_clang) {
@@ -104,7 +104,7 @@ if (skia_use_system_zlib) {
 
   source_set("zlib_inflate_chunk_simd") {
     visibility = [ ":*" ]
-    configs += [ ":zlib_simd_config" ]
+    configs += [ ":zlib_simd_config", "../../:spectre_mitigation" ]
     if (use_x86_x64_optimizations) {
       defines = [ "INFLATE_CHUNK_SIMD_SSE2" ]
       if (current_cpu == "x64") {
@@ -153,7 +153,7 @@ if (skia_use_system_zlib) {
     public_include_dirs = [ "../externals/zlib" ]
     defines = [ "ZLIB_IMPLEMENTATION" ]
     deps = []
-    configs = []
+    configs = [ "//:spectre_mitigation" ]
 
     sources = [
       "../externals/zlib/adler32.c",


### PR DESCRIPTION
**Description of Change**

- Addressing [Binskim BA2024.EnableSpectreMitigations](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-ba2024enablespectremitigations)
- Use `-mretpoline` flag for Clang build
- Use `/Qspectre` for MSVS build
- Use `-mindirect-branch=thunk` and `-mindirect-branch-register` for GCC build
- This applies to Skia module and other, statically linked sub-modules

**SkiaSharp Issue**

None.

**API Changes**

None.

**Behavioral Changes**

None.

**Required SkiaSharp PR**

Required for https://github.com/mono/SkiaSharp/pull/3480

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
