### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,17 @@ Skia Graphics Release Notes
 
 This file includes a list of high level updates for each milestone release.
 
+Milestone 151
+-------------
+  * Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.
+  * Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.
+  * Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
+    into input glyph list and provides scattered writes with a stride length into a
+    client provided output buffer.  Useful for fast access and transfer of advance
+    widths in shaping. Shown to improve Blink performance.
+
+* * *
+
 Milestone 150
 -------------
   * `SkRegion::setRects(const SkIRect[], int)` has been deprecated in favor of `SkRegion::setRects(SkSpan<const SkIRect>)`.

--- a/infra/bots/jobs.json
+++ b/infra/bots/jobs.json
@@ -586,8 +586,7 @@
     "name": "Build-Ubuntu24.04-Clang-x86_64-Release-Wuffs"
   },
   {
-    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit",
-    "cq_config": {}
+    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit"
   },
   {
     "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit_CPU"
@@ -2036,20 +2035,10 @@
     "name": "Test-Ubuntu24.04-Clang-NUC5PPYH-GPU-IntelHD405-x86_64-Release-All-Vulkan"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
     "name": "Test-Win11-Clang-AlphaR2-GPU-RadeonR9M470X-x86_64-Debug-All-ANGLE"

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -94659,7 +94659,6 @@
         "src/codec/SkWuffs.*"
       ]
     },
-    "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit": {},
     "Build-Win-Clang-x86-Debug": {},
     "Build-Win-Clang-x86_64-Release-Direct3D": {},
     "Build-Win-Clang-x86_64-Release-Vulkan": {},
@@ -94748,16 +94747,6 @@
       "location_regexes": [
         "tools/gpu/vk/.*",
         "tests/ganesh/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
       ]
     },
     "Test-Win11-Clang-GCE-CPU-AVX2-x86_64-Release-All": {},

--- a/relnotes/ext_format_query.md
+++ b/relnotes/ext_format_query.md
@@ -1,1 +1,0 @@
-Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.

--- a/relnotes/rust_png_gainmap.md
+++ b/relnotes/rust_png_gainmap.md
@@ -1,1 +1,0 @@
-Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.

--- a/relnotes/strided_getwidths.md
+++ b/relnotes/strided_getwidths.md
@@ -1,4 +1,0 @@
-Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
-into input glyph list and provides scattered writes with a stride length into a
-client provided output buffer.  Useful for fast access and transfer of advance
-widths in shaping. Shown to improve Blink performance.


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

# mono/skia — Merge upstream `chrome/m151` (bug-fix sync)

## Summary

Merges the current tip of `upstream/chrome/m151` into our
`skiasharp` branch. Same-milestone bug-fix sync (`m151 → m151`):
no C++ / C API / DEPS / binding changes.

- **Base branch:** `skiasharp`
- **Head branch:** `skia-sync/m151`
- **Upstream ref merged:** `chrome/m151` @ `1536d3975057297af8087d22419f6c95dc96305d`
- **Previous merge:** `5209f4a49b55104de2c521fc6f605aee530e4cd8` (`[skia-sync] Merge upstream chrome/m151 (#274)`)
- **New merge commit:** `67d4e950785b19ffa49ff1a8fd5f440ec628340d` (two-parent, preserves `git blame` attribution)

## Upstream commits picked up (2)

| SHA | Subject | Category |
|-----|---------|----------|
| `1536d3975` | Merge 3 release notes into RELEASE_NOTES.md | Docs |
| `ac3c0d3fc` | Filter unsupported CQ try jobs on chrome/m151 | Upstream CI infra |

**Combined diffstat**

```
 RELEASE_NOTES.md              | 11 +++++++++++
 infra/bots/jobs.json          | 17 +++--------------
 infra/bots/tasks.json         | 11 -----------
 relnotes/ext_format_query.md  |  1 -
 relnotes/rust_png_gainmap.md  |  1 -
 relnotes/strided_getwidths.md |  4 ----
 6 files changed, 14 insertions(+), 31 deletions(-)
```

## Merge conflicts

**None.** `git merge --no-commit upstream/chrome/m151` completed cleanly
(`Automatic merge went well; stopped before committing as requested`).
`git diff --check` reports zero conflict markers.

No conflict resolution was needed, so the mandatory
"verify-upstream-or-reapply" audit table is empty by construction —
every fork patch remains on the branch untouched. Snapshot of the 1025
fork patches taken before the merge (`fork-patches-before.txt`); none
of them touch any of the 6 files modified upstream in this sync.

## C API shim fixes

**None required.** No files under `include/c/` or `src/c/` were touched
by upstream in this range, so no shim adaptation was needed. Verified
all 79 C API headers/implementations remain intact after the merge:

```
$ ls src/c/*.cpp include/c/*.h | wc -l
79
```

`git blame src/c/sk_canvas.cpp` still resolves to the original 2016 /
2018 authoring commits, confirming the merge preserved history.

## Items needing human attention

None — this is a docs- and infra-only bump from upstream. No new gn
args, no new source files added to `BUILD.gn`, no DEPS changes,
`SK_C_INCREMENT` remains at 0.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).