### PR TITLE
[skia-sync] Merge upstream chrome/m148

### DIFF
--- a/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
+++ b/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
@@ -9,7 +9,8 @@
 
 #include "include/gpu/graphite/TextureInfo.h"
 #include "include/gpu/graphite/dawn/DawnGraphiteTypes.h"
-#include "include/private/base/SkTemplates.h"
+#include "include/private/base/SkTArray.h"
+#include "src/base/SkTBlockList.h"
 #include "src/core/SkTraceEvent.h"
 #include "src/gpu/SkSLToBackend.h"
 #include "src/gpu/Swizzle.h"
@@ -34,7 +35,8 @@
 #include "src/sksl/ir/SkSLProgram.h"
 
 #include <atomic>
-#include <vector>
+
+using namespace skia_private;
 
 namespace skgpu::graphite {
 
@@ -152,7 +154,7 @@ wgpu::StencilFaceState stencil_face_to_dawn(DepthStencilSettings::Face face) {
 
 size_t create_vertex_attributes(SkSpan<const Attribute> attrs,
                                 int shaderLocationOffset,
-                                std::vector<wgpu::VertexAttribute>* out) {
+                                TArray<wgpu::VertexAttribute>* out) {
     SkASSERT(out && out->empty());
     out->resize(attrs.size());
     size_t vertexAttributeOffset = 0;
@@ -499,12 +501,16 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
                 !(samplerDescArrPtr && samplerDescArrPtr->at(0).isImmutable())) {
                 groupLayouts[1] = sharedContext->getSingleTextureSamplerBindGroupLayout();
             } else {
-                std::vector<wgpu::BindGroupLayoutEntry> entries(numTexturesAndSamplers);
+                TArray<wgpu::BindGroupLayoutEntry> entries;
+                entries.reset(numTexturesAndSamplers);
+
 #if !defined(__EMSCRIPTEN__)
                 // Static sampler layouts are passed into Dawn by address and therefore must stay
                 // alive until the BindGroupLayoutDescriptor is created. So, store them outside of
-                // the loop that iterates over each BindGroupLayoutEntry.
-                skia_private::TArray<wgpu::StaticSamplerBindingLayout> staticSamplerLayouts;
+                // the loop that iterates over each BindGroupLayoutEntry. Use a TBlockList so that
+                // any append StaticSamplerBindingLayouts have a stable address in case we have to
+                // grow the collection.
+                SkTBlockList<wgpu::StaticSamplerBindingLayout, 1> staticSamplerLayouts;
 
                 // Note that the number of samplers is equivalent to numTexturesAndSamplers / 2. So,
                 // a sampler's index within any container that only pertains to sampler information
@@ -598,7 +604,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     // Vertex state
     std::array<wgpu::VertexBufferLayout, kNumVertexBuffers> vertexBufferLayouts;
     // Static data buffer layout
-    std::vector<wgpu::VertexAttribute> staticDataAttributes;
+    TArray<wgpu::VertexAttribute> staticDataAttributes;
     {
         auto arrayStride = create_vertex_attributes(step->staticAttributes(),
                                                     0,
@@ -622,7 +628,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     }
 
     // Append data buffer layout
-    std::vector<wgpu::VertexAttribute> appendDataAttributes;
+    TArray<wgpu::VertexAttribute> appendDataAttributes;
     {
         // Note: the shaderLocationOffset in this function call needs to be the staticAttributeSize
         auto arrayStride = create_vertex_attributes(step->appendAttributes(),

--- a/src/ports/SkTypeface_mac_ct.cpp
+++ b/src/ports/SkTypeface_mac_ct.cpp
@@ -604,9 +604,9 @@ static SK_SFNT_ULONG get_font_type_tag(CTFontRef ctFont) {
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const {
     *ttcIndex = 0;
 
-    fInitStream([this]{
+    SkAutoSharedMutexExclusive sm(fStreamMutex);
     if (fStream) {
-        return;
+        return fStream->duplicate();
     }
 
     SK_SFNT_ULONG fontType = get_font_type_tag(fFontRef.get());
@@ -704,12 +704,12 @@ std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const
         ++entry;
     }
     fStream = std::make_unique<SkMemoryStream>(std::move(streamData));
-    });
     return fStream->duplicate();
 }
 
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenExistingStream(int* ttcIndex) const {
     *ttcIndex = 0;
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return fStream ? fStream->duplicate() : nullptr;
 }
 
@@ -1220,7 +1220,7 @@ sk_sp<SkTypeface> SkTypeface_Mac::onMakeClone(const SkFontArguments& args) const
     if (!ctVariant) {
         return nullptr;
     }
-
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return SkTypeface_Mac::Make(std::move(ctVariant), ctVariation.opsz,
                                 fStream ? fStream->duplicate() : nullptr);
 }

--- a/src/ports/SkTypeface_mac_ct.h
+++ b/src/ports/SkTypeface_mac_ct.h
@@ -19,6 +19,7 @@
 #include "include/core/SkStream.h"
 #include "include/core/SkTypeface.h"
 #include "include/private/base/SkOnce.h"
+#include "src/base/SkSharedMutex.h"
 #include "src/utils/mac/SkUniqueCFRef.h"
 
 #ifdef SK_BUILD_FOR_MAC
@@ -129,8 +130,8 @@ protected:
 private:
     mutable std::unique_ptr<SkStreamAsset> fStream;
     mutable SkUniqueCFRef<CFArrayRef> fVariationAxes;
+    mutable SkSharedMutex fStreamMutex;
     bool fIsFromStream;
-    mutable SkOnce fInitStream;
     mutable SkOnce fInitVariationAxes;
 
     using INHERITED = SkTypeface;


### PR DESCRIPTION
Automated upstream merge of `chrome/m148`.

## Skia upstream sync — release-line `release/4.148.x` (m148 → m148 bug fixes)

This is a **bug-fix-only sync** on the release line. The sync brings the
`release/4.148.x` branch in `mono/skia` up to the current tip of upstream
`google/skia` `chrome/m148`. Because `CURRENT == TARGET`, no milestone bump
or build-config changes are involved.

### Upstream merge

Merged `upstream/chrome/m148` (tip `46f2e16555cac1211f4087cf24728fd741ac6495`)
into `skia-sync/release-4.148.x` on top of the previous m148 pin
(`1a155bae3a` — the tip of `release/4.148.x` before this sync).

New upstream commits pulled in (oldest → newest):

| SHA | Subject | Touched paths |
|-----|---------|---------------|
| `3a90f6662a` | `[graphite] Use stable collection for static bindings` | `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp` |
| `46f2e16555` | `[m148] Resolved a Data Race on fStream in SkTypeface_Mac` | `src/ports/SkTypeface_mac_ct.{cpp,h}` |

The merge was created with `git merge --no-commit upstream/chrome/m148`
followed by `git commit`, producing a proper two-parent merge commit
(`d5c1f3f66dfc7c41f32240191b9a33bb55758f89`) with attribution preserved.

### Conflicts resolved

**None.** `Automatic merge went well; stopped before committing as requested.`
No `git diff --check` issues, no conflict markers, and no SkiaSharp fork
patches needed re-application — neither upstream commit overlaps any file
we maintain in the fork.

### C API fixes

**None required.** Both upstream commits touch only upstream-only sources:

- `src/ports/SkTypeface_mac_ct.{cpp,h}` — Apple/CoreText typeface backend
  (not part of our `include/c/` / `src/c/` shim).
- `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp` — Graphite/Dawn GPU
  backend. SkiaSharp uses Ganesh, not Graphite, so this file is not built
  into `libSkiaSharp`.

Our C API shim (`src/c/*.cpp`, `include/c/*.h`) is unchanged.
`SK_C_INCREMENT` remains `0` in `include/c/sk_types.h`, and the
SkiaSharp-side regenerated bindings show no diff.

### Source-file inventory

`git diff` from the previous m148 pin to upstream's new tip shows no files
added or removed under `src/` or `include/`, so no `BUILD.gn` adjustments
are needed and no upstream-side files were dropped.

### Items needing human attention

None. This is a clean bug-fix sync with no unresolved questions.

### Verification

- ✅ Merge commit has two parents and preserves `git blame` attribution
- ✅ Zero conflict markers (`git diff --check` clean)
- ✅ C API files intact (`ls src/c/*.cpp include/c/*.h` matches pre-merge)
- ✅ Native `libSkiaSharp.so.148.0.0` builds on Linux x64 from this submodule SHA

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).