### PR TITLE
Add gradient interpolation C API for CSS Color Level 4

### DIFF
--- a/include/c/sk_shader.h
+++ b/include/c/sk_shader.h
@@ -40,6 +40,11 @@ SK_C_API sk_shader_t* sk_shader_new_sweep_gradient_color4f(const sk_point_t* cen
 SK_C_API sk_shader_t* sk_shader_new_two_point_conical_gradient(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color_t colors[], const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix);
 SK_C_API sk_shader_t* sk_shader_new_two_point_conical_gradient_color4f(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_matrix_t* localMatrix);
 
+SK_C_API sk_shader_t* sk_shader_new_linear_gradient_interpolation(const sk_point_t points[2], const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix);
+SK_C_API sk_shader_t* sk_shader_new_radial_gradient_interpolation(const sk_point_t* center, float radius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix);
+SK_C_API sk_shader_t* sk_shader_new_sweep_gradient_interpolation(const sk_point_t* center, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix);
+SK_C_API sk_shader_t* sk_shader_new_two_point_conical_gradient_interpolation(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix);
+
 // SkPerlinNoiseShader
 
 SK_C_API sk_shader_t* sk_shader_new_perlin_noise_fractal_noise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, const sk_isize_t* tileSize);

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -583,6 +583,33 @@ typedef enum {
 } sk_shader_tilemode_t;
 
 typedef enum {
+    DESTINATION_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    SRGB_LINEAR_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    LAB_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    OKLAB_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    OKLAB_GAMUT_MAP_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    LCH_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    OKLCH_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    OKLCH_GAMUT_MAP_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    SRGB_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    HSL_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+    HWB_SK_GRADIENT_INTERPOLATION_COLORSPACE,
+} sk_gradient_interpolation_colorspace_t;
+
+typedef enum {
+    SHORTER_SK_GRADIENT_INTERPOLATION_HUEMETHOD,
+    LONGER_SK_GRADIENT_INTERPOLATION_HUEMETHOD,
+    INCREASING_SK_GRADIENT_INTERPOLATION_HUEMETHOD,
+    DECREASING_SK_GRADIENT_INTERPOLATION_HUEMETHOD,
+} sk_gradient_interpolation_huemethod_t;
+
+typedef struct {
+    sk_gradient_interpolation_colorspace_t fColorSpace;
+    sk_gradient_interpolation_huemethod_t fHueMethod;
+    bool fInPremul;
+} sk_gradient_interpolation_t;
+
+typedef enum {
     NORMAL_SK_BLUR_STYLE,   //!< fuzzy inside and outside
     SOLID_SK_BLUR_STYLE,    //!< solid inside, fuzzy outside
     OUTER_SK_BLUR_STYLE,    //!< nothing inside, fuzzy outside

--- a/src/c/sk_shader.cpp
+++ b/src/c/sk_shader.cpp
@@ -157,14 +157,14 @@ sk_shader_t* sk_shader_new_two_point_conical_gradient_color4f(const sk_point_t* 
     return ToShader(SkShaders::TwoPointConicalGradient(*AsPoint(start), startRadius, *AsPoint(end), endRadius, SkGradient(gc, {}), localMatrix ? &m : nullptr).release());
 }
 
-static SkGradientShader::Interpolation AsInterpolation(const sk_gradient_interpolation_t* interp) {
-    SkGradientShader::Interpolation result;
+static SkGradient::Interpolation AsInterpolation(const sk_gradient_interpolation_t* interp) {
+    SkGradient::Interpolation result;
     if (interp) {
         result.fInPremul = interp->fInPremul
-            ? SkGradientShader::Interpolation::InPremul::kYes
-            : SkGradientShader::Interpolation::InPremul::kNo;
-        result.fColorSpace = (SkGradientShader::Interpolation::ColorSpace)interp->fColorSpace;
-        result.fHueMethod = (SkGradientShader::Interpolation::HueMethod)interp->fHueMethod;
+            ? SkGradient::Interpolation::InPremul::kYes
+            : SkGradient::Interpolation::InPremul::kNo;
+        result.fColorSpace = (SkGradient::Interpolation::ColorSpace)interp->fColorSpace;
+        result.fHueMethod = (SkGradient::Interpolation::HueMethod)interp->fHueMethod;
     }
     return result;
 }
@@ -173,28 +173,44 @@ sk_shader_t* sk_shader_new_linear_gradient_interpolation(const sk_point_t points
     SkMatrix m;
     if (localMatrix)
         m = AsMatrix(localMatrix);
-    return ToShader(SkGradientShader::MakeLinear(AsPoint(points), AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+    SkGradient::Colors gc(SkSpan<const SkColor4f>(AsColor4f(colors), colorCount),
+                          colorPos ? SkSpan<const float>(colorPos, colorCount) : SkSpan<const float>(),
+                          (SkTileMode)tileMode,
+                          sk_ref_sp(AsColorSpace(colorspace)));
+    return ToShader(SkShaders::LinearGradient(AsPoint(points), SkGradient(gc, AsInterpolation(interpolation)), localMatrix ? &m : nullptr).release());
 }
 
 sk_shader_t* sk_shader_new_radial_gradient_interpolation(const sk_point_t* center, float radius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
     SkMatrix m;
     if (localMatrix)
         m = AsMatrix(localMatrix);
-    return ToShader(SkGradientShader::MakeRadial(*AsPoint(center), (SkScalar)radius, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+    SkGradient::Colors gc(SkSpan<const SkColor4f>(AsColor4f(colors), colorCount),
+                          colorPos ? SkSpan<const float>(colorPos, colorCount) : SkSpan<const float>(),
+                          (SkTileMode)tileMode,
+                          sk_ref_sp(AsColorSpace(colorspace)));
+    return ToShader(SkShaders::RadialGradient(*AsPoint(center), (SkScalar)radius, SkGradient(gc, AsInterpolation(interpolation)), localMatrix ? &m : nullptr).release());
 }
 
 sk_shader_t* sk_shader_new_sweep_gradient_interpolation(const sk_point_t* center, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
     SkMatrix m;
     if (localMatrix)
         m = AsMatrix(localMatrix);
-    return ToShader(SkGradientShader::MakeSweep(center->x, center->y, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, startAngle, endAngle, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+    SkGradient::Colors gc(SkSpan<const SkColor4f>(AsColor4f(colors), colorCount),
+                          colorPos ? SkSpan<const float>(colorPos, colorCount) : SkSpan<const float>(),
+                          (SkTileMode)tileMode,
+                          sk_ref_sp(AsColorSpace(colorspace)));
+    return ToShader(SkShaders::SweepGradient({center->x, center->y}, startAngle, endAngle, SkGradient(gc, AsInterpolation(interpolation)), localMatrix ? &m : nullptr).release());
 }
 
 sk_shader_t* sk_shader_new_two_point_conical_gradient_interpolation(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
     SkMatrix m;
     if (localMatrix)
         m = AsMatrix(localMatrix);
-    return ToShader(SkGradientShader::MakeTwoPointConical(*AsPoint(start), startRadius, *AsPoint(end), endRadius, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+    SkGradient::Colors gc(SkSpan<const SkColor4f>(AsColor4f(colors), colorCount),
+                          colorPos ? SkSpan<const float>(colorPos, colorCount) : SkSpan<const float>(),
+                          (SkTileMode)tileMode,
+                          sk_ref_sp(AsColorSpace(colorspace)));
+    return ToShader(SkShaders::TwoPointConicalGradient(*AsPoint(start), startRadius, *AsPoint(end), endRadius, SkGradient(gc, AsInterpolation(interpolation)), localMatrix ? &m : nullptr).release());
 }
 
 // SkPerlinNoiseShader

--- a/src/c/sk_shader.cpp
+++ b/src/c/sk_shader.cpp
@@ -157,6 +157,46 @@ sk_shader_t* sk_shader_new_two_point_conical_gradient_color4f(const sk_point_t* 
     return ToShader(SkShaders::TwoPointConicalGradient(*AsPoint(start), startRadius, *AsPoint(end), endRadius, SkGradient(gc, {}), localMatrix ? &m : nullptr).release());
 }
 
+static SkGradientShader::Interpolation AsInterpolation(const sk_gradient_interpolation_t* interp) {
+    SkGradientShader::Interpolation result;
+    if (interp) {
+        result.fInPremul = interp->fInPremul
+            ? SkGradientShader::Interpolation::InPremul::kYes
+            : SkGradientShader::Interpolation::InPremul::kNo;
+        result.fColorSpace = (SkGradientShader::Interpolation::ColorSpace)interp->fColorSpace;
+        result.fHueMethod = (SkGradientShader::Interpolation::HueMethod)interp->fHueMethod;
+    }
+    return result;
+}
+
+sk_shader_t* sk_shader_new_linear_gradient_interpolation(const sk_point_t points[2], const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
+    SkMatrix m;
+    if (localMatrix)
+        m = AsMatrix(localMatrix);
+    return ToShader(SkGradientShader::MakeLinear(AsPoint(points), AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+}
+
+sk_shader_t* sk_shader_new_radial_gradient_interpolation(const sk_point_t* center, float radius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
+    SkMatrix m;
+    if (localMatrix)
+        m = AsMatrix(localMatrix);
+    return ToShader(SkGradientShader::MakeRadial(*AsPoint(center), (SkScalar)radius, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+}
+
+sk_shader_t* sk_shader_new_sweep_gradient_interpolation(const sk_point_t* center, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, float startAngle, float endAngle, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
+    SkMatrix m;
+    if (localMatrix)
+        m = AsMatrix(localMatrix);
+    return ToShader(SkGradientShader::MakeSweep(center->x, center->y, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, startAngle, endAngle, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+}
+
+sk_shader_t* sk_shader_new_two_point_conical_gradient_interpolation(const sk_point_t* start, float startRadius, const sk_point_t* end, float endRadius, const sk_color4f_t* colors, const sk_colorspace_t* colorspace, const float colorPos[], int colorCount, sk_shader_tilemode_t tileMode, const sk_gradient_interpolation_t* interpolation, const sk_matrix_t* localMatrix) {
+    SkMatrix m;
+    if (localMatrix)
+        m = AsMatrix(localMatrix);
+    return ToShader(SkGradientShader::MakeTwoPointConical(*AsPoint(start), startRadius, *AsPoint(end), endRadius, AsColor4f(colors), sk_ref_sp(AsColorSpace(colorspace)), colorPos, colorCount, (SkTileMode)tileMode, AsInterpolation(interpolation), localMatrix ? &m : nullptr).release());
+}
+
 // SkPerlinNoiseShader
 
 sk_shader_t* sk_shader_new_perlin_noise_fractal_noise(float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, const sk_isize_t* tileSize) {


### PR DESCRIPTION
Companion PR for mono/SkiaSharp#3773

Adds C API types and functions for gradient interpolation color space support:

- `sk_gradient_interpolation_colorspace_t` enum (11 CSS Color Level 4 spaces)
- `sk_gradient_interpolation_huemethod_t` enum (4 hue methods)
- `sk_gradient_interpolation_t` struct
- 4 new `sk_shader_new_*_gradient_interpolation` functions
- `AsInterpolation` helper using the new m147 `SkGradient` API