### PR TITLE
Add sk_imagefilter_new_empty() C API

### DIFF
--- a/include/c/sk_imagefilter.h
+++ b/include/c/sk_imagefilter.h
@@ -18,6 +18,7 @@ SK_C_PLUS_PLUS_BEGIN_GUARD
 // sk_imagefilter_t
 
 SK_C_API void sk_imagefilter_unref(sk_imagefilter_t* cfilter);
+SK_C_API sk_imagefilter_t* sk_imagefilter_new_empty(void);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_arithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor, const sk_imagefilter_t* background, const sk_imagefilter_t* foreground, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_blend(sk_blendmode_t mode, const sk_imagefilter_t* background, const sk_imagefilter_t* foreground, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_blender(sk_blender_t* blender, const sk_imagefilter_t* background, const sk_imagefilter_t* foreground, const sk_rect_t* cropRect);

--- a/src/c/sk_imagefilter.cpp
+++ b/src/c/sk_imagefilter.cpp
@@ -24,6 +24,10 @@ void sk_imagefilter_unref(sk_imagefilter_t* cfilter) {
     SkSafeUnref(AsImageFilter(cfilter));
 }
 
+sk_imagefilter_t* sk_imagefilter_new_empty(void) {
+    return ToImageFilter(SkImageFilters::Empty().release());
+}
+
 sk_imagefilter_t* sk_imagefilter_new_arithmetic(float k1, float k2, float k3, float k4, bool enforcePMColor, const sk_imagefilter_t* background, const sk_imagefilter_t* foreground, const sk_rect_t* cropRect) {
     return ToImageFilter(SkImageFilters::Arithmetic(k1, k2, k3, k4, enforcePMColor, sk_ref_sp(AsImageFilter(background)), sk_ref_sp(AsImageFilter(foreground)), AsRect(cropRect)).release());
 }


### PR DESCRIPTION
Wraps SkImageFilters::Empty() which returns a transparent-black image filter (identity/no-op for filter chains).

Part of mono/SkiaSharp#3937

## Changes
- Added `sk_imagefilter_new_empty(void)` to `include/c/sk_imagefilter.h`
- Implemented wrapper in `src/c/sk_imagefilter.cpp` calling `SkImageFilters::Empty().release()`

## Notes
- Each call creates a new ref-counted sk_sp instance (not a singleton)
- Follows existing pattern for other image filter factory functions
- Will be consumed by SkiaSharp C# wrapper

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>