### PR TITLE
Add Tizen x64 and arm64 target_cpu support in GN build config

### DIFF
--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -36,7 +36,7 @@ declare_args() {
   clang_win_version = ""
 
   ncli = ""
-  ncli_version = "4.0"
+  ncli_version = "8.0"
   ncli_gcc_version = "9.2.0"
   ncli_gcc_version_short = "9.2"
   ncli_llvm_version = "10"
@@ -195,6 +195,14 @@ if (is_tizen) {
     ncli_target = "i586-tizen-linux-gnueabi"
     ncli_platform = "tizen-${ncli_version}/mobile/rootstraps/mobile-${ncli_version}-emulator.core"
     ncli_gccdir = "i586-linux-gnueabi-gcc-${ncli_gcc_version_short}"
+  } else if (target_cpu == "x64") {
+    ncli_target = "x86_64-tizen-linux-gnu"
+    ncli_platform = "tizen-${ncli_version}/tizen/rootstraps/tizen-${ncli_version}-emulator64.core"
+    ncli_gccdir = "x86_64-linux-gnu-gcc-${ncli_gcc_version_short}"
+  } else if (target_cpu == "arm64") {
+    ncli_target = "aarch64-tizen-linux-gnu"
+    ncli_platform = "tizen-${ncli_version}/tizen/rootstraps/tizen-${ncli_version}-device64.core"
+    ncli_gccdir = "aarch64-linux-gnu-gcc-${ncli_gcc_version_short}"
   }
 }
 


### PR DESCRIPTION
## Summary

Add x64 and arm64 `target_cpu` branches to the Tizen `is_tizen` block in `gn/BUILDCONFIG.gn`, enabling 64-bit native library builds for Tizen.

### Changes

- `gn/BUILDCONFIG.gn`: Default `ncli_version` changed from `4.0` to `8.0` (callers override via GN args for older rootstraps)
- Added `x64` branch: `x86_64-tizen-linux-gnu` target with `tizen-{ver}-emulator64.core` rootstrap
- Added `arm64` branch: `aarch64-tizen-linux-gnu` target with `tizen-{ver}-device64.core` rootstrap

### Architecture mapping

| target_cpu | ncli_target | rootstrap | gcc dir |
|-----------|-------------|-----------|---------|
| `arm` | `arm-tizen-linux-gnueabi` | `mobile-{ver}-device.core` | `arm-linux-gnueabi-gcc-9.2` |
| `x86` | `i586-tizen-linux-gnueabi` | `mobile-{ver}-emulator.core` | `i586-linux-gnueabi-gcc-9.2` |
| **`x64`** | **`x86_64-tizen-linux-gnu`** | **`tizen-{ver}-emulator64.core`** | **`x86_64-linux-gnu-gcc-9.2`** |
| **`arm64`** | **`aarch64-tizen-linux-gnu`** | **`tizen-{ver}-device64.core`** | **`aarch64-linux-gnu-gcc-9.2`** |

### Related

- mono/SkiaSharp#3620 — SkiaSharp PR that adds build.cake, packaging, and submodule update