### PR TITLE
Fix NanoServer: use empty font manager instead of DirectWrite

### DIFF
--- a/src/c/sk_typeface.cpp
+++ b/src/c/sk_typeface.cpp
@@ -177,6 +177,8 @@ sk_fontmgr_t* sk_fontmgr_create_default(void) {
     return ToFontMgr(SkFontMgr_New_Android(nullptr, SkFontScanner_Make_FreeType()).release());
 #elif defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
     return ToFontMgr(SkFontMgr_New_CoreText(nullptr).release());
+#elif defined(SK_BUILD_FOR_NANOSERVER)
+    return ToFontMgr(SkFontMgr::RefEmpty().release());
 #elif defined(SK_BUILD_FOR_WIN)
     return ToFontMgr(SkFontMgr_New_DirectWrite().release());
 #elif defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
@@ -228,6 +230,9 @@ sk_typeface_t* sk_fontmgr_create_from_file(sk_fontmgr_t* fontmgr, const char* pa
 }
 
 sk_typeface_t* sk_fontmgr_legacy_create_typeface(sk_fontmgr_t* fontmgr, const char* familyName, sk_fontstyle_t* style) {
+    if (!fontmgr || !style) {
+        return nullptr;
+    }
     return ToTypeface(AsFontMgr(fontmgr)->legacyMakeTypeface(familyName, *AsFontStyle(style)).release());
 }
 


### PR DESCRIPTION
NanoServer has no DirectWrite, GDI, or font support. `sk_fontmgr_create_default` was returning a DirectWrite-based font manager that crashes on any font operation.

### Changes

1. **`sk_fontmgr_create_default`** — When `SK_BUILD_FOR_NANOSERVER` is defined, return `SkFontMgr::RefEmpty()` (a built-in empty font manager from Skia core) instead of `SkFontMgr_New_DirectWrite()`.

2. **`sk_fontmgr_legacy_create_typeface`** — Add null guards for `fontmgr` and `style` parameters, returning `nullptr` instead of dereferencing null.

### Context

The NanoServer native build already defines `SK_BUILD_FOR_NANOSERVER` via `extra_cflags`. The crash manifested as `AccessViolationException (0xC0000005)` at `sk_fontmgr_legacy_create_typeface` during `SKTypeface` static initialization when running Docker samples on Windows nanoserver containers.

Companion PR: mono/SkiaSharp#3835