### PR TITLE
[release/3.119.x] Update FreeType to 2.14.3

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -36,7 +36,7 @@ deps = {
   # "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
   # "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
-  "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@83af801b552111e37d9466a887e1783a0fb5f196",
+  "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@0a0221a1347e2f1e07c395263540026e9a0aa7c7",
   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@2b3631a866b3077d9d675caa4ec9010b342b5a7c",
   # "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
   # "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",


### PR DESCRIPTION
Bump FreeType from 2.13.3 to 2.14.3.

### Changes
- Updated `DEPS` to point to FreeType 2.14.3 (`0a0221a1347e2f1e07c395263540026e9a0aa7c7`, tag VER-2-14-3)
- No BUILD.gn changes needed

### Verification
- Native build succeeded (macOS ARM64)
- All tests passed

Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/3725