### PR TITLE
Update libpng to 1.6.57

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -56,7 +56,7 @@ deps = {
   # "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@927aabfcd26897abb9776ecf2a6c38ea5bb52ab6",
   # "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
-  "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@02f2b4f4699f0ef9111a6534f093b53732df4452",
+  "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@95ab3fdca83ea294efd3b092e9a53c5a39886444",
   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",
   # "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
   # "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",


### PR DESCRIPTION
Update libpng from 1.6.54 to 1.6.57 to fix critical security vulnerabilities:

- **CVE-2026-25646** (CRITICAL) — Heap buffer overflow in png_set_quantize(), 30-year-old bug
- **CVE-2026-33416** (HIGH) — Use-after-free between png_struct and png_info
- **CVE-2026-33636** (HIGH) — ARM/AArch64 NEON palette expansion OOB read/write

**Analysis:** Patch-level update, no BUILD.gn changes needed, no breaking API changes. All 20 BUILD.gn source files verified present in v1.6.57.

Required SkiaSharp PR: (will be linked after creation)