### PR TITLE
Add sk_codec_is_animated C API

### DIFF
--- a/include/c/sk_codec.h
+++ b/include/c/sk_codec.h
@@ -14,6 +14,12 @@
 
 SK_C_PLUS_PLUS_BEGIN_GUARD
 
+typedef enum {
+    SK_CODEC_ANIMATION_STATUS_YES,
+    SK_CODEC_ANIMATION_STATUS_NO,
+    SK_CODEC_ANIMATION_STATUS_UNKNOWN,
+} sk_codec_animation_status_t;
+
 SK_C_API size_t sk_codec_min_buffered_bytes_needed(void);
 
 SK_C_API sk_codec_t* sk_codec_new_from_stream(sk_stream_t* stream, sk_codec_result_t* result);
@@ -37,6 +43,7 @@ SK_C_API int sk_codec_get_frame_count(sk_codec_t* codec);
 SK_C_API void sk_codec_get_frame_info(sk_codec_t* codec, sk_codec_frameinfo_t* frameInfo);
 SK_C_API bool sk_codec_get_frame_info_for_index(sk_codec_t* codec, int index, sk_codec_frameinfo_t* frameInfo);
 SK_C_API int sk_codec_get_repetition_count(sk_codec_t* codec);
+SK_C_API sk_codec_animation_status_t sk_codec_is_animated(sk_codec_t* codec);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/src/c/sk_codec.cpp
+++ b/src/c/sk_codec.cpp
@@ -106,3 +106,7 @@ bool sk_codec_get_frame_info_for_index(sk_codec_t* codec, int index, sk_codec_fr
 int sk_codec_get_repetition_count(sk_codec_t* codec) {
     return AsCodec(codec)->getRepetitionCount();
 }
+
+sk_codec_animation_status_t sk_codec_is_animated(sk_codec_t* codec) {
+    return (sk_codec_animation_status_t)AsCodec(codec)->isAnimated();
+}

--- a/src/c/sk_codec.cpp
+++ b/src/c/sk_codec.cpp
@@ -108,5 +108,6 @@ int sk_codec_get_repetition_count(sk_codec_t* codec) {
 }
 
 sk_codec_animation_status_t sk_codec_is_animated(sk_codec_t* codec) {
-    return (sk_codec_animation_status_t)AsCodec(codec)->isAnimated();
+    SkCodec::IsAnimated result = AsCodec(codec)->isAnimated();
+    return static_cast<sk_codec_animation_status_t>(static_cast<int>(result));
 }


### PR DESCRIPTION
Add C API for `isAnimated()` to disambiguate `RepetitionCount == 0`.

## C API changes

- Added `sk_codec_animation_status_t` enum (YES=0, NO=1, UNKNOWN=2)
- Added `sk_codec_is_animated()` function

## Implementation notes

Uses explicit `static_cast<int>()` to convert C++ `enum class` to C enum. C-style cast does not work correctly for enum class types - it was causing all values to be returned incorrectly, making the API non-functional.

Per Skia's own tests (`tests/CodecAnimTest.cpp`): animated images with `FrameCount > 1` return `IsAnimated::kYes`, static images return `IsAnimated::kNo`.

Fixes mono/SkiaSharp#3939