### PR TITLE
[skia-sync] Merge upstream chrome/m147

### DIFF
--- a/include/core/SkRegion.h
+++ b/include/core/SkRegion.h
@@ -447,8 +447,9 @@ public:
 #endif
 
     /** \class SkRegion::Iterator
-        Returns sequence of rectangles, sorted along y-axis, then x-axis, that make
-        up SkRegion.
+        Goes through the region one rectangle at a time. For each "strip" of one or more contiguous
+        Y values (scanlines) in ascending order, the iterator returns each rectangle in that strip
+        (from left to right) before advancing to the next strip (which may or may not have a gap).
     */
     class SK_API Iterator {
     public:
@@ -494,9 +495,12 @@ public:
         bool done() const { return fDone; }
 
         /** Advances SkRegion::Iterator to next SkIRect in SkRegion if it is not done.
-
-        example: https://fiddle.skia.org/c/@Region_Iterator_next
-        */
+         * This moves to the next rectangle to the right within the current
+         * horizontal strip. If the end of the strip is reached, it automatically
+         * advances to the first rectangle in the next strip, skipping any vertical gaps.
+         *
+         * example: https://fiddle.skia.org/c/@Region_Iterator_next
+         */
         void next();
 
         /** Returns SkIRect element in SkRegion. Does not return predictable results if SkRegion
@@ -514,6 +518,7 @@ public:
 
     private:
         const SkRegion* fRgn;
+        // See top of SkRegion.cpp for more on the RLE encoding
         const SkRegion::RunType*  fRuns;
         SkIRect         fRect = {0, 0, 0, 0};
         bool            fDone;

--- a/include/effects/SkRuntimeEffect.h
+++ b/include/effects/SkRuntimeEffect.h
@@ -324,8 +324,8 @@ private:
     uint32_t fStableKey = 0;
     SkString fName;
 
-    std::unique_ptr<SkSL::Program> fBaseProgram;
-    std::unique_ptr<SkSL::RP::Program> fRPProgram;
+    std::unique_ptr<const SkSL::Program> fBaseProgram;
+    std::unique_ptr<const SkSL::RP::Program> fRPProgram;
     mutable SkOnce fCompileRPProgramOnce;
     const SkSL::FunctionDefinition& fMain;
     std::vector<Uniform> fUniforms;

--- a/src/core/SkRegion.cpp
+++ b/src/core/SkRegion.cpp
@@ -23,14 +23,30 @@
 
 using namespace skia_private;
 
-/* Region Layout
+/* SkRegion Run-Length Encoding (RLE) Format:
  *
- *  TOP
+ * A region is stored as a series of non-overlapping horizontal strips (scanlines).
+ * All rectangles in a strip share the same Top and Bottom Y-coordinates.
  *
- *  [ Bottom, X-Intervals, [Left, Right]..., X-Sentinel ]
- *  ...
+ * Data layout:
+ * [Top-Y]
+ *    [Bottom-Y, Interval-Count (N), Left-1, Right-1, ..., Left-N, Right-N, X-Sentinel]
+ *    [Bottom-Y, Interval-Count (M), Left-1, Right-1, ..., Left-M, Right-M, X-Sentinel]
+ *    ...
+ * [Y-Sentinel]
  *
- *  Y-Sentinel
+ * - Sentinels are 0x7FFFFFFF (SkRegion_kRunTypeSentinel).
+ * - Interval-Count can be 0 (representing a vertical gap between strips).
+ * - Strips are sorted by Y; Intervals within a strip are sorted by X.
+ *
+ * Example: Two rects [10, 10, 20, 20] and [30, 10, 40, 20] on one line,
+ *          then a gap until Y=30, then [15, 30, 25, 40] would be:
+ *
+ *          10                       // Global Top-Y
+ *          20, 2, 10, 20, 30, 40, S // Strip 1: Y 10-20, 2 rects, X-Sentinel
+ *          30, 0, S                 // Strip 2: Y 20-30, 0 rects (gap), X-Sentinel
+ *          40, 1, 15, 25, S         // Strip 3: Y 30-40, 1 rect, X-Sentinel
+ *          S                        // Y-Sentinel
  */
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -96,6 +112,10 @@ static SkRegionPriv::RunType* skip_intervals(const SkRegionPriv::RunType runs[])
 #endif
     runs += intervals * 2 + 1;
     return const_cast<SkRegionPriv::RunType*>(runs);
+}
+
+static inline void assert_sentinel(int32_t value, bool isSentinel) {
+    SkASSERT(SkRegionValueIsSentinel(value) == isSentinel);
 }
 
 bool SkRegion::RunsAreARect(const SkRegion::RunType runs[], int count,
@@ -299,7 +319,7 @@ bool SkRegion::setRuns(RunType runs[], int count) {
         if (runs[3] == SkRegion_kRunTypeSentinel) {  // should be first left...
             runs += 3;  // skip empty initial span
             runs[0] = runs[-2]; // set new top to prev bottom
-            assert_sentinel(runs[1], false);    // bot: a sentinal would mean two in a row
+            assert_sentinel(runs[1], false);    // bot: a sentinel would mean two in a row
             assert_sentinel(runs[2], false);    // intervalcount
             assert_sentinel(runs[3], false);    // left
             assert_sentinel(runs[4], false);    // right
@@ -879,7 +899,7 @@ public:
 
     int flush() {
         (*fArray)[fStartDst] = fTop;
-        // Previously reserved enough for TWO sentinals.
+        // Previously reserved enough for TWO sentinels.
         SkASSERT(fArray->count() > SkToInt(fPrevDst + fPrevLen));
         (*fArray)[fPrevDst + fPrevLen] = SkRegion_kRunTypeSentinel;
         return (int)(fPrevDst - fStartDst + fPrevLen + 1);
@@ -1050,20 +1070,18 @@ bool SkRegion::Oper(const SkRegion& rgnaOrig, const SkRegion& rgnbOrig, Op op,
     // swith to using pointers, so we can swap them as needed
     const SkRegion* rgna = &rgnaOrig;
     const SkRegion* rgnb = &rgnbOrig;
-    // after this point, do not refer to rgnaOrig or rgnbOrig!!!
 
-    // collaps difference and reverse-difference into just difference
+    // collapse difference and reverse-difference into just difference
     if (kReverseDifference_Op == op) {
-        using std::swap;
-        swap(rgna, rgnb);
+        std::swap(rgna, rgnb);
         op = kDifference_Op;
     }
 
     SkIRect bounds;
-    bool    a_empty = rgna->isEmpty();
-    bool    b_empty = rgnb->isEmpty();
-    bool    a_rect = rgna->isRect();
-    bool    b_rect = rgnb->isRect();
+    bool a_empty = rgna->isEmpty();
+    bool b_empty = rgnb->isEmpty();
+    bool a_rect = rgna->isRect();
+    bool b_rect = rgnb->isRect();
 
     switch (op) {
     case kDifference_Op:
@@ -1188,9 +1206,11 @@ static bool validate_run_count(int ySpanCount, int intervalCount, int runCount) 
     }
     SkSafeMath safeMath;
     int sum = 2;
+    // 3 bytes per ySpan (stop Y, how many intervals, sentinel)
     sum = safeMath.addInt(sum, ySpanCount);
     sum = safeMath.addInt(sum, ySpanCount);
     sum = safeMath.addInt(sum, ySpanCount);
+    // 2 bytes per interval (startX, stop X)
     sum = safeMath.addInt(sum, intervalCount);
     sum = safeMath.addInt(sum, intervalCount);
     return safeMath && sum == runCount;
@@ -1218,6 +1238,7 @@ static bool validate_run(const int32_t* runs,
     const int32_t* const end = runs + runCount;
     SkIRect bounds = {0, 0, 0 ,0};  // calulated bounds
     SkIRect rect = {0, 0, 0, 0};    // current rect
+    bool prevWasEmpty = true;       // If we start with an empty slice, that's corrupted data.
     rect.fTop = *runs++;
     if (rect.fTop == SkRegion_kRunTypeSentinel) {
         return false;  // no rect can contain SkRegion_kRunTypeSentinel
@@ -1246,6 +1267,15 @@ static bool validate_run(const int32_t* runs,
         if (xIntervals < 0 || xIntervals > intervalCount || runs + 1 + 2 * xIntervals > end) {
             return false;
         }
+        if (xIntervals == 0) {
+            if (prevWasEmpty) {
+                // back to back empty spans are invalid; our serialization always has them together
+                return false;
+            }
+            prevWasEmpty = true;
+        } else {
+            prevWasEmpty = false;
+        }
         intervalCount -= xIntervals;
         bool firstInterval = true;
         int32_t lastRight = 0;  // check that x-intervals are distinct and ordered.
@@ -1263,7 +1293,7 @@ static bool validate_run(const int32_t* runs,
             bounds.join(rect);
         }
         if (*runs++ != SkRegion_kRunTypeSentinel) {
-            return false;  // required check sentinal.
+            return false;  // required check sentinel.
         }
         rect.fTop = rect.fBottom;
         SkASSERT(runs < end);

--- a/src/core/SkRegionPriv.h
+++ b/src/core/SkRegionPriv.h
@@ -38,9 +38,6 @@ inline bool SkRegionValueIsSentinel(int32_t value) {
     return value == (int32_t)SkRegion_kRunTypeSentinel;
 }
 
-#define assert_sentinel(value, isSentinel) \
-    SkASSERT(SkRegionValueIsSentinel(value) == isSentinel)
-
 #ifdef SK_DEBUG
 // Given the first interval (just past the interval-count), compute the
 // interval count, by search for the x-sentinel

--- a/src/core/SkRuntimeEffect.cpp
+++ b/src/core/SkRuntimeEffect.cpp
@@ -222,30 +222,48 @@ const SkSL::RP::Program* SkRuntimeEffect::getRPProgram(SkSL::DebugTracePriv* deb
     fCompileRPProgramOnce([&] {
         // We generally do not run the inliner when an SkRuntimeEffect program is initially created,
         // because the final compile to native shader code will do this. However, in SkRP, there's
-        // no additional compilation occurring, so we need to manually inline here if we want the
-        // performance boost of inlining.
-        if (!(fFlags & kDisableOptimization_Flag)) {
-            SkSL::Compiler compiler;
-            fBaseProgram->fConfig->fSettings.fInlineThreshold = SkSL::kDefaultInlineThreshold;
-            compiler.runInliner(*fBaseProgram);
+        // no additional compilation occurring, so we need to optimize/inline here if we want the
+        // performance boost of inlining. Since fBaseProgram is a shared (const) object, we can't
+        // mutate it in-place (e.g. calling compiler.runInliner). If optimization is neccesary,
+        // we re-compile the program from source with inlining and optimization enabled to get a
+        // freshly optimized copy (it's pretty cheap to re-compile and there's no easy way to copy
+        // an SkSL::Program).
+        const SkSL::Program* programToUse = fBaseProgram.get();
+        const SkSL::FunctionDefinition* mainToUse = &fMain;
 
-            // After inlining, the program is likely to have dead functions left behind.
-            while (SkSL::Transform::EliminateDeadFunctions(*fBaseProgram)) {
-                // Removing dead functions may cause more functions to become unreferenced.
+        std::unique_ptr<SkSL::Program> optimizedCopy;
+        bool shouldOptimize = !(fFlags & kDisableOptimization_Flag);
+        SkSL::ProgramSettings settings = fBaseProgram->fConfig->fSettings;
+        bool needsOptimization = !settings.fOptimize ||
+                                  settings.fInlineThreshold < SkSL::kDefaultInlineThreshold;
+        if (shouldOptimize && needsOptimization) {
+            SkSL::Compiler compiler;
+            settings.fOptimize = true;
+            settings.fInlineThreshold = SkSL::kDefaultInlineThreshold;
+            optimizedCopy = compiler.convertProgram(
+                    fBaseProgram->fConfig->fKind, *fBaseProgram->fSource, settings);
+            SkASSERT(optimizedCopy);
+            if (optimizedCopy) {
+                const auto* mainDecl = optimizedCopy->getFunction("main");
+                SkASSERT(mainDecl);
+                if (mainDecl) {
+                    programToUse = optimizedCopy.get();
+                    mainToUse = mainDecl->definition();
+                }
             }
         }
 
         SkSL::DebugTracePriv tempDebugTrace;
         if (debugTrace) {
             const_cast<SkRuntimeEffect*>(this)->fRPProgram = MakeRasterPipelineProgram(
-                    *fBaseProgram, fMain, debugTrace, /*writeTraceOps=*/true);
+                    *programToUse, *mainToUse, debugTrace, /*writeTraceOps=*/true);
         } else if (kRPEnableLiveTrace) {
             debugTrace = &tempDebugTrace;
             const_cast<SkRuntimeEffect*>(this)->fRPProgram = MakeRasterPipelineProgram(
-                    *fBaseProgram, fMain, debugTrace, /*writeTraceOps=*/false);
+                    *programToUse, *mainToUse, debugTrace, /*writeTraceOps=*/false);
         } else {
             const_cast<SkRuntimeEffect*>(this)->fRPProgram = MakeRasterPipelineProgram(
-                    *fBaseProgram, fMain, /*debugTrace=*/nullptr, /*writeTraceOps=*/false);
+                    *programToUse, *mainToUse, /*debugTrace=*/nullptr, /*writeTraceOps=*/false);
         }
 
         if (kRPEnableLiveTrace) {
@@ -450,8 +468,9 @@ void SkRuntimeEffectPriv::WriteChildEffects(
 }
 
 SkSL::ProgramSettings SkRuntimeEffect::MakeSettings(const Options& options) {
+    constexpr int kDisableSKSLInlining = 0;
     SkSL::ProgramSettings settings;
-    settings.fInlineThreshold = 0;
+    settings.fInlineThreshold = kDisableSKSLInlining;
     settings.fForceNoInline = options.forceUnoptimized;
     settings.fOptimize = !options.forceUnoptimized;
     settings.fMaxVersionAllowed = options.maxVersionAllowed;

--- a/src/sksl/codegen/SkSLRasterPipelineBuilder.cpp
+++ b/src/sksl/codegen/SkSLRasterPipelineBuilder.cpp
@@ -387,7 +387,7 @@ void Builder::discard_stack(int32_t count, int stackID) {
             case BuilderOp::copy_stack_to_slots_unmasked: {
                 // Look for a pattern of `push, immediate-ops, pop` and simplify it down to an
                 // immediate-op directly to the value slot.
-                if (count == 1) {
+                if (count == lastInstruction->fImmA) {
                     if (this->simplifyImmediateUnmaskedOp()) {
                         return;
                     }
@@ -1374,7 +1374,7 @@ Program::StackDepths Program::tempStackMaxDepths() const {
         current[stackID] += stack_usage(inst);
         largest[stackID] = std::max(current[stackID], largest[stackID]);
         // If we assert here, the generated program has popped off the top of the stack.
-        SkASSERTF(current[stackID] >= 0, "unbalanced temp stack push/pop on stack %d", stackID);
+        SkASSERTF_RELEASE(current[stackID] >= 0, "unbalanced temp stack push/pop on stack");
     }
 
     // Ensure that when the program is complete, our stacks are fully balanced.

--- a/tests/RegionTest.cpp
+++ b/tests/RegionTest.cpp
@@ -33,7 +33,7 @@ static void Union(SkRegion* rgn, const SkIRect& rect) {
 #define TEST_INTERSECT(rgn, rect)       REPORTER_ASSERT(reporter, rgn.intersects(rect))
 #define TEST_NO_CONTAINS(rgn, rect)     REPORTER_ASSERT(reporter, !rgn.contains(rect))
 
-// inspired by http://code.google.com/p/skia/issues/detail?id=958
+// inspired by https://issues.skia.org/issues/40032017
 //
 static void test_fromchrome(skiatest::Reporter* reporter) {
     SkRegion r;
@@ -587,4 +587,114 @@ DEF_TEST(region_very_large, reporter) {
     REPORTER_ASSERT(reporter, smallRegion.contains(0, 499));
     REPORTER_ASSERT(reporter, smallRegion.contains(499, 0));
     REPORTER_ASSERT(reporter, smallRegion.contains(499, 499));
+}
+
+DEF_TEST(SkRegion_Iterator_StepsThroughAllScanlines, reporter) {
+    SkRegion rgn1;
+    rgn1.op({12, 10, 17, 20}, SkRegion::kUnion_Op);
+    rgn1.op({31, 10, 39, 25}, SkRegion::kUnion_Op);
+    rgn1.op({16, 30, 23, 40}, SkRegion::kUnion_Op);
+
+    int32_t buffer[32];
+    memset(&buffer, 0, 128);
+    size_t len = rgn1.writeToMemory(&buffer);
+    SkASSERT_RELEASE(len < 128);
+    SkRegion rgn2;
+    size_t len2 = rgn2.readFromMemory(&buffer, len);
+    REPORTER_ASSERT(reporter, len == len2);
+    // TODO(kjlubick) make sure fuzzer uses the iterators
+
+    // Make sure the serialized/deserialzed version is the same as the original.
+    for (const auto& rgn : {rgn1, rgn2}) {
+        SkRegion::Iterator iter(rgn);
+
+        // The first scanline strip starts at Y=10 and ends at Y=20.
+        //   The first rectangle there starts at X=12 and ends at X=17
+        REPORTER_ASSERT(reporter, !iter.done());
+        REPORTER_ASSERT(reporter, iter.rect() == SkIRect::MakeLTRB(12, 10, 17, 20));
+
+        //    There's a second rectangle in that section from X=31 to X=39.
+        iter.next();
+        REPORTER_ASSERT(reporter, !iter.done());
+        REPORTER_ASSERT(reporter, iter.rect() == SkIRect::MakeLTRB(31, 10, 39, 20));
+
+        // The next scanline strip continues at Y=20 and goes til Y=25
+        //     The one and only rectangle here starts at X=31 and goes to X=39
+        iter.next();
+        REPORTER_ASSERT(reporter, !iter.done());
+        REPORTER_ASSERT(reporter, iter.rect() == SkIRect::MakeLTRB(31, 20, 39, 25));
+
+        // There's a jump to the final scanline strip from Y=30 to Y=40
+        //     The one and only rectangle here starts at X=16 and goes to X=23
+        iter.next();
+        REPORTER_ASSERT(reporter, !iter.done());
+        REPORTER_ASSERT(reporter, iter.rect() == SkIRect::MakeLTRB(16, 30, 23, 40));
+
+        // Call next() -> no more rectangles
+        iter.next();
+        REPORTER_ASSERT(reporter, iter.done());
+    }
+}
+
+DEF_TEST(SkRegion_ReadFromMemory_ConsecutiveEmptySlices_Invalid, reporter) {
+    constexpr int32_t kSentinel = 0x7FFFFFFF;
+    const int32_t corrupt[] = {
+        42,             // number of int32s in the RLE portion (after 7 metadata int32s)
+        0, 0, 100, 100, // bounds
+        12,             // 12 spans (10 are empty)
+        2,              // 2 rectangles
+        0, 5,           // first stripe is from Y=0 to Y=5,
+        1,              // 1 rectangle
+        0, 100,         // from x = 0 to 100 (arbitrary)
+        kSentinel,
+        10, 0, kSentinel, // Empty from  5-10
+        20, 0, kSentinel, // Empty from 10-20...
+        30, 0, kSentinel,
+        40, 0, kSentinel,
+        50, 0, kSentinel,
+        60, 0, kSentinel,
+        70, 0, kSentinel,
+        80, 0, kSentinel,
+        90, 0, kSentinel,
+        95, 0, kSentinel,
+        100, 1, 20, 30, kSentinel, // one final real rectangle until Y=100
+        kSentinel, // final sentinal
+    };
+
+    SkRegion rgn;
+    size_t len = rgn.readFromMemory(&corrupt, sizeof(corrupt));
+    REPORTER_ASSERT(reporter, len == 0);  // len == 0 means "could not read"
+
+    // When there was a buggy version of this, the following iteration caused a crash.
+    SkRegion::Iterator iter(rgn);
+    while (!iter.done()) {
+        iter.next();
+    }
+}
+
+DEF_TEST(SkRegion_ReadFromMemory_SingleEmptySlice_Valid, reporter) {
+    constexpr int32_t kSentinel = 0x7FFFFFFF;
+    const int32_t valid[] = {
+        15,             // number of int32s in the RLE portion (after 7 metadata int32s)
+        0, 0, 100, 100, // bounds
+        3,              // 3 spans (1 is empty)
+        2,              // 2 rectangles
+        0, 5,           // first stripe is from Y=0 to Y=5,
+        1,              // 1 rectangle
+        0, 100,         // from x = 0 to 100 (arbitrary)
+        kSentinel,
+        80, 0, kSentinel, // Empty from  5-80
+        100, 1, 20, 30, kSentinel, // one final real rectangle
+        kSentinel, // final sentinal
+    };
+
+    SkRegion rgn;
+    size_t len = rgn.readFromMemory(&valid, sizeof(valid));
+    REPORTER_ASSERT(reporter, len > 0);  // len == 0 means "could not read"
+
+    // Make sure we don't read any memory we aren't supposed to.
+    SkRegion::Iterator iter(rgn);
+    while (!iter.done()) {
+        iter.next();
+    }
 }

--- a/tests/SkRuntimeEffectTest.cpp
+++ b/tests/SkRuntimeEffectTest.cpp
@@ -1795,3 +1795,45 @@ DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(GrSkSLFP_UniformArray,
     }
 }
 #endif
+
+DEF_TEST(SkRuntimeShader_b500080194, r) {
+    constexpr const char* kSkSL =
+        "half4 main(float2 xy) {"
+          "float4 v;"
+          "v.x += xy.x;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "(v = abs(v)).xyz;"
+          "return half4(v);"
+        "}";
+
+    auto [effect, err] = SkRuntimeEffect::MakeForShader(SkString(kSkSL));
+
+    if (!effect) {
+        REPORT_FAILURE(r, "SkSL compile failed", SkString("SkSL compile failed"));
+    } else {
+        sk_sp<SkShader> shader = effect->makeShader(/*uniforms=*/nullptr, {});
+        SkPaint paint;
+        paint.setShader(std::move(shader));
+        sk_sp<SkSurface> surface = SkSurfaces::Raster(SkImageInfo::MakeN32Premul(64, 64));
+        // This caused a crash before the patch.
+        surface->getCanvas()->drawPaint(paint);
+    }
+}


### PR DESCRIPTION
Automated upstream merge of `chrome/m147`.

# mono/skia PR: Merge upstream chrome/m147 bug fixes

## Summary

Same-milestone bug-fix sync. Merged 3 upstream commits from `chrome/m147` into `skia-sync/m147`.

## Upstream Commits Merged

| Commit | Description |
|--------|-------------|
| `dcbd374c13` | [m147] Avoid removing too many stack entries in SkRP during discard_stack |
| `4eda6e72ad` | [m147] Make local optimized copy of program when creating SkRP version |
| `6e0fbe154c` | [m147] Reject SkRegions with multiple empty slices in a row |

## Files Changed by Upstream

- `src/sksl/codegen/SkSLRasterPipelineBuilder.cpp` — SkRP discard_stack fix
- `include/effects/SkRuntimeEffect.h`, `src/core/SkRuntimeEffect.cpp` — SkRuntimeEffect optimization
- `include/core/SkRegion.h`, `src/core/SkRegion.cpp`, `src/core/SkRegionPriv.h` — SkRegion validation

## C API Changes

None. No files in `src/c/` or `include/c/` were modified by the upstream commits.

## Conflicts

None. Merge was clean (no conflicts).

## Items Needing Human Attention

None. This is a routine bug-fix merge with no breaking changes.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-track.lock.yml).