### PR TITLE
Change current_cpu detect from loongarch64 to loong64

### DIFF
--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -56,7 +56,7 @@ if (skia_use_system_libpng) {
       ]
     }
 
-    if (current_cpu == "loongarch64") {
+    if (current_cpu == "loong64") {
       sources += [
         "../externals/libpng/loongarch/filter_lsx_intrinsics.c",
         "../externals/libpng/loongarch/loongarch_lsx_init.c",


### PR DESCRIPTION
**Description of Change**

Change current_cpu detect from 'loongarch64' to 'loong64'

gn use `loong64` instead of `loongarch64` in current_cpu. Below is the output from `gn help target_cpu`

```bash
$ gn help target_cpu
target_cpu: The desired cpu architecture for the build.

  This value should be used to indicate the desired architecture for the
  primary objects of the build. It will match the cpu architecture of the
  default toolchain, but not necessarily the current toolchain.

  In many cases, this is the same as "host_cpu", but in the case of
  cross-compiles, this can be set to something different. This value is
  different from "current_cpu" in that it does not change based on the current
  toolchain. When writing rules, "current_cpu" should be used rather than
  "target_cpu" most of the time.

  This value is not used internally by GN for any purpose, so it may be set to
  whatever value is needed for the build. GN defaults this value to the empty
  string ("") and the configuration files should set it to an appropriate value
  (e.g., setting it to the value of "host_cpu") if it is not overridden on the
  command line or in the args.gn file.

Possible values

  - "x86"
  - "x64"
  - "arm"
  - "arm64"
  - "mipsel"
  - "mips64el"
  - "s390x"
  - "ppc64"
  - "riscv32"
  - "riscv64"
  - "e2k"
  - "loong64"

```

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

None.


**API Changes**

 

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

None.


**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

gn help target_cpu

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [x] Rebased on top of `skiasharp` at time of PR
- [x] Changes adhere to coding standard
- [x] Updated documentation
