### PR TITLE
[skia-sync] Merge upstream chrome/m148

### DIFF
--- a/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
+++ b/src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp
@@ -9,7 +9,8 @@
 
 #include "include/gpu/graphite/TextureInfo.h"
 #include "include/gpu/graphite/dawn/DawnGraphiteTypes.h"
-#include "include/private/base/SkTemplates.h"
+#include "include/private/base/SkTArray.h"
+#include "src/base/SkTBlockList.h"
 #include "src/core/SkTraceEvent.h"
 #include "src/gpu/SkSLToBackend.h"
 #include "src/gpu/Swizzle.h"
@@ -34,7 +35,8 @@
 #include "src/sksl/ir/SkSLProgram.h"
 
 #include <atomic>
-#include <vector>
+
+using namespace skia_private;
 
 namespace skgpu::graphite {
 
@@ -152,7 +154,7 @@ wgpu::StencilFaceState stencil_face_to_dawn(DepthStencilSettings::Face face) {
 
 size_t create_vertex_attributes(SkSpan<const Attribute> attrs,
                                 int shaderLocationOffset,
-                                std::vector<wgpu::VertexAttribute>* out) {
+                                TArray<wgpu::VertexAttribute>* out) {
     SkASSERT(out && out->empty());
     out->resize(attrs.size());
     size_t vertexAttributeOffset = 0;
@@ -499,12 +501,16 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
                 !(samplerDescArrPtr && samplerDescArrPtr->at(0).isImmutable())) {
                 groupLayouts[1] = sharedContext->getSingleTextureSamplerBindGroupLayout();
             } else {
-                std::vector<wgpu::BindGroupLayoutEntry> entries(numTexturesAndSamplers);
+                TArray<wgpu::BindGroupLayoutEntry> entries;
+                entries.reset(numTexturesAndSamplers);
+
 #if !defined(__EMSCRIPTEN__)
                 // Static sampler layouts are passed into Dawn by address and therefore must stay
                 // alive until the BindGroupLayoutDescriptor is created. So, store them outside of
-                // the loop that iterates over each BindGroupLayoutEntry.
-                skia_private::TArray<wgpu::StaticSamplerBindingLayout> staticSamplerLayouts;
+                // the loop that iterates over each BindGroupLayoutEntry. Use a TBlockList so that
+                // any append StaticSamplerBindingLayouts have a stable address in case we have to
+                // grow the collection.
+                SkTBlockList<wgpu::StaticSamplerBindingLayout, 1> staticSamplerLayouts;
 
                 // Note that the number of samplers is equivalent to numTexturesAndSamplers / 2. So,
                 // a sampler's index within any container that only pertains to sampler information
@@ -598,7 +604,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     // Vertex state
     std::array<wgpu::VertexBufferLayout, kNumVertexBuffers> vertexBufferLayouts;
     // Static data buffer layout
-    std::vector<wgpu::VertexAttribute> staticDataAttributes;
+    TArray<wgpu::VertexAttribute> staticDataAttributes;
     {
         auto arrayStride = create_vertex_attributes(step->staticAttributes(),
                                                     0,
@@ -622,7 +628,7 @@ sk_sp<DawnGraphicsPipeline> DawnGraphicsPipeline::Make(
     }
 
     // Append data buffer layout
-    std::vector<wgpu::VertexAttribute> appendDataAttributes;
+    TArray<wgpu::VertexAttribute> appendDataAttributes;
     {
         // Note: the shaderLocationOffset in this function call needs to be the staticAttributeSize
         auto arrayStride = create_vertex_attributes(step->appendAttributes(),

--- a/src/ports/SkTypeface_mac_ct.cpp
+++ b/src/ports/SkTypeface_mac_ct.cpp
@@ -604,9 +604,9 @@ static SK_SFNT_ULONG get_font_type_tag(CTFontRef ctFont) {
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const {
     *ttcIndex = 0;
 
-    fInitStream([this]{
+    SkAutoSharedMutexExclusive sm(fStreamMutex);
     if (fStream) {
-        return;
+        return fStream->duplicate();
     }
 
     SK_SFNT_ULONG fontType = get_font_type_tag(fFontRef.get());
@@ -704,12 +704,12 @@ std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenStream(int* ttcIndex) const
         ++entry;
     }
     fStream = std::make_unique<SkMemoryStream>(std::move(streamData));
-    });
     return fStream->duplicate();
 }
 
 std::unique_ptr<SkStreamAsset> SkTypeface_Mac::onOpenExistingStream(int* ttcIndex) const {
     *ttcIndex = 0;
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return fStream ? fStream->duplicate() : nullptr;
 }
 
@@ -1220,7 +1220,7 @@ sk_sp<SkTypeface> SkTypeface_Mac::onMakeClone(const SkFontArguments& args) const
     if (!ctVariant) {
         return nullptr;
     }
-
+    SkAutoSharedMutexShared sm(fStreamMutex);
     return SkTypeface_Mac::Make(std::move(ctVariant), ctVariation.opsz,
                                 fStream ? fStream->duplicate() : nullptr);
 }

--- a/src/ports/SkTypeface_mac_ct.h
+++ b/src/ports/SkTypeface_mac_ct.h
@@ -19,6 +19,7 @@
 #include "include/core/SkStream.h"
 #include "include/core/SkTypeface.h"
 #include "include/private/base/SkOnce.h"
+#include "src/base/SkSharedMutex.h"
 #include "src/utils/mac/SkUniqueCFRef.h"
 
 #ifdef SK_BUILD_FOR_MAC
@@ -129,8 +130,8 @@ protected:
 private:
     mutable std::unique_ptr<SkStreamAsset> fStream;
     mutable SkUniqueCFRef<CFArrayRef> fVariationAxes;
+    mutable SkSharedMutex fStreamMutex;
     bool fIsFromStream;
-    mutable SkOnce fInitStream;
     mutable SkOnce fInitVariationAxes;
 
     using INHERITED = SkTypeface;


### PR DESCRIPTION
Automated upstream merge of `chrome/m148`.

## Summary

Release-line bug-fix sync onto `release/4.148.x`. Pulls 2 new upstream commits from `google/skia` `chrome/m148` into mono/skia `release/4.148.x` via the `skia-sync/release-4.148.x` branch.

This is **not** a milestone bump — `CURRENT == TARGET == 148`. No SkiaSharp version/soname/nuget changes; the parent-repo companion PR only bumps the submodule pointer and the two `cgmanifest.json` SHAs.

## Upstream merge

| Field | Value |
| --- | --- |
| Upstream ref | `chrome/m148` (google/skia) |
| Old upstream HEAD | `54851b68b7a1d49bc4b4361f12786a7d7ad91fff` |
| New upstream HEAD | `46f2e16555cac1211f4087cf24728fd741ac6495` |
| Merge-base | `54851b68b7a1d49bc4b4361f12786a7d7ad91fff` |
| New upstream commits | 2 |
| Merge commit on this branch | `6d45d9aed12bacb599261ccebcf4a9764b0467ea` |

### Upstream commits pulled in

| SHA | Subject | Files |
| --- | --- | --- |
| `46f2e16555` | `[m148] Resolved a Data Race on fStream in SkTypeface_Mac` | `src/ports/SkTypeface_mac_ct.{cpp,h}` |
| `3a90f6662a` | `[graphite] Use stable collection for static bindings` | `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp` |

Both are cherry-picked bug-fixes (already on `chrome/m148` upstream). The first is a macOS-only thread-safety fix in CoreText typeface caching (`gTFCache`); the second is a Graphite/Dawn-only buffer-stability fix. SkiaSharp ships Ganesh (not Graphite), so the Graphite change is benign noise. The macOS typeface fix is the genuinely valuable bug-fix for SkiaSharp users on macOS — it eliminates a data race where `onOpenStream` and `onOpenExistingStream` could race on `fStream` from different threads.

## Conflicts resolved

**None.** `git merge --no-commit` completed with `"Automatic merge went well"`; `git diff --check` reports zero conflict markers. The 2 upstream commits touch 3 files only, all outside our fork patches.

Fork-patch audit (mandatory snapshot before merging):

```
$ MB=$(git merge-base origin/release/4.148.x upstream/chrome/m148)
$ git log --oneline "$MB..origin/release/4.148.x" | wc -l
963   # snapshot saved in workflow artifacts as fork-patches-before.txt
```

No fork patch touches `src/ports/SkTypeface_mac_ct.{cpp,h}` or `src/gpu/graphite/dawn/DawnGraphicsPipeline.cpp`, so nothing needed to be re-applied or classified as upstreamed.

## C API impact

**None.** Neither upstream commit touches:
- `src/c/**` or `include/c/**` (SkiaSharp C shim)
- `src/xamarin/**` or `include/xamarin/**` (SkiaSharp Xamarin shim)
- `BUILD.gn`, `DEPS`, `modules/skcms/version.sha1`
- Any public header pulled in by our C API

The binding generator was re-run in the parent repo and reports `No changes to bindings (C API signatures unchanged)` and `No new functions found`. `SK_C_INCREMENT` stays at `0`.

## Source-file verification

```
$ git diff $(git merge-base origin/release/4.148.x upstream/chrome/m148)..upstream/chrome/m148 \
    --diff-filter=AD --name-only -- src/ include/
(empty — no added or deleted source files)
```

No `BUILD.gn` adjustments required.

## Items needing human attention

- **None.** Pure bug-fix sync, clean merge, no C API impact, no binding deltas, all tests pass in the companion PR.
- Linux x64 was the build platform used in CI here. The macOS data-race fix (`SkTypeface_mac_ct.cpp`) is not exercised by the Linux x64 native build or test suite; the macOS native build will pick it up automatically on the release/4.148.x macOS pipeline once both PRs land.

## Companion PR

Parent repo: `mono/SkiaSharp` PR on branch `skia-sync/release-4.148.x` targeting `release/4.148.x`. The parent PR bumps the submodule pointer to the merge commit of this PR and updates the two `cgmanifest.json` SHAs (mono/skia `commitHash` and Skia core `upstream_merge_commit`).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).