### PR TITLE
Add sk_imagefilter_new_crop C API

### DIFF
--- a/include/c/sk_imagefilter.h
+++ b/include/c/sk_imagefilter.h
@@ -25,6 +25,7 @@ SK_C_API sk_imagefilter_t* sk_imagefilter_new_blender(sk_blender_t* blender, con
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_blur(float sigmaX, float sigmaY, sk_shader_tilemode_t tileMode, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_color_filter(sk_colorfilter_t* cf, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_compose(const sk_imagefilter_t* outer, const sk_imagefilter_t* inner);
+SK_C_API sk_imagefilter_t* sk_imagefilter_new_crop(const sk_rect_t* rect, sk_shader_tilemode_t tileMode, const sk_imagefilter_t* input);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_displacement_map_effect(sk_color_channel_t xChannelSelector, sk_color_channel_t yChannelSelector, float scale, const sk_imagefilter_t* displacement, const sk_imagefilter_t* color, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_drop_shadow(float dx, float dy, float sigmaX, float sigmaY, sk_color_t color, const sk_imagefilter_t* input, const sk_rect_t* cropRect);
 SK_C_API sk_imagefilter_t* sk_imagefilter_new_drop_shadow_only(float dx, float dy, float sigmaX, float sigmaY, sk_color_t color, const sk_imagefilter_t* input, const sk_rect_t* cropRect);

--- a/src/c/sk_imagefilter.cpp
+++ b/src/c/sk_imagefilter.cpp
@@ -52,6 +52,10 @@ sk_imagefilter_t* sk_imagefilter_new_compose(const sk_imagefilter_t* outer, cons
     return ToImageFilter(SkImageFilters::Compose(sk_ref_sp(AsImageFilter(outer)), sk_ref_sp(AsImageFilter(inner))).release());
 }
 
+sk_imagefilter_t* sk_imagefilter_new_crop(const sk_rect_t* rect, sk_shader_tilemode_t tileMode, const sk_imagefilter_t* input) {
+    return ToImageFilter(SkImageFilters::Crop(*AsRect(rect), (SkTileMode)tileMode, sk_ref_sp(AsImageFilter(input))).release());
+}
+
 sk_imagefilter_t* sk_imagefilter_new_displacement_map_effect(sk_color_channel_t xChannelSelector, sk_color_channel_t yChannelSelector, float scale, const sk_imagefilter_t* displacement, const sk_imagefilter_t* color, const sk_rect_t* cropRect) {
     return ToImageFilter(SkImageFilters::DisplacementMap((SkColorChannel)xChannelSelector, (SkColorChannel)yChannelSelector, scale, sk_ref_sp(AsImageFilter(displacement)), sk_ref_sp(AsImageFilter(color)), AsRect(cropRect)).release());
 }


### PR DESCRIPTION
Wraps SkImageFilters::Crop(const SkRect& rect, SkTileMode tileMode, sk_sp<SkImageFilter> input).

This is the modern replacement for the deprecated cropRect parameter pattern on individual filters.

Fixes mono/SkiaSharp#3938

## Changes
- Added sk_imagefilter_new_crop to sk_imagefilter.h
- Implemented wrapper in sk_imagefilter.cpp

## Testing
Tested in mono/SkiaSharp#TBD with comprehensive C# tests.