### PR TITLE
Update expat to 2.8.1

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -48,7 +48,7 @@ deps = {
   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
   # "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
   # "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@c69d433d8509c5c64564c2f0d054bf102a5cf67e",
-  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@f31adfd584b7f6c50bbf4d22eb928538ffc9145a",
+  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@c7ffbf3879f6aef7a7b020ef84ddb4ee00222b19",
   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@0a0221a1347e2f1e07c395263540026e9a0aa7c7",
   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@b0ffab42d473eb380ad0fcf42730e0f1868cbc97",
   # "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",

--- a/third_party/expat/BUILD.gn
+++ b/third_party/expat/BUILD.gn
@@ -44,6 +44,29 @@ if (skia_use_system_expat) {
       "$_src/expat/lib/xmltok_impl.h",
     ]
 
+    if (is_win) {
+      sources += [
+        "$_src/expat/lib/random_rand_s.c",
+        "$_src/expat/lib/random_rand_s.h",
+      ]
+    } else if (is_mac || is_ios) {
+      sources += [
+        "$_src/expat/lib/random_arc4random_buf.c",
+        "$_src/expat/lib/random_arc4random_buf.h",
+      ]
+    } else {
+      sources += [
+        "$_src/expat/lib/random_dev_urandom.c",
+        "$_src/expat/lib/random_dev_urandom.h",
+      ]
+      if (is_android || (is_linux && !is_tizen)) {
+        sources += [
+          "$_src/expat/lib/random_getrandom.c",
+          "$_src/expat/lib/random_getrandom.h",
+        ]
+      }
+    }
+
     unused_sources = [
       # Not independently compiled, but conditionally included in xmltok.c
       "$_src/expat/lib/xmltok_impl.c",


### PR DESCRIPTION
Updates libexpat from 2.7.5 to 2.8.1.

Changes:
- `DEPS`: updated commit hash
- `third_party/expat/BUILD.gn`: added platform-conditional random source files (refactored out of `xmlparse.c` upstream in 2.8.x)

Build verified locally on macOS arm64.

Required SkiaSharp PR: https://github.com/mono/SkiaSharp/pull/4079