### PR TITLE
Add sk_colorfilter_new_overdraw C API

### DIFF
--- a/include/c/sk_colorfilter.h
+++ b/include/c/sk_colorfilter.h
@@ -27,6 +27,7 @@ SK_C_API sk_colorfilter_t* sk_colorfilter_new_luma_color(void);
 SK_C_API sk_colorfilter_t* sk_colorfilter_new_high_contrast(const sk_highcontrastconfig_t* config);
 SK_C_API sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t table[256]);
 SK_C_API sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t tableA[256], const uint8_t tableR[256], const uint8_t tableG[256], const uint8_t tableB[256]);
+SK_C_API sk_colorfilter_t* sk_colorfilter_new_overdraw(const sk_color_t colors[6]);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/src/c/sk_colorfilter.cpp
+++ b/src/c/sk_colorfilter.cpp
@@ -11,6 +11,7 @@
 #include "include/effects/SkColorMatrixFilter.h"
 #include "include/effects/SkHighContrastFilter.h"
 #include "include/effects/SkLumaColorFilter.h"
+#include "include/effects/SkOverdrawColorFilter.h"
 
 #include "include/c/sk_colorfilter.h"
 
@@ -66,4 +67,8 @@ sk_colorfilter_t* sk_colorfilter_new_table(const uint8_t table[256]) {
 
 sk_colorfilter_t* sk_colorfilter_new_table_argb(const uint8_t tableA[256], const uint8_t tableR[256], const uint8_t tableG[256], const uint8_t tableB[256]) {
     return ToColorFilter(SkColorFilters::TableARGB(tableA, tableR, tableG, tableB).release());
+}
+
+sk_colorfilter_t* sk_colorfilter_new_overdraw(const sk_color_t colors[6]) {
+    return ToColorFilter(SkOverdrawColorFilter::MakeWithSkColors(colors).release());
 }


### PR DESCRIPTION
C API for SKColorFilter.CreateOverdraw() - wraps SkOverdrawColorFilter::MakeWithSkColors.

Maps overdraw counts (0-5+) to a 6-color palette for rendering performance debugging.

Part of mono/SkiaSharp#3941 and mono/SkiaSharp#4227