### PR TITLE
Add sk_paint_compute_fast_bounds C API

### DIFF
--- a/include/c/sk_paint.h
+++ b/include/c/sk_paint.h
@@ -51,6 +51,8 @@ SK_C_API sk_blender_t* sk_paint_get_blender(sk_paint_t* cpaint);
 SK_C_API sk_path_effect_t* sk_paint_get_path_effect(sk_paint_t* cpaint);
 SK_C_API void sk_paint_set_path_effect(sk_paint_t* cpaint, sk_path_effect_t* effect);  
 SK_C_API bool sk_paint_get_fill_path(const sk_paint_t* cpaint, const sk_path_t* src, sk_pathbuilder_t* dst, const sk_rect_t* cullRect, const sk_matrix_t* cmatrix);
+SK_C_API bool sk_paint_can_compute_fast_bounds(const sk_paint_t* cpaint);
+SK_C_API void sk_paint_compute_fast_bounds(const sk_paint_t* cpaint, const sk_rect_t* orig, sk_rect_t* storage);
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/src/c/sk_paint.cpp
+++ b/src/c/sk_paint.cpp
@@ -165,3 +165,11 @@ void sk_paint_set_path_effect(sk_paint_t* cpaint, sk_path_effect_t* effect) {
 bool sk_paint_get_fill_path(const sk_paint_t* cpaint, const sk_path_t* src, sk_pathbuilder_t* dst, const sk_rect_t* cullRect, const sk_matrix_t* cmatrix) {
     return skpathutils::FillPathWithPaint(*AsPath(src), *AsPaint(cpaint), AsPathBuilder(dst), AsRect(cullRect), AsMatrix(cmatrix));
 }
+
+bool sk_paint_can_compute_fast_bounds(const sk_paint_t* cpaint) {
+    return AsPaint(cpaint)->canComputeFastBounds();
+}
+
+void sk_paint_compute_fast_bounds(const sk_paint_t* cpaint, const sk_rect_t* orig, sk_rect_t* storage) {
+    *AsRect(storage) = AsPaint(cpaint)->computeFastBounds(*AsRect(orig), AsRect(storage));
+}


### PR DESCRIPTION
## Summary

Adds two C API functions wrapping the **public** `SkPaint` quick-reject API:

```c
bool sk_paint_can_compute_fast_bounds(const sk_paint_t* cpaint);
void sk_paint_compute_fast_bounds(const sk_paint_t* cpaint, const sk_rect_t* orig, sk_rect_t* storage);
```

`sk_paint_compute_fast_bounds` returns the conservative device-space bounds a paint can draw into for a given source rect, composing the paint's path effect, stroke radius, mask filter and image filter. This lets SkiaSharp expose `SKPaint.ComputeFastBounds` / `SKPaint.CanComputeFastBounds`, completing the documented quick-reject pattern alongside the existing `sk_canvas_quick_reject`.

Consumer PR: **mono/SkiaSharp#4271**.

## Why `SkPaint` and not `SkMaskFilter`?

This work originally targeted `SkMaskFilter::computeFastBounds`, but that method is **private** — and has been since 2018.

| When | Commit | What |
|------|--------|------|
| 2012-01-30 | `9efd9a048a` | `computeFastBounds` added to the public `SkMaskFilter`, for quick-rejecting shadow/blur draws. |
| 2018-01-23 | `80747ef591` (Mike Reed) | "move the guts of `SkMaskFilter.h` into `SkMaskFilterBase.h`" — made it **private**. Pure encapsulation (empty bug field); part of making all effect types opaque handles, with implementation methods moved to internal `*Base` classes. |

Binding the private method would require the C shim to `#include "src/core/SkMaskFilterBase.h"` and call `as_MFB()` — fragile private coupling. The **public** `SkPaint::computeFastBounds` calls the mask-filter bounds internally (`doComputeFastBounds`), so it is a strict superset and the canonical entry point. `SkPaint::computeFastBounds` does carry a `(to be made private)` doc note (added 2018-01-03, `2823f9f06c1`), but it has remained public and unchanged for ~8 years with no move to privatize it.

Community threads on groups.google.com/g/skia-discuss confirm `computeFastBounds` is the recommended way to get visual bounds including blur/shadow/stroke (e.g. ["How to get the path bound including border?"](https://groups.google.com/g/skia-discuss/c/EFbFlfJjNxE), 2024-01-28).

## Implementation

```cpp
bool sk_paint_can_compute_fast_bounds(const sk_paint_t* cpaint) {
    return AsPaint(cpaint)->canComputeFastBounds();
}

void sk_paint_compute_fast_bounds(const sk_paint_t* cpaint, const sk_rect_t* orig, sk_rect_t* storage) {
    *AsRect(storage) = AsPaint(cpaint)->computeFastBounds(*AsRect(orig), AsRect(storage));
}
```

`computeFastBounds` returns a reference that is either `orig` (the ultra-fast fill-with-no-effects case) or `*storage`; assigning it into `*storage` is correct and safe for both (self-assignment of a trivially-copyable `SkRect` in the latter case). Uses only the already-included public `SkPaint.h` — no private headers.

## Testing

Verified via the consumer PR: native rebuilt from source (macOS arm64), symbols exported, and the full managed test suite passes (5743 passed, 0 failed). Behavior covered: blur outsets by 3×sigma, stroke outsets by strokeWidth/2, stroke+blur composition, fill no-op, and managed/native parity.
