### PR TITLE
Update libjpeg-turbo to 3.1.4.1

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -58,7 +58,7 @@ deps = {
   # "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
   # "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
   # "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
-  "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
+  "third_party/externals/libjpeg-turbo"          : "https://github.com/libjpeg-turbo/libjpeg-turbo.git@9217719d3a58633923b096af4c1d50d304768a64",
   # "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@3061454d980de7d53608f594194cfac722721d2a",
   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@4fa21912338357f89e4fd51cf2368325b59e9bd9",

--- a/third_party/libjpeg-turbo/BUILD.gn
+++ b/third_party/libjpeg-turbo/BUILD.gn
@@ -16,14 +16,39 @@ if (skia_use_system_libjpeg_turbo) {
     libs = [ "jpeg" ]
   }
 } else {
+  # NOTE: As of 3.1.4.1, we point DEPS directly at the upstream libjpeg-turbo
+  # commit (not Chromium's fork tip). The upstream source does not include
+  # pre-generated build config files because it relies on CMake's
+  # configure_file(). Since Skia uses GN (not CMake), we provide pre-baked
+  # versions of these files in this directory:
+  #
+  #   third_party/libjpeg-turbo/jconfig.h      - from src/jconfig.h.in
+  #   third_party/libjpeg-turbo/jconfigint.h   - from src/jconfigint.h.in
+  #   third_party/libjpeg-turbo/jversion.h     - from src/jversion.h.in
+  #   third_party/libjpeg-turbo/neon-compat.h  - from simd/arm/neon-compat.h.in
+  #
+  # When updating libjpeg-turbo, compare the .in templates and regenerate
+  # these files if the templates have changed. See the header comments in each
+  # file for the CMake substitution values used.
+
+  config("libjpeg_config") {
+    include_dirs = [
+      ".",
+      "../externals/libjpeg-turbo",
+      "../externals/libjpeg-turbo/src",
+    ]
+  }
+
   source_set("libjpeg_headers") {
+    public_configs = [ ":libjpeg_config" ]
     sources = [
-      "../externals/libjpeg-turbo/src/jconfig.h",
+      "jconfig.h",
+      "jconfigint.h",
+      "jversion.h",
       "../externals/libjpeg-turbo/src/jdct.h",
       "../externals/libjpeg-turbo/src/jinclude.h",
       "../externals/libjpeg-turbo/src/jmorecfg.h",
       "../externals/libjpeg-turbo/src/jpeglib.h",
-      "../externals/libjpeg-turbo/src/jpeglibmangler.h",
     ]
   }
 
@@ -106,6 +131,12 @@ if (skia_use_system_libjpeg_turbo) {
   static_library("libjpeg16") {
     sources = libjpeg16_sources
 
+    include_dirs = [
+      ".",
+      "../externals/libjpeg-turbo",
+      "../externals/libjpeg-turbo/src",
+    ]
+
     defines = [
       "NO_GETENV",
       "NO_PUTENV",
@@ -117,6 +148,12 @@ if (skia_use_system_libjpeg_turbo) {
 
   static_library("libjpeg12") {
     sources = libjpeg12_sources
+
+    include_dirs = [
+      ".",
+      "../externals/libjpeg-turbo",
+      "../externals/libjpeg-turbo/src",
+    ]
 
     defines = [
       "NO_GETENV",
@@ -176,7 +213,10 @@ if (skia_use_system_libjpeg_turbo) {
         "../externals/libjpeg-turbo/simd/arm/jidctred-neon.c",
         "../externals/libjpeg-turbo/simd/arm/jquanti-neon.c",
       ]
-      include_dirs = [ "../externals/libjpeg-turbo/simd/arm" ]
+      include_dirs = [
+        ".",
+        "../externals/libjpeg-turbo/simd/arm",
+      ]
       if (current_cpu == "arm") {
         sources += [
           "../externals/libjpeg-turbo/simd/arm/aarch32/jchuff-neon.c",

--- a/third_party/libjpeg-turbo/jconfig.h
+++ b/third_party/libjpeg-turbo/jconfig.h
@@ -1,0 +1,79 @@
+/* jconfig.h
+ *
+ * Pre-baked configuration for libjpeg-turbo when building with Skia's GN build
+ * system (which does not use CMake). Generated from src/jconfig.h.in in the
+ * upstream libjpeg-turbo repository.
+ *
+ * Upstream version: 3.1.4.1
+ * Template: src/jconfig.h.in
+ *
+ * CMake substitution values used:
+ *   JPEG_LIB_VERSION = 62 (default, no WITH_JPEG7/WITH_JPEG8)
+ *   VERSION = 3.1.4.1
+ *   LIBJPEG_TURBO_VERSION_NUMBER = 3001004
+ *   C_ARITH_CODING_SUPPORTED = undefined (controlled by BUILD.gn defines)
+ *   D_ARITH_CODING_SUPPORTED = undefined (controlled by BUILD.gn defines)
+ *   WITH_SIMD = undefined (controlled by BUILD.gn defines)
+ *   RIGHT_SHIFT_IS_UNSIGNED = undefined (not set on modern compilers)
+ */
+
+/* Version ID for the JPEG library.
+ * Might be useful for tests like "#if JPEG_LIB_VERSION >= 60".
+ */
+#define JPEG_LIB_VERSION  62
+
+/* libjpeg-turbo version */
+#define LIBJPEG_TURBO_VERSION  3.1.4.1
+
+/* libjpeg-turbo version in integer form */
+#define LIBJPEG_TURBO_VERSION_NUMBER  3001004
+
+/* Support arithmetic encoding when using 8-bit samples */
+/* #undef C_ARITH_CODING_SUPPORTED */
+
+/* Support arithmetic decoding when using 8-bit samples */
+/* #undef D_ARITH_CODING_SUPPORTED */
+
+/* Support in-memory source/destination managers */
+#define MEM_SRCDST_SUPPORTED  1
+
+/* Use accelerated SIMD routines when using 8-bit samples */
+/* #undef WITH_SIMD */
+
+/* This version of libjpeg-turbo supports run-time selection of data precision,
+ * so BITS_IN_JSAMPLE is no longer used to specify the data precision at build
+ * time.  However, some downstream software expects the macro to be defined.
+ * Since 12-bit data precision is an opt-in feature that requires explicitly
+ * calling 12-bit-specific libjpeg API functions and using 12-bit-specific data
+ * types, the unmodified portion of the libjpeg API still behaves as if it were
+ * built for 8-bit precision, and JSAMPLE is still literally an 8-bit data
+ * type.  Thus, it is correct to define BITS_IN_JSAMPLE to 8 here.
+ */
+#ifndef BITS_IN_JSAMPLE
+#define BITS_IN_JSAMPLE  8
+#endif
+
+#ifdef _WIN32
+
+#undef RIGHT_SHIFT_IS_UNSIGNED
+
+/* Define "boolean" as unsigned char, not int, per Windows custom */
+#ifndef __RPCNDR_H__            /* don't conflict if rpcndr.h already read */
+typedef unsigned char boolean;
+#endif
+#define HAVE_BOOLEAN            /* prevent jmorecfg.h from redefining it */
+
+/* Define "INT32" as int, not long, per Windows custom */
+#if !(defined(_BASETSD_H_) || defined(_BASETSD_H))   /* don't conflict if basetsd.h already read */
+typedef short INT16;
+typedef signed int INT32;
+#endif
+#define XMD_H                   /* prevent jmorecfg.h from redefining it */
+
+#else
+
+/* Define if your (broken) compiler shifts signed values as if they were
+   unsigned. */
+/* #undef RIGHT_SHIFT_IS_UNSIGNED */
+
+#endif

--- a/third_party/libjpeg-turbo/jconfigint.h
+++ b/third_party/libjpeg-turbo/jconfigint.h
@@ -1,0 +1,111 @@
+/*
+ * jconfigint.h - Pre-baked for libjpeg-turbo 3.1.4.1
+ *
+ * Generated from src/jconfigint.h.in with platform-adaptive macros.
+ * See BUILD.gn header comment for rationale.
+ */
+
+/* libjpeg-turbo build number */
+#define BUILD  ""
+
+/* How to hide global symbols. */
+#ifndef HIDDEN
+#if defined(__GNUC__)
+#define HIDDEN  __attribute__((visibility("hidden")))
+#else
+#define HIDDEN
+#endif
+#endif
+
+/* Compiler's inline keyword */
+#undef inline
+
+/* How to obtain function inlining. */
+#ifndef INLINE
+#if defined(__GNUC__)
+#define INLINE  inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define INLINE  __forceinline
+#else
+#define INLINE
+#endif
+#endif
+
+/* How to obtain thread-local storage */
+#if defined(_MSC_VER) && (defined(_WIN32) || defined(_WIN64))
+#define THREAD_LOCAL  __declspec(thread)
+#else
+#define THREAD_LOCAL  __thread
+#endif
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME  "libjpeg-turbo"
+
+/* Version number of package */
+#define VERSION  "3.1.4.1"
+
+/* The size of `size_t', as computed by sizeof. */
+#if defined(_WIN64) || defined(__LP64__) || defined(__x86_64__) || defined(__aarch64__) || defined(__ppc64__)
+#define SIZEOF_SIZE_T  8
+#else
+#define SIZEOF_SIZE_T  4
+#endif
+
+/* Define if your compiler has __builtin_ctzl() and sizeof(unsigned long) == sizeof(size_t).
+ * On Windows LLP64 (including clang-cl), sizeof(long)==4 but sizeof(size_t)==8,
+ * so __builtin_ctzl would truncate. Only enable when sizes match. */
+#if defined(__GNUC__) && defined(__SIZEOF_LONG__) && defined(__SIZEOF_SIZE_T__) && \
+    (__SIZEOF_LONG__ == __SIZEOF_SIZE_T__)
+#define HAVE_BUILTIN_CTZL
+#endif
+
+/* Define to 1 if you have the <intrin.h> header file. */
+#if defined(_MSC_VER)
+#define HAVE_INTRIN_H  1
+#endif
+
+#if defined(_MSC_VER) && defined(HAVE_INTRIN_H)
+#if (SIZEOF_SIZE_T == 8)
+#define HAVE_BITSCANFORWARD64
+#elif (SIZEOF_SIZE_T == 4)
+#define HAVE_BITSCANFORWARD
+#endif
+#endif
+
+#if defined(__has_attribute)
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH  __attribute__((fallthrough));
+#else
+#define FALLTHROUGH
+#endif
+#else
+#define FALLTHROUGH
+#endif
+
+/*
+ * Define BITS_IN_JSAMPLE as either
+ *   8   for 8-bit sample values (the usual setting)
+ *   12  for 12-bit sample values
+ * Only 8 and 12 are legal data precisions for lossy JPEG according to the
+ * JPEG standard, and the IJG code does not support anything else!
+ */
+
+#ifndef BITS_IN_JSAMPLE
+#define BITS_IN_JSAMPLE  8      /* use 8 or 12 */
+#endif
+
+/*
+ * Arithmetic coding and SIMD support are controlled by BUILD.gn defines,
+ * not by this header. The BUILD.gn file conditionally defines WITH_SIMD,
+ * C_ARITH_CODING_SUPPORTED, and D_ARITH_CODING_SUPPORTED as appropriate
+ * per-target and per-platform.
+ *
+ * Safety: upstream restricts these features to 8-bit precision only.
+ * Defensively undefine them for 12/16-bit builds in case BUILD.gn
+ * defines are ever flattened across targets.
+ */
+#if BITS_IN_JSAMPLE != 8
+#undef C_ARITH_CODING_SUPPORTED
+#undef D_ARITH_CODING_SUPPORTED
+#undef WITH_SIMD
+#endif

--- a/third_party/libjpeg-turbo/jversion.h
+++ b/third_party/libjpeg-turbo/jversion.h
@@ -1,0 +1,59 @@
+/*
+ * jversion.h
+ *
+ * This file was part of the Independent JPEG Group's software:
+ * Copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+ * libjpeg-turbo Modifications:
+ * Copyright (C) 2010, 2012-2026, D. R. Commander.
+ * For conditions of distribution and use, see the accompanying README.ijg
+ * file.
+ *
+ * This file contains software version identification.
+ *
+ * Pre-baked for libjpeg-turbo 3.1.4.1 (from src/jversion.h.in).
+ * See BUILD.gn header comment for rationale.
+ */
+
+
+#if JPEG_LIB_VERSION >= 80
+
+#define JVERSION        "8d  15-Jan-2012"
+
+#elif JPEG_LIB_VERSION >= 70
+
+#define JVERSION        "7  27-Jun-2009"
+
+#else
+
+#define JVERSION        "6b  27-Mar-1998"
+
+#endif
+
+/*
+ * NOTE: It is our convention to place the authors in the following order:
+ * - libjpeg-turbo authors (2009-) in descending order of the date of their
+ *   most recent contribution to the project, then in ascending order of the
+ *   date of their first contribution to the project, then in alphabetical
+ *   order
+ * - Upstream authors in descending order of the date of the first inclusion of
+ *   their code
+ */
+
+#define JCOPYRIGHT1 \
+  "Copyright (C) 2009-2026 D. R. Commander\n" \
+  "Copyright (C) 2015-2016, 2018, 2022 Matthieu Darbois\n" \
+  "Copyright (C) 2019-2021 Arm Limited\n" \
+  "Copyright (C) 2015, 2020 Google, Inc.\n" \
+  "Copyright (C) 2011, 2014, 2016 Siarhei Siamashka\n" \
+  "Copyright (C) 2015 Intel Corporation\n"
+#define JCOPYRIGHT2 \
+  "Copyright (C) 2013-2014 Linaro Limited\n" \
+  "Copyright (C) 2013-2014 MIPS Technologies, Inc.\n" \
+  "Copyright (C) 2009, 2012 Pierre Ossman for Cendio AB\n" \
+  "Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies)\n" \
+  "Copyright (C) 1999-2006 MIYASAKA Masaru\n" \
+  "Copyright (C) 1999 Ken Murchison\n" \
+  "Copyright (C) 1991-2020 Thomas G. Lane, Guido Vollbeding\n"
+
+#define JCOPYRIGHT_SHORT \
+  "Copyright (C) 1991-2026 The libjpeg-turbo Project and many others"

--- a/third_party/libjpeg-turbo/neon-compat.h
+++ b/third_party/libjpeg-turbo/neon-compat.h
@@ -1,0 +1,66 @@
+/* neon-compat.h
+ *
+ * Pre-baked NEON compatibility header for libjpeg-turbo when building with
+ * Skia's GN build system (which does not use CMake). Generated from
+ * simd/arm/neon-compat.h.in in the upstream libjpeg-turbo repository.
+ *
+ * Upstream version: 3.1.4.1
+ * Template: simd/arm/neon-compat.h.in
+ *
+ * CMake substitution values used:
+ *   HAVE_VLD1_S16_X3 = defined (available on Clang and MSVC)
+ *   HAVE_VLD1_U16_X2 = defined (available on Clang and MSVC)
+ *   HAVE_VLD1Q_U8_X4 = defined (available on Clang and MSVC)
+ *
+ * Note: These intrinsics are available on all compilers we target (Clang for
+ * all platforms, MSVC for Windows). GCC < 12 lacks them, but Skia does not
+ * build with GCC.
+ */
+
+/*
+ * Copyright (C) 2020, 2024, D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2020-2021, Arm Limited.  All Rights Reserved.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#if defined(__clang__) || defined(_MSC_VER)
+#define HAVE_VLD1_S16_X3
+#define HAVE_VLD1_U16_X2
+#define HAVE_VLD1Q_U8_X4
+#endif
+
+/* Define compiler-independent count-leading-zeros and byte-swap macros */
+#if defined(_MSC_VER) && !defined(__clang__)
+#define BUILTIN_CLZ(x)  _CountLeadingZeros(x)
+#define BUILTIN_CLZLL(x)  _CountLeadingZeros64(x)
+#define BUILTIN_BSWAP64(x)  _byteswap_uint64(x)
+#elif defined(__clang__) || defined(__GNUC__)
+#define BUILTIN_CLZ(x)  __builtin_clz(x)
+#define BUILTIN_CLZLL(x)  __builtin_clzll(x)
+#define BUILTIN_BSWAP64(x)  __builtin_bswap64(x)
+#else
+#error "Unknown compiler"
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wdeclaration-after-statement"
+#pragma clang diagnostic ignored "-Wc99-extensions"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif


### PR DESCRIPTION
Context: https://github.com/mono/SkiaSharp/issues/3689
Changes: https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.1.0...3.1.4.1

Switch DEPS from Chromium's libjpeg-turbo fork to the upstream GitHub repo
(libjpeg-turbo/libjpeg-turbo) at tag 3.1.4.1 (commit 9217719d). Chromium's
fork has not rolled past 3.1.0, so pointing directly at upstream is the only
way to pick up the new release.

Since upstream relies on CMake's configure_file() and Skia uses GN, we provide
pre-baked versions of the four generated config headers:

- `jconfig.h` (from `src/jconfig.h.in`)
- `jconfigint.h` (from `src/jconfigint.h.in`)
- `jversion.h` (from `src/jversion.h.in`)
- `neon-compat.h` (from `simd/arm/neon-compat.h.in`)

BUILD.gn gains a `config("libjpeg_config")` with `public_configs` on
`libjpeg_headers` so all dependents (including libjpeg12/libjpeg16) resolve
the overlay headers. The SIMD target also picks up `"."` in include_dirs.

### Improvements over what Chromium shipped

- `HAVE_BUILTIN_CTZL` guarded by `__SIZEOF_LONG__ == __SIZEOF_SIZE_T__` to prevent silent truncation on Windows clang-cl (LLP64: long=4, size_t=8)
- `SIZEOF_SIZE_T` uses compiler-defined macros instead of glibc's `__WORDSIZE`
- `HAVE_VLD1_*` NEON intrinsics guarded by `__clang__ || _MSC_VER` (matches Chromium; upstream uses a CMake compile-test)
- Defensive `#undef` of `C_ARITH`/`D_ARITH`/`WITH_SIMD` for `BITS_IN_JSAMPLE != 8`

### Verification

- ✅ Native build (macOS arm64)
- ✅ Tests: 5662 passed, 0 failed (1 pre-existing unrelated failure)

Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/4012