### PR TITLE
Add sk_stream_get_data C API function

### DIFF
--- a/include/c/sk_stream.h
+++ b/include/c/sk_stream.h
@@ -52,6 +52,7 @@ SK_C_API bool sk_stream_move(sk_stream_t* cstream, int32_t offset);
 SK_C_API bool sk_stream_has_length(sk_stream_t* cstream);
 SK_C_API size_t sk_stream_get_length(sk_stream_t* cstream);
 SK_C_API const void* sk_stream_get_memory_base(sk_stream_t* cstream);
+SK_C_API sk_data_t* sk_stream_get_data(sk_stream_t* cstream);
 SK_C_API sk_stream_t* sk_stream_fork(sk_stream_t* cstream);
 SK_C_API sk_stream_t* sk_stream_duplicate(sk_stream_t* cstream);
 SK_C_API void sk_stream_destroy(sk_stream_t* cstream);

--- a/src/c/sk_stream.cpp
+++ b/src/c/sk_stream.cpp
@@ -141,6 +141,10 @@ const void* sk_stream_get_memory_base(sk_stream_t* cstream) {
     return AsStream(cstream)->getMemoryBase();
 }
 
+sk_data_t* sk_stream_get_data(sk_stream_t* cstream) {
+    return ToData(AsStream(cstream)->getData().release());
+}
+
 sk_stream_t* sk_stream_fork(sk_stream_t* cstream) {
     return ToStream(AsStream(cstream)->fork().release());
 }


### PR DESCRIPTION
Exposes `SkStream::getData()` virtual method through the C API shim.

```cpp
sk_data_t* sk_stream_get_data(sk_stream_t* cstream);
```

Returns the stream's contents as `sk_data_t*` when efficiently available (e.g. `SkMemoryStream` returns its backing data directly). Returns `nullptr` for streams that don't support cheap data access.

Companion PR in mono/SkiaSharp adds the C# wrapper (`SKStream.GetData()`) and tests.

Related: mono/SkiaSharp#3769