### PR TITLE
Fix sk_stream_get_data const correctness for m147

### DIFF
--- a/src/c/sk_stream.cpp
+++ b/src/c/sk_stream.cpp
@@ -142,7 +142,7 @@ const void* sk_stream_get_memory_base(sk_stream_t* cstream) {
 }
 
 sk_data_t* sk_stream_get_data(sk_stream_t* cstream) {
-    return ToData(AsStream(cstream)->getData().release());
+    return ToData(const_cast<SkData*>(AsStream(cstream)->getData().release()));
 }
 
 sk_stream_t* sk_stream_fork(sk_stream_t* cstream) {


### PR DESCRIPTION
Follow-up to #200.

`SkStream::getData()` now returns `sk_sp<const SkData>` after upstream commit bca32dc673 ("Make underlying SkData in SkMemoryStream const"). The C API shim needs a `const_cast` to match the existing `sk_data_t*` return convention.

This is the same pattern used by `sk_image_ref_encoded`, which also handles `sk_sp<const SkData>` from `refEncodedData()`. The cast is safe because `SkData` is immutable and ref-counted.

Companion: mono/SkiaSharp#3772