### PR TITLE
Add sk_webpencoder_encode_animated to C API

### DIFF
--- a/include/c/sk_pixmap.h
+++ b/include/c/sk_pixmap.h
@@ -40,6 +40,7 @@ SK_C_API bool sk_pixmap_erase_color4f(const sk_pixmap_t* cpixmap, const sk_color
 // Sk*Encoder
 
 SK_C_API bool sk_webpencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, const sk_webpencoder_options_t* options);
+SK_C_API bool sk_webpencoder_encode_animated(sk_wstream_t* dst, const sk_webpencoder_frame_t* src, int count, const sk_webpencoder_options_t* options);
 SK_C_API bool sk_jpegencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, const sk_jpegencoder_options_t* options);
 SK_C_API bool sk_pngencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, const sk_pngencoder_options_t* options);
 

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -1014,6 +1014,11 @@ typedef struct {
     float fQuality;
 } sk_webpencoder_options_t;
 
+typedef struct {
+    const sk_pixmap_t* pixmap;
+    int duration;
+} sk_webpencoder_frame_t;
+
 typedef struct sk_rrect_t sk_rrect_t;
 
 typedef enum {

--- a/src/c/sk_pixmap.cpp
+++ b/src/c/sk_pixmap.cpp
@@ -10,9 +10,12 @@
 #include "include/core/SkPixmap.h"
 #include "include/core/SkSwizzle.h"
 #include "include/core/SkUnPreMultiply.h"
+#include "include/encode/SkEncoder.h"
 #include "include/encode/SkJpegEncoder.h"
 #include "include/encode/SkPngEncoder.h"
 #include "include/encode/SkWebpEncoder.h"
+
+#include <vector>
 
 #include "include/c/sk_pixmap.h"
 
@@ -106,6 +109,15 @@ bool sk_pixmap_erase_color4f(const sk_pixmap_t* cpixmap, const sk_color4f_t* col
 
 bool sk_webpencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, const sk_webpencoder_options_t* options) {
     return SkWebpEncoder::Encode(AsWStream(dst), *AsPixmap(src), AsWebpEncoderOptions(options));
+}
+
+bool sk_webpencoder_encode_animated(sk_wstream_t* dst, const sk_webpencoder_frame_t* src, int count, const sk_webpencoder_options_t* options) {
+    std::vector<SkEncoder::Frame> frames(count);
+    for (int i = 0; i < count; i++) {
+        frames[i].pixmap = *AsPixmap(src[i].pixmap);
+        frames[i].duration = src[i].duration;
+    }
+    return SkWebpEncoder::EncodeAnimated(AsWStream(dst), frames, AsWebpEncoderOptions(options));
 }
 
 bool sk_jpegencoder_encode(sk_wstream_t* dst, const sk_pixmap_t* src, const sk_jpegencoder_options_t* options) {


### PR DESCRIPTION
## Summary

Add animated WebP encoding support to the C API shim by wrapping `SkWebpEncoder::EncodeAnimated`.

### New types
- `sk_webpencoder_frame_t` — struct containing a `sk_pixmap_t*` and `int duration` (milliseconds)

### New functions
- `sk_webpencoder_encode_animated(sk_wstream_t*, const sk_webpencoder_frame_t*, int count, const sk_webpencoder_options_t*)` — returns `bool`

### Implementation notes
- `sk_webpencoder_frame_t` is not layout-compatible with `SkEncoder::Frame` (pointer vs value for pixmap), so the implementation does manual conversion via `std::vector<SkEncoder::Frame>`
- Reuses existing `sk_webpencoder_options_t` and its `AsWebpEncoderOptions` mapping
- No `DEF_MAP` or `static_assert` needed for the frame struct

Companion PR: mono/SkiaSharp#3771

<details><summary>Squash commit message</summary>

```
Add sk_webpencoder_encode_animated to C API (#199)

Context: https://github.com/mono/SkiaSharp/issues/3768
Companion: https://github.com/mono/SkiaSharp/pull/3771

Wrap SkWebpEncoder::EncodeAnimated (Skia m107+) in the C API shim
so SkiaSharp can expose animated WebP encoding to managed code.

  * New sk_webpencoder_frame_t struct (const sk_pixmap_t* + int
    duration in ms) in sk_types.h
  * New sk_webpencoder_encode_animated function in sk_pixmap.h/cpp
    with manual std::vector<SkEncoder::Frame> conversion because
    the C struct uses a pointer where C++ uses a value type
  * AsWebpEncoderOptions returns by value in m147, so the animated
    call uses the value form (no pointer dereference)

Co-authored-by: Matthew Leibowitz <mattleibow@live.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
```

</details>