### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,17 @@ Skia Graphics Release Notes
 
 This file includes a list of high level updates for each milestone release.
 
+Milestone 151
+-------------
+  * Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.
+  * Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.
+  * Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
+    into input glyph list and provides scattered writes with a stride length into a
+    client provided output buffer.  Useful for fast access and transfer of advance
+    widths in shaping. Shown to improve Blink performance.
+
+* * *
+
 Milestone 150
 -------------
   * `SkRegion::setRects(const SkIRect[], int)` has been deprecated in favor of `SkRegion::setRects(SkSpan<const SkIRect>)`.

--- a/infra/bots/jobs.json
+++ b/infra/bots/jobs.json
@@ -586,8 +586,7 @@
     "name": "Build-Ubuntu24.04-Clang-x86_64-Release-Wuffs"
   },
   {
-    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit",
-    "cq_config": {}
+    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit"
   },
   {
     "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit_CPU"
@@ -2036,20 +2035,10 @@
     "name": "Test-Ubuntu24.04-Clang-NUC5PPYH-GPU-IntelHD405-x86_64-Release-All-Vulkan"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
     "name": "Test-Win11-Clang-AlphaR2-GPU-RadeonR9M470X-x86_64-Debug-All-ANGLE"

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -94659,7 +94659,6 @@
         "src/codec/SkWuffs.*"
       ]
     },
-    "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit": {},
     "Build-Win-Clang-x86-Debug": {},
     "Build-Win-Clang-x86_64-Release-Direct3D": {},
     "Build-Win-Clang-x86_64-Release-Vulkan": {},
@@ -94748,16 +94747,6 @@
       "location_regexes": [
         "tools/gpu/vk/.*",
         "tests/ganesh/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
       ]
     },
     "Test-Win11-Clang-GCE-CPU-AVX2-x86_64-Release-All": {},

--- a/relnotes/ext_format_query.md
+++ b/relnotes/ext_format_query.md
@@ -1,1 +1,0 @@
-Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.

--- a/relnotes/rust_png_gainmap.md
+++ b/relnotes/rust_png_gainmap.md
@@ -1,1 +1,0 @@
-Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.

--- a/relnotes/strided_getwidths.md
+++ b/relnotes/strided_getwidths.md
@@ -1,4 +1,0 @@
-Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
-into input glyph list and provides scattered writes with a stride length into a
-client provided output buffer.  Useful for fast access and transfer of advance
-widths in shaping. Shown to improve Blink performance.


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

## Sync mono/skia with upstream chrome/m151 (bug-fix only)

**Mode:** Same-milestone bug-fix sync (`CURRENT == TARGET == m151`, `is_release == false`).
No milestone/version bump — this only re-syncs the mono/skia `skiasharp` branch with
upstream `chrome/m151` to pick up 2 new bug-fix commits since our last merge.

### Merge details

- **Base:** `origin/skiasharp` — `e1be35b25f` [gn] Drop redundant SK_BUILD_FOR_WASM define (#204)
- **Upstream ref:** `upstream/chrome/m151` — tip at `1536d3975057297af8087d22419f6c95dc96305d`
- **Head:** `skia-sync/m151` — merge commit `de2e431eb3533193f077ad8a038a0a8239147db8` (two-parent, proper history)
- **Previous upstream merge base:** `79e2e1538e94bb1d6b5bbbc56279036aa7574b10`
- **New upstream merge base:** `1536d3975057297af8087d22419f6c95dc96305d`

### Upstream commits merged (2)

| SHA | Subject | Files |
|---|---|---|
| `1536d39750` | Merge 3 release notes into RELEASE_NOTES.md | `RELEASE_NOTES.md`, `relnotes/{ext_format_query,rust_png_gainmap,strided_getwidths}.md` (deleted) |
| `ac3c0d3fcd` | Filter unsupported CQ try jobs on chrome/m151 | `infra/bots/{jobs,tasks}.json` |

Both commits are non-code (release notes + infra CI config). No C++ source, headers,
C API, DEPS, or third-party dependency changes.

### Conflicts resolved

**None.** `git merge --no-commit upstream/chrome/m151` completed cleanly with
"Automatic merge went well". All affected files (RELEASE_NOTES.md, infra/bots/) fell
into the "Take upstream" category per the SKILL.md file-category table, and no
SkiaSharp fork patches touch any of these files, so no fork patch classification was
needed.

**Merged file changes (all from upstream side, no fork-side edits):**

| File | Change |
|---|---|
| `RELEASE_NOTES.md` | +11 −0 (three consolidated release notes) |
| `infra/bots/jobs.json` | +3 −14 (filtered try jobs) |
| `infra/bots/tasks.json` | +0 −11 (filtered try tasks) |
| `relnotes/ext_format_query.md` | deleted (merged into RELEASE_NOTES.md) |
| `relnotes/rust_png_gainmap.md` | deleted (merged into RELEASE_NOTES.md) |
| `relnotes/strided_getwidths.md` | deleted (merged into RELEASE_NOTES.md) |

### Fork patches preserved

Snapshot of `origin/skiasharp..upstream/chrome/m151` merge-base showed the full list
of fork patches (see `/tmp/gh-aw/agent/fork-patches-before.txt` artifact). None of
them touch files that conflicted — all merged cleanly. `git blame src/c/sk_canvas.cpp`
still shows the original 2016/2018 Matthew Leibowitz commits (attribution preserved).

### C API fixes

**None.** No changes to `include/c/**`, `src/c/**`, `sk_types.h`, or `SK_C_INCREMENT`
(remains at `0`). All C API files are intact.

### Gate verification

- ✅ Two-parent merge commit: `de2e431eb3 e1be35b25f 1536d39750`
- ✅ C API files intact: `ls src/c/*.cpp include/c/*.h` — all present
- ✅ `git diff --check` — no conflict markers
- ✅ `git blame` on `src/c/sk_canvas.cpp` shows original attribution
- ✅ Source file additions/deletions from upstream side: none (`git diff MB..upstream --diff-filter=AD -- src/ include/` is empty)

### Items needing human attention

**None.** This is a pure bug-fix sync with no code changes, no conflicts, no C API
work, and no new upstream gn args required. The native build (Linux x64) and full
SkiaSharp test suite pass — see the mono/SkiaSharp PR summary for the parent-repo
build/test results.

### Notes

- Only Linux x64 was built in the automation. The changes here touch only release
  notes and CI infra, so cross-platform impact is zero, but Windows/macOS/iOS/Android/
  WASM CI will exercise the merged submodule on the mono/SkiaSharp PR as usual.
- `depot_tools` in the sandbox has an unrelated local edit
  (`gclient_paths.py`: `@functools.lru_cache` → `@functools.lru_cache()`) — this is an
  environmental artifact of the runner's Python version and is **not** part of this
  sync. It was deliberately not committed.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).