### PR TITLE
Use int32_t instead of long for stream move offset

### DIFF
--- a/include/c/sk_stream.h
+++ b/include/c/sk_stream.h
@@ -48,7 +48,7 @@ SK_C_API bool sk_stream_rewind(sk_stream_t* cstream);
 SK_C_API bool sk_stream_has_position(sk_stream_t* cstream);
 SK_C_API size_t sk_stream_get_position(sk_stream_t* cstream);
 SK_C_API bool sk_stream_seek(sk_stream_t* cstream, size_t position);
-SK_C_API bool sk_stream_move(sk_stream_t* cstream, long offset);
+SK_C_API bool sk_stream_move(sk_stream_t* cstream, int32_t offset);
 SK_C_API bool sk_stream_has_length(sk_stream_t* cstream);
 SK_C_API size_t sk_stream_get_length(sk_stream_t* cstream);
 SK_C_API const void* sk_stream_get_memory_base(sk_stream_t* cstream);

--- a/include/xamarin/SkManagedStream.h
+++ b/include/xamarin/SkManagedStream.h
@@ -47,7 +47,7 @@ public:
     typedef bool              (*RewindProc)      (      SkManagedStream* s, void* context);
     typedef size_t            (*GetPositionProc) (const SkManagedStream* s, void* context);
     typedef bool              (*SeekProc)        (      SkManagedStream* s, void* context, size_t position);
-    typedef bool              (*MoveProc)        (      SkManagedStream* s, void* context, long offset);
+    typedef bool              (*MoveProc)        (      SkManagedStream* s, void* context, int32_t offset);
     typedef size_t            (*GetLengthProc)   (const SkManagedStream* s, void* context);
     typedef SkManagedStream*  (*DuplicateProc)   (const SkManagedStream* s, void* context);
     typedef SkManagedStream*  (*ForkProc)        (const SkManagedStream* s, void* context);

--- a/include/xamarin/sk_managedstream.h
+++ b/include/xamarin/sk_managedstream.h
@@ -49,7 +49,7 @@ typedef bool                       (*sk_managedstream_hasLength_proc)    (const 
 typedef bool                       (*sk_managedstream_rewind_proc)       (      sk_stream_managedstream_t* s, void* context);
 typedef size_t                     (*sk_managedstream_getPosition_proc)  (const sk_stream_managedstream_t* s, void* context);
 typedef bool                       (*sk_managedstream_seek_proc)         (      sk_stream_managedstream_t* s, void* context, size_t position);
-typedef bool                       (*sk_managedstream_move_proc)         (      sk_stream_managedstream_t* s, void* context, long offset);
+typedef bool                       (*sk_managedstream_move_proc)         (      sk_stream_managedstream_t* s, void* context, int32_t offset);
 typedef size_t                     (*sk_managedstream_getLength_proc)    (const sk_stream_managedstream_t* s, void* context);
 typedef sk_stream_managedstream_t* (*sk_managedstream_duplicate_proc)    (const sk_stream_managedstream_t* s, void* context);
 typedef sk_stream_managedstream_t* (*sk_managedstream_fork_proc)         (const sk_stream_managedstream_t* s, void* context);

--- a/src/c/sk_stream.cpp
+++ b/src/c/sk_stream.cpp
@@ -125,7 +125,7 @@ bool sk_stream_seek (sk_stream_t* cstream, size_t position) {
     return AsStream(cstream)->seek(position);
 }
 
-bool sk_stream_move (sk_stream_t* cstream, long offset) {
+bool sk_stream_move (sk_stream_t* cstream, int32_t offset) {
     return AsStream(cstream)->move(offset);
 }
 

--- a/src/xamarin/SkManagedStream.cpp
+++ b/src/xamarin/SkManagedStream.cpp
@@ -58,7 +58,10 @@ bool SkManagedStream::seek(size_t position) {
 }
 bool SkManagedStream::move(long offset) {
     if (!fProcs.fMove) return false;
-    return fProcs.fMove(this, fContext, offset);
+    // The managed-side MoveProc takes int32_t; fail loud on overflow rather
+    // than silently truncating the upper bits (only reachable on LP64).
+    if (offset > INT32_MAX || offset < INT32_MIN) return false;
+    return fProcs.fMove(this, fContext, static_cast<int32_t>(offset));
 }
 size_t SkManagedStream::getLength() const {
     if (!fProcs.fGetLength) return 0;

--- a/src/xamarin/sk_managedstream.cpp
+++ b/src/xamarin/sk_managedstream.cpp
@@ -108,7 +108,7 @@ bool dSeek(SkManagedStream* stream, void* context, size_t position) {
     if (!gProcs.fSeek) return false;
     return gProcs.fSeek(ToManagedStream(stream), context, position);
 }
-bool dMove(SkManagedStream* stream, void* context, long offset) {
+bool dMove(SkManagedStream* stream, void* context, int32_t offset) {
     if (!gProcs.fMove) return false;
     return gProcs.fMove(ToManagedStream(stream), context, offset);
 }


### PR DESCRIPTION
**Description of Change**
C long is 32-bit on Windows (LLP64) and 64-bit on Linux/macOS (LP64), so the sk_stream_move and sk_managedstream_move_proc C-API signatures gave managed callers a silently platform-dependent parameter size. The SkiaSharp bindings mapped long to Int32, which on Linux meant negative offsets were misinterpreted as huge positive numbers at the ABI boundary (the .NET marshaller zero-extends the 32-bit value into a 64-bit register slot, so -1 becomes 0x00000000FFFFFFFF when native reads the 64-bit long).

Narrow the C-API surface to int32_t so the ABI is unambiguously 32-bit on every platform. Internally SkManagedStream::move(long) still matches upstream SkStream's signature; we range-check the offset before calling into the managed MoveProc and return false on overflow rather than silently truncating.

Practical impact: stream offsets are now explicitly capped at 2 GB on all platforms. Windows behaviour is unchanged (it was already 32-bit); Linux loses the theoretical ability to pass >2 GB offsets but gains correct handling of negative offsets. The trade-off favours correctness over a range that nobody could reliably use anyway.

<!--
    Describe your changes here.
-->

**SkiaSharp Issue**

<!--
    Provide links to SkiaSharp issues here.
    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
-->

Related to https://github.com/mono/SkiaSharp/issues/<issue-number>

**API Changes**

None.

<!--
List all API changes here (or just put None), example:

Added: 
- `void skobject_method_name()`

Changed:
 - `void skobject_old_method_name()` => `void skobject_new_method_name()`
-->

**Behavioral Changes**

None.

<!--
    Describe any non-bug related behavioral changes that may change how users app behaves
    when upgrading to this version of the codebase.
-->

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/<pr-number>

<!--
    Replace this with the full URL to the skia PR.
-->

**PR Checklist**

- [ ] Rebased on top of `skiasharp` at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation
