### PR TITLE
Add sk_runtimeeffect_make_image_filter C API functions

### DIFF
--- a/include/c/sk_imagefilter.h
+++ b/include/c/sk_imagefilter.h
@@ -47,6 +47,8 @@ SK_C_API sk_imagefilter_t* sk_imagefilter_new_spot_lit_diffuse(const sk_point3_t
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_distant_lit_specular(const sk_point3_t* direction, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_point_lit_specular(const sk_point3_t* location, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_spot_lit_specular(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
+SK_C_API sk_imagefilter_t* sk_imagefilter_new_runtime_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
+SK_C_API sk_imagefilter_t* sk_imagefilter_new_runtime_shader_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/include/c/sk_imagefilter.h
+++ b/include/c/sk_imagefilter.h
@@ -47,8 +47,6 @@ SK_C_API sk_imagefilter_t* sk_imagefilter_new_spot_lit_diffuse(const sk_point3_t
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_distant_lit_specular(const sk_point3_t* direction, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_point_lit_specular(const sk_point3_t* location, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_spot_lit_specular(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
-SK_C_API sk_imagefilter_t* sk_imagefilter_new_runtime_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
-SK_C_API sk_imagefilter_t* sk_imagefilter_new_runtime_shader_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 
 
 SK_C_PLUS_PLUS_END_GUARD

--- a/include/c/sk_runtimeeffect.h
+++ b/include/c/sk_runtimeeffect.h
@@ -19,8 +19,8 @@ SK_C_API void sk_runtimeeffect_unref(sk_runtimeeffect_t* effect);
 SK_C_API sk_shader_t* sk_runtimeeffect_make_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const sk_matrix_t* localMatrix);
 SK_C_API sk_colorfilter_t* sk_runtimeeffect_make_color_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
 SK_C_API sk_blender_t* sk_runtimeeffect_make_blender(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
-SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, const char* childShaderName, const sk_imagefilter_t* input);
-SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 SK_C_API size_t sk_runtimeeffect_get_uniform_byte_size(const sk_runtimeeffect_t* effect);
 
 SK_C_API size_t sk_runtimeeffect_get_uniforms_size(const sk_runtimeeffect_t* effect);

--- a/include/c/sk_runtimeeffect.h
+++ b/include/c/sk_runtimeeffect.h
@@ -19,8 +19,8 @@ SK_C_API void sk_runtimeeffect_unref(sk_runtimeeffect_t* effect);
 SK_C_API sk_shader_t* sk_runtimeeffect_make_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const sk_matrix_t* localMatrix);
 SK_C_API sk_colorfilter_t* sk_runtimeeffect_make_color_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
 SK_C_API sk_blender_t* sk_runtimeeffect_make_blender(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
-SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
-SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, const char* childShaderName, const sk_imagefilter_t* input);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 SK_C_API size_t sk_runtimeeffect_get_uniform_byte_size(const sk_runtimeeffect_t* effect);
 
 SK_C_API size_t sk_runtimeeffect_get_uniforms_size(const sk_runtimeeffect_t* effect);

--- a/include/c/sk_runtimeeffect.h
+++ b/include/c/sk_runtimeeffect.h
@@ -19,7 +19,7 @@ SK_C_API void sk_runtimeeffect_unref(sk_runtimeeffect_t* effect);
 SK_C_API sk_shader_t* sk_runtimeeffect_make_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const sk_matrix_t* localMatrix);
 SK_C_API sk_colorfilter_t* sk_runtimeeffect_make_color_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
 SK_C_API sk_blender_t* sk_runtimeeffect_make_blender(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
-SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char* childShaderName, const sk_imagefilter_t* input);
 SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 SK_C_API size_t sk_runtimeeffect_get_uniform_byte_size(const sk_runtimeeffect_t* effect);
 

--- a/include/c/sk_runtimeeffect.h
+++ b/include/c/sk_runtimeeffect.h
@@ -19,6 +19,8 @@ SK_C_API void sk_runtimeeffect_unref(sk_runtimeeffect_t* effect);
 SK_C_API sk_shader_t* sk_runtimeeffect_make_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const sk_matrix_t* localMatrix);
 SK_C_API sk_colorfilter_t* sk_runtimeeffect_make_color_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
 SK_C_API sk_blender_t* sk_runtimeeffect_make_blender(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input);
+SK_C_API sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount);
 SK_C_API size_t sk_runtimeeffect_get_uniform_byte_size(const sk_runtimeeffect_t* effect);
 
 SK_C_API size_t sk_runtimeeffect_get_uniforms_size(const sk_runtimeeffect_t* effect);

--- a/src/c/sk_imagefilter.cpp
+++ b/src/c/sk_imagefilter.cpp
@@ -12,6 +12,7 @@
 #include "include/core/SkPicture.h"
 #include "include/core/SkRegion.h"
 #include "include/effects/SkImageFilters.h"
+#include "include/effects/SkRuntimeEffect.h"
 
 #include "include/c/sk_imagefilter.h"
 
@@ -142,4 +143,37 @@ sk_imagefilter_t* sk_imagefilter_new_point_lit_specular(const sk_point3_t* locat
 
 sk_imagefilter_t* sk_imagefilter_new_spot_lit_specular(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect) {
     return ToImageFilter(SkImageFilters::SpotLitSpecular(*AsPoint3(location), *AsPoint3(target), specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, sk_ref_sp(AsImageFilter(input)), AsRect(cropRect)).release());
+}
+
+sk_imagefilter_t* sk_imagefilter_new_runtime_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
+    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
+
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
+
+    std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
+    return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
+}
+
+sk_imagefilter_t* sk_imagefilter_new_runtime_shader_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
+    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
+
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
+
+    std::vector<std::string_view> names(inputCount);
+    for (int i = 0; i < inputCount; i++) {
+        names[i] = std::string_view(childShaderNames[i]);
+    }
+
+    std::vector<sk_sp<SkImageFilter>> skInputs(inputCount);
+    for (int i = 0; i < inputCount; i++) {
+        skInputs[i] = sk_ref_sp(AsImageFilter(inputs[i]));
+    }
+
+    return ToImageFilter(SkImageFilters::RuntimeShader(builder, maxSampleRadius, names.data(), skInputs.data(), inputCount).release());
 }

--- a/src/c/sk_imagefilter.cpp
+++ b/src/c/sk_imagefilter.cpp
@@ -144,36 +144,3 @@ sk_imagefilter_t* sk_imagefilter_new_point_lit_specular(const sk_point3_t* locat
 sk_imagefilter_t* sk_imagefilter_new_spot_lit_specular(const sk_point3_t* location, const sk_point3_t* target, float specularExponent, float cutoffAngle, sk_color_t lightColor, float surfaceScale, float ks, float shininess, const sk_imagefilter_t* input, const sk_rect_t* cropRect) {
     return ToImageFilter(SkImageFilters::SpotLitSpecular(*AsPoint3(location), *AsPoint3(target), specularExponent, cutoffAngle, lightColor, surfaceScale, ks, shininess, sk_ref_sp(AsImageFilter(input)), AsRect(cropRect)).release());
 }
-
-sk_imagefilter_t* sk_imagefilter_new_runtime_shader(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
-    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
-
-    auto effectChildren = AsRuntimeEffect(effect)->children();
-    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
-        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
-    }
-
-    std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
-    return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
-}
-
-sk_imagefilter_t* sk_imagefilter_new_runtime_shader_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
-    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
-
-    auto effectChildren = AsRuntimeEffect(effect)->children();
-    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
-        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
-    }
-
-    std::vector<std::string_view> names(inputCount);
-    for (int i = 0; i < inputCount; i++) {
-        names[i] = std::string_view(childShaderNames[i]);
-    }
-
-    std::vector<sk_sp<SkImageFilter>> skInputs(inputCount);
-    for (int i = 0; i < inputCount; i++) {
-        skInputs[i] = sk_ref_sp(AsImageFilter(inputs[i]));
-    }
-
-    return ToImageFilter(SkImageFilters::RuntimeShader(builder, maxSampleRadius, names.data(), skInputs.data(), inputCount).release());
-}

--- a/src/c/sk_runtimeeffect.cpp
+++ b/src/c/sk_runtimeeffect.cpp
@@ -7,7 +7,9 @@
 
 #include "include/core/SkTypes.h"
 #include "include/core/SkColorFilter.h"
+#include "include/core/SkImageFilter.h"
 #include "include/core/SkShader.h"
+#include "include/effects/SkImageFilters.h"
 #include "include/effects/SkRuntimeEffect.h"
 
 #include "include/c/sk_types.h"
@@ -128,4 +130,37 @@ void sk_runtimeeffect_get_child_from_index(const sk_runtimeeffect_t* effect, int
 
 void sk_runtimeeffect_get_child_from_name(const sk_runtimeeffect_t* effect, const char* name, size_t len, sk_runtimeeffect_child_t* cchild) {
     *cchild = *ToRuntimeEffectChild(AsRuntimeEffect(effect)->findChild(std::string_view(name, len)));
+}
+
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
+    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
+
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
+
+    std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
+    return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
+}
+
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
+    SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
+
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
+
+    std::vector<std::string_view> names(inputCount);
+    for (int i = 0; i < inputCount; i++) {
+        names[i] = std::string_view(childShaderNames[i]);
+    }
+
+    std::vector<sk_sp<SkImageFilter>> skInputs(inputCount);
+    for (int i = 0; i < inputCount; i++) {
+        skInputs[i] = sk_ref_sp(AsImageFilter(inputs[i]));
+    }
+
+    return ToImageFilter(SkImageFilters::RuntimeShader(builder, maxSampleRadius, names.data(), skInputs.data(), inputCount).release());
 }

--- a/src/c/sk_runtimeeffect.cpp
+++ b/src/c/sk_runtimeeffect.cpp
@@ -18,8 +18,6 @@
 
 #include "src/c/sk_types_priv.h"
 
-using namespace skia_private;
-
 sk_runtimeeffect_t* sk_runtimeeffect_make_for_color_filter(sk_string_t* sksl, sk_string_t* error) {
     auto [effect, errorMessage] = SkRuntimeEffect::MakeForColorFilter(AsString(*sksl));
     if (error && errorMessage.size() > 0)
@@ -135,18 +133,28 @@ void sk_runtimeeffect_get_child_from_name(const sk_runtimeeffect_t* effect, cons
     *cchild = *ToRuntimeEffectChild(AsRuntimeEffect(effect)->findChild(std::string_view(name, len)));
 }
 
-sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, const char* childShaderName, const sk_imagefilter_t* input) {
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
     SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
+
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
 
     std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
     return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
 }
 
-sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
     SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
 
-    STArray<4, std::string_view> names(inputCount);
-    STArray<4, sk_sp<SkImageFilter>> skInputs(inputCount);
+    auto effectChildren = AsRuntimeEffect(effect)->children();
+    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
+        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
+    }
+
+    skia_private::STArray<4, std::string_view> names(inputCount);
+    skia_private::STArray<4, sk_sp<SkImageFilter>> skInputs(inputCount);
     for (int i = 0; i < inputCount; i++) {
         names.push_back(std::string_view(childShaderNames[i]));
         skInputs.push_back(sk_ref_sp(AsImageFilter(inputs[i])));

--- a/src/c/sk_runtimeeffect.cpp
+++ b/src/c/sk_runtimeeffect.cpp
@@ -133,7 +133,7 @@ void sk_runtimeeffect_get_child_from_name(const sk_runtimeeffect_t* effect, cons
     *cchild = *ToRuntimeEffectChild(AsRuntimeEffect(effect)->findChild(std::string_view(name, len)));
 }
 
-sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char* childShaderName, const sk_imagefilter_t* input) {
     SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
 
     auto effectChildren = AsRuntimeEffect(effect)->children();
@@ -142,7 +142,7 @@ sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect,
     }
 
     std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
-    return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
+    return ToImageFilter(SkImageFilters::RuntimeShader(builder, maxSampleRadius, name, sk_ref_sp(AsImageFilter(input))).release());
 }
 
 sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {

--- a/src/c/sk_runtimeeffect.cpp
+++ b/src/c/sk_runtimeeffect.cpp
@@ -11,11 +11,14 @@
 #include "include/core/SkShader.h"
 #include "include/effects/SkImageFilters.h"
 #include "include/effects/SkRuntimeEffect.h"
+#include "include/private/base/SkTArray.h"
 
 #include "include/c/sk_types.h"
 #include "include/c/sk_runtimeeffect.h"
 
 #include "src/c/sk_types_priv.h"
+
+using namespace skia_private;
 
 sk_runtimeeffect_t* sk_runtimeeffect_make_for_color_filter(sk_string_t* sksl, sk_string_t* error) {
     auto [effect, errorMessage] = SkRuntimeEffect::MakeForColorFilter(AsString(*sksl));
@@ -132,34 +135,21 @@ void sk_runtimeeffect_get_child_from_name(const sk_runtimeeffect_t* effect, cons
     *cchild = *ToRuntimeEffectChild(AsRuntimeEffect(effect)->findChild(std::string_view(name, len)));
 }
 
-sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, const char* childShaderName, const sk_imagefilter_t* input) {
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter(sk_runtimeeffect_t* effect, sk_data_t* uniforms, const char* childShaderName, const sk_imagefilter_t* input) {
     SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
-
-    auto effectChildren = AsRuntimeEffect(effect)->children();
-    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
-        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
-    }
 
     std::string_view name = childShaderName ? std::string_view(childShaderName) : std::string_view();
     return ToImageFilter(SkImageFilters::RuntimeShader(builder, name, sk_ref_sp(AsImageFilter(input))).release());
 }
 
-sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, sk_flattenable_t** children, size_t childCount, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
+sk_imagefilter_t* sk_runtimeeffect_make_image_filter_with_children(sk_runtimeeffect_t* effect, sk_data_t* uniforms, float maxSampleRadius, const char** childShaderNames, const sk_imagefilter_t** inputs, int inputCount) {
     SkRuntimeShaderBuilder builder(sk_ref_sp(AsRuntimeEffect(effect)), sk_ref_sp(AsData(uniforms)));
 
-    auto effectChildren = AsRuntimeEffect(effect)->children();
-    for (size_t i = 0; i < childCount && i < effectChildren.size(); i++) {
-        builder.child(effectChildren[i].name) = sk_ref_sp(AsFlattenable(children[i]));
-    }
-
-    std::vector<std::string_view> names(inputCount);
+    STArray<4, std::string_view> names(inputCount);
+    STArray<4, sk_sp<SkImageFilter>> skInputs(inputCount);
     for (int i = 0; i < inputCount; i++) {
-        names[i] = std::string_view(childShaderNames[i]);
-    }
-
-    std::vector<sk_sp<SkImageFilter>> skInputs(inputCount);
-    for (int i = 0; i < inputCount; i++) {
-        skInputs[i] = sk_ref_sp(AsImageFilter(inputs[i]));
+        names.push_back(std::string_view(childShaderNames[i]));
+        skInputs.push_back(sk_ref_sp(AsImageFilter(inputs[i])));
     }
 
     return ToImageFilter(SkImageFilters::RuntimeShader(builder, maxSampleRadius, names.data(), skInputs.data(), inputCount).release());


### PR DESCRIPTION
Add two C API functions for creating image filters from runtime shader effects:

- `sk_runtimeeffect_make_image_filter` — single-child variant with `maxSampleRadius`, `childShaderName` (auto-detect if empty), optional `input` filter, and builder `children` for static child slots
- `sk_runtimeeffect_make_image_filter_with_children` — multi-child variant with parallel `childShaderNames`/`inputs` arrays, `maxSampleRadius`, and builder `children`

Both reconstruct an `SkRuntimeEffectBuilder` from decomposed C API parameters and call `SkImageFilters::RuntimeShader`. Multi-child path uses `skia_private::STArray<4>` for stack-backed allocations.

Fixes mono/SkiaSharp#3776