### PR TITLE
[skiasharp] Update zlib to 1.3.2.1-motley

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -84,7 +84,7 @@ deps = {
   # "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
   #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
-  "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@e432200a7931de1b0b1b50201aac8a46d9380cb2",
+  "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@89921383f1f51331f48a2dc843403779770ea3a9",
 
   'bin': {
     'packages': [

--- a/third_party/zlib/BUILD.gn
+++ b/third_party/zlib/BUILD.gn
@@ -84,8 +84,18 @@ if (skia_use_system_zlib) {
       # An ARMv7 GCC build will fail to compile without building this target
       # for ARMv8-a+crc and letting runtime cpu detection select the correct
       # function.
-      if (!is_win && !is_clang) {
-        cflags_c = [ "-march=armv8-a+aes+crc" ]
+      if (!is_win) {
+        if (current_cpu == "arm") {
+          # ARM32 needs explicit arch flag for both GCC and clang (older
+          # clang versions cannot handle function-level CRC target attributes).
+          cflags_c = [ "-march=armv8-a+crc" ]
+        } else if (current_cpu == "arm64") {
+          # ARM64 cross-compilation with older clang (e.g. clang-13) needs
+          # explicit +crc+crypto for CRC32 intrinsics and PMULL instructions.
+          cflags_c = [ "-march=armv8-a+crc+crypto" ]
+        } else if (!is_clang) {
+          cflags_c = [ "-march=armv8-a+aes+crc" ]
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Update Chromium's zlib fork from `e432200a` (1.3.0.1-motley) to `89921383` (1.3.2.1-motley).

## Changes

- `DEPS`: Updated zlib commit hash

## Verification

- Native macOS arm64 build: ✅
- C# build: ✅
- Tests: ✅

Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/3720