### PR TITLE
Backport "[loong64] Fix linker error by undefined symbols."

### DIFF
--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -55,5 +55,12 @@ if (skia_use_system_libpng) {
         "../externals/libpng/intel/intel_init.c",
       ]
     }
+
+    if (current_cpu == "loong64") {
+      sources += [
+        "../externals/libpng/loongarch/filter_lsx_intrinsics.c",
+        "../externals/libpng/loongarch/loongarch_lsx_init.c",
+      ]
+    }
   }
 }


### PR DESCRIPTION
**Description of Change**

Backport commit 37427562a35b08ec8f7865f9b597150be6dce972.

We upgraded libpng in our branch, but not adapted the build system.  This caused a linker error building for LoongArch.  Backport the build system change to fix that.

**SkiaSharp Issue**

Related to https://github.com/mono/SkiaSharp/issues/3230

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

None.

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
