### PR TITLE
Add missing sk_fontmgr_legacy_create_typeface C API

### DIFF
--- a/include/c/sk_typeface.h
+++ b/include/c/sk_typeface.h
@@ -52,6 +52,7 @@ SK_C_API sk_typeface_t* sk_fontmgr_match_family_style_character(sk_fontmgr_t*, c
 SK_C_API sk_typeface_t* sk_fontmgr_create_from_data(sk_fontmgr_t*, sk_data_t* data, int index);
 SK_C_API sk_typeface_t* sk_fontmgr_create_from_stream(sk_fontmgr_t*, sk_stream_asset_t* stream, int index);
 SK_C_API sk_typeface_t* sk_fontmgr_create_from_file(sk_fontmgr_t*, const char* path, int index);
+SK_C_API sk_typeface_t* sk_fontmgr_legacy_create_typeface(sk_fontmgr_t*, const char* familyName, sk_fontstyle_t* style);
 
 // font style
 

--- a/src/c/sk_typeface.cpp
+++ b/src/c/sk_typeface.cpp
@@ -184,6 +184,10 @@ sk_typeface_t* sk_fontmgr_create_from_file(sk_fontmgr_t* fontmgr, const char* pa
     return ToTypeface(AsFontMgr(fontmgr)->makeFromFile(path, index).release());
 }
 
+sk_typeface_t* sk_fontmgr_legacy_create_typeface(sk_fontmgr_t* fontmgr, const char* familyName, sk_fontstyle_t* style) {
+    return ToTypeface(AsFontMgr(fontmgr)->legacyMakeTypeface(familyName, *AsFontStyle(style)).release());
+}
+
 
 // font style
 


### PR DESCRIPTION
## Context

- https://github.com/mono/SkiaSharp/issues/3693
- https://github.com/mono/skia/pull/195

## What happened

During the review of PR #195, the `sk_fontmgr_legacy_create_typeface` function was added
in a separate commit (`e6736d19f`) pushed to a local branch (`dev/issue-3693-legacy-typeface`)
on mono/skia — but this commit was **not pushed to the PR author's fork branch**. When PR #195
was squash-merged, only the commits on the fork's branch were included. The separately pushed
commit was left behind, so the function that the PR was named after was never actually merged.

This was a process error: the fix should have been pushed to the PR branch (on the author's
fork) before merging, not to a separate branch on the upstream repo.

## Fix

This PR cherry-picks commit `e6736d19f23da0746c4291ed7223e69ffbce3ac1` onto `skiasharp` to
add the missing function.

## What the function does

`sk_fontmgr_legacy_create_typeface` exposes `SkFontMgr::legacyMakeTypeface()` to the C API.
It is needed by SkiaSharp's `SKTypeface.Default` to reliably resolve the platform default
typeface on Android, where `matchFamilyStyle(null)` returns null because `onMatchFamily(null)`
rejects null family names. `legacyMakeTypeface(null)` bypasses this by using `fDefaultStyleSet`
(which searches "sans-serif", "Roboto", then falls back to style set 0).

Without this function, `SKTypeface.Default` falls back to the empty typeface on Android API 36,
causing all text measurement and drawing to produce zero/nothing.