### PR TITLE
Enforce --no-undefined linker flag and fix libpng LoongArch LSX build

### DIFF
--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -204,7 +204,10 @@ config("default") {
 
   if (is_android) {
     cflags += [ "--sysroot=$ndk/toolchains/llvm/prebuilt/$ndk_host/sysroot" ]
-    ldflags += [ "-static-libstdc++" ]
+    ldflags += [
+      "-static-libstdc++",
+      "-Wl,--no-undefined",
+    ]
   }
 
   if (is_tizen) {
@@ -366,6 +369,7 @@ config("default") {
 
   if (is_linux) {
     libs += [ "pthread" ]
+    ldflags += [ "-Wl,--no-undefined" ]
   }
 
   if (is_mac) {

--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -55,5 +55,12 @@ if (skia_use_system_libpng) {
         "../externals/libpng/intel/intel_init.c",
       ]
     }
+
+    if (current_cpu == "loongarch64") {
+      sources += [
+        "../externals/libpng/loongarch/filter_lsx_intrinsics.c",
+        "../externals/libpng/loongarch/loongarch_lsx_init.c",
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two related changes to harden the native shared library builds:

### 1. Enforce `-Wl,--no-undefined` for Linux and Android

Add `-Wl,--no-undefined` to the default linker flags in `gn/skia/BUILD.gn` `config("default")` for `is_linux` and `is_android`. This causes the linker to reject shared libraries with unresolved symbols at build time, rather than producing binaries that crash at runtime with symbol lookup errors.

macOS (`ld64`) and Windows (MSVC) already enforce this by default — Linux and Android were the only platforms that silently allowed undefined symbols through.

### 2. Fix libpng LoongArch LSX build

The `--no-undefined` flag immediately exposed a latent bug: Skia's `BUILD.gn` for libpng includes SIMD-optimized source files for ARM (NEON) and x86 (SSE2) but was missing the LoongArch LSX equivalents.

When cross-compiling for loongarch64, the compiler defines `__loongarch_sx`, which causes `pngpriv.h` to set `PNG_LOONGARCH_LSX_OPT=1` and route `PNG_FILTER_OPTIMIZATIONS` → `png_init_filter_functions_lsx()`. Without the implementation files compiled, this was a latent undefined symbol that previously went undetected.

### Files Changed

| File | Change |
|------|--------|
| `gn/skia/BUILD.gn` | Add `-Wl,--no-undefined` for `is_linux` and `is_android` |
| `third_party/libpng/BUILD.gn` | Add `loongarch/filter_lsx_intrinsics.c` and `loongarch/loongarch_lsx_init.c` for `current_cpu == "loongarch64"` |

### Verified

- ✅ Local Docker build for loongarch64 glibc — **fails without** the libpng fix, **passes with** it
- ✅ CI build [156565](https://dev.azure.com/xamarin/6fd3d886-57a5-4e31-8db7-52a1b47c07a8/_build/results?buildId=156565): all 4 loongarch64 jobs (glibc, alpine, nodeps, alpine-nodeps) pass
- ✅ All other Linux arch builds (x64, arm, arm64, riscv64, x86) unaffected

### Related

- mono/SkiaSharp#3629 — SkiaSharp PR that consumes this submodule update