### PR TITLE
[skiasharp] Update libexpat to 2.7.5

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -44,7 +44,7 @@ deps = {
   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
   # "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
   # "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
-  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@4575e52f83e0d6d7bd24939eab8952bbc7bc358f",
+  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@83af801b552111e37d9466a887e1783a0fb5f196",
   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@2b3631a866b3077d9d675caa4ec9010b342b5a7c",
   # "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",


### PR DESCRIPTION
Bumps libexpat from 2.7.3 to 2.7.5.

## Changes
- `DEPS`: Updated expat commit hash
- No BUILD.gn changes required

Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/3717