### PR TITLE
[skia-sync] Merge upstream chrome/m148

### DIFF
--- a/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
+++ b/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
@@ -9,7 +9,8 @@
 
 #include "include/gpu/graphite/TextureInfo.h"
 #include "include/gpu/graphite/dawn/DawnGraphiteTypes.h"
-#include "include/private/base/SkTemplates.h"
+#include "include/private/base/SkTArray.h"
+#include "src/base/SkTBlockList.h"
 #include "src/core/SkTraceEvent.h"
 #include "src/gpu/SkSLToBackend.h"
 #include "src/gpu/Swizzle.h"
@@ -34,7 +35,8 @@
 #include "src/sksl/ir/SkSLProgram.h"
 
 #include <atomic>
-#include <vector>
+
+using namespace skia_private;
 
 namespace skgpu::graphite {
 
@@ -152,7 +154,7 @@ wgpu::StencilFaceState stencil_face_to_dawn(DepthStencilSettings::Face face) {
 
 size_t create_vertex_attributes(SkSpan<const Attribute> attrs,
                                 int shaderLocationOffset,
-                                std::vector<wgpu::VertexAttribute>* out) {
+                                TArray<wgpu::VertexAttribute>* out) {
     SkASSERT(out && out->empty());
     out->resize(attrs.size());
     size_t vertexAttributeOffset = 0;
@@ -499,12 +501,16 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
                 !(samplerDescArrPtr && samplerDescArrPtr->at(0).isImmutable())) {
                 groupLayouts[1] = sharedContext->getSingleTextureSamplerBindGroupLayout();
             } else {
-                std::vector<wgpu::BindGroupLayoutEntry> entries(numTexturesAndSamplers);
+                TArray<wgpu::BindGroupLayoutEntry> entries;
+                entries.reset(numTexturesAndSamplers);
+
 #if !defined(__EMSCRIPTEN__)
                 // Static sampler layouts are passed into Dawn by address and therefore must stay
                 // alive until the BindGroupLayoutDescriptor is created. So, store them outside of
-                // the loop that iterates over each BindGroupLayoutEntry.
-                skia_private::TArray<wgpu::StaticSamplerBindingLayout> staticSamplerLayouts;
+                // the loop that iterates over each BindGroupLayoutEntry. Use a TBlockList so that
+                // any append StaticSamplerBindingLayouts have a stable address in case we have to
+                // grow the collection.
+                SkTBlockList<wgpu::StaticSamplerBindingLayout, 1> staticSamplerLayouts;
 
                 // Note that the number of samplers is equivalent to numTexturesAndSamplers / 2. So,
                 // a sampler's index within any container that only pertains to sampler information
@@ -598,7 +604,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     // Vertex state
     std::array<wgpu::VertexBufferLayout, kNumVertexBuffers> vertexBufferLayouts;
     // Static data buffer layout
-    std::vector<wgpu::VertexAttribute> staticDataAttributes;
+    TArray<wgpu::VertexAttribute> staticDataAttributes;
     {
         auto arrayStride = create_vertex_attributes(step->staticAttributes(),
                                                     0,
@@ -622,7 +628,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     }
 
     // Append data buffer layout
-    std::vector<wgpu::VertexAttribute> appendDataAttributes;
+    TArray<wgpu::VertexAttribute> appendDataAttributes;
     {
         // Note: the shaderLocationOffset in this function call needs to be the staticAttributeSize
         auto arrayStride = create_vertex_attributes(step->appendAttributes(),

--- a/src/ports/SkTypeface_mac_ct.cpp
+++ b/src/ports/SkTypeface_mac_ct.cpp
@@ -604,9 +604,9 @@ static SK_SFNT_ULONG get_font_type_tag(CTFontRef ctFont) {
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const {
     *ttcIndex = 0;
 
-    fInitStream([this]{
+    SkAutoSharedMutexExclusive sm(fStreamMutex);
     if (fStream) {
-        return;
+        return fStream->duplicate();
     }
 
     SK_SFNT_ULONG fontType = get_font_type_tag(fFontRef.get());
@@ -704,12 +704,12 @@ std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const
         ++entry;
     }
     fStream = std::make_unique<SkMemoryStream>(std::move(streamData));
-    });
     return fStream->duplicate();
 }
 
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenExistingStream(int* ttcIndex) const {
     *ttcIndex = 0;
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return fStream ? fStream->duplicate() : nullptr;
 }
 
@@ -1220,7 +1220,7 @@ sk_sp<SkTypeface> SkTypeface_Mac::onMakeClone(const SkFontArguments& args) const
     if (!ctVariant) {
         return nullptr;
     }
-
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return SkTypeface_Mac::Make(std::move(ctVariant), ctVariation.opsz,
                                 fStream ? fStream->duplicate() : nullptr);
 }

--- a/src/ports/SkTypeface_mac_ct.h
+++ b/src/ports/SkTypeface_mac_ct.h
@@ -19,6 +19,7 @@
 #include "include/core/SkStream.h"
 #include "include/core/SkTypeface.h"
 #include "include/private/base/SkOnce.h"
+#include "src/base/SkSharedMutex.h"
 #include "src/utils/mac/SkUniqueCFRef.h"
 
 #ifdef SK_BUILD_FOR_MAC
@@ -129,8 +130,8 @@ protected:
 private:
     mutable std::unique_ptr<SkStreamAsset> fStream;
     mutable SkUniqueCFRef<CFArrayRef> fVariationAxes;
+    mutable SkSharedMutex fStreamMutex;
     bool fIsFromStream;
-    mutable SkOnce fInitStream;
     mutable SkOnce fInitVariationAxes;
 
     using INHERITED = SkTypeface;


### PR DESCRIPTION
Automated upstream merge of `chrome/m148`.

## Upstream merge

Merged `upstream/chrome/m148` (`46f2e16555cac1211f4087cf24728fd741ac6495`) into
`skia-sync/release-4.148.x` on top of the existing release-line tip
(`1a155bae3ac86db6d3efbd996f00e774b6a7b722`, which was the m148 merge that shipped in 4.148.0).

This is a **release-line, bug-fix-only sync** (current `m148` == target `m148`).
Two upstream cherry-picks were applied since the last sync (`54851b68b`):

| SHA | Subject | Files touched | Affects SkiaSharp? |
|-----|---------|---------------|--------------------|
| `46f2e16555` | `[m148] Resolved a Data Race on fStream in SkTypeface_Mac` | `src/ports/SkTypeface_mac_ct.{cpp,h}` | Yes (macOS only) — eliminates a TOCTOU race on `fStream` in the global `gTFCache` |
| `3a90f6662a` | `[graphite] Use stable collection for static bindings` | `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp` | No — Graphite/Dawn-only; SkiaSharp ships Ganesh, not Graphite |

## Conflicts resolved

None. `git merge --no-commit upstream/chrome/m148` reported
"Automatic merge went well; stopped before committing as requested" and `git diff --check`
showed zero conflict markers. The C API shim (`src/c/*.cpp`, `include/c/*.h`,
`include/xamarin/**`) was untouched by both upstream commits.

## C API fixes

None. Neither commit touches headers consumed by `src/c/` or `include/c/`, so no
shim adaptation was needed. `SK_C_INCREMENT` (in `include/c/sk_types.h`) is unchanged.

## Build verification

- `dotnet cake --target=externals-linux --arch=x64` succeeded (`libSkiaSharp 14m04s`,
  `libHarfBuzzSharp 01m12s`, total 15m28s). The resulting `libSkiaSharp.so.148.0.0`
  links cleanly with the documented dependency set (`libfontconfig.so.1`, `libc++.so.1`,
  `libc++abi.so.1`, `libunwind.so.1`, libm/libc/ld-linux).
- macOS / Windows / Android / iOS native builds are NOT exercised by this workflow —
  the actual cherry-pick (`SkTypeface_mac_ct`) is Mac-only, so the multi-platform CI
  on the resulting PR is the source of truth for that file.

## Items needing human attention

- **macOS native validation.** The headline fix is macOS-only and cannot be compiled on
  the Linux CI used for this sync. Verify the macOS leg of the resulting PR's
  cross-platform build passes before merging.
- **No DEPS or BUILD.gn changes.** This is purely a source-only sync; depot_tools/gn
  metadata is untouched.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).