### PR TITLE
Add ANGLE to deps_os[win] for Windows-only sync

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -111,3 +111,11 @@ deps = {
     'condition': 'False',
   },
 }
+
+# Platform-specific dependencies, synced by passing the OS name to git-sync-deps.
+# e.g. `python tools/git-sync-deps win`
+deps_os = {
+  "win": {
+    "third_party/externals/angle2"               : "https://github.com/google/angle.git@ea1cea778c4a2312ef1b963b29a62fe595dd4df8",
+  },
+}


### PR DESCRIPTION
Adds ANGLE to the existing `deps_os["win"]` section so SkiaSharp can fetch it through `tools/git-sync-deps win` rather than maintaining a separate clone operation.

- Pins the existing `chromium/6275` revision: `ea1cea778c4a2312ef1b963b29a62fe595dd4df8`
- Keeps this PR DEPS-only; `tools/git-sync-deps` is unchanged
- ANGLE is omitted unless the caller explicitly requests the `win` dependency set

Companion integration PR: mono/SkiaSharp#3701