### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,17 @@ Skia Graphics Release Notes
 
 This file includes a list of high level updates for each milestone release.
 
+Milestone 151
+-------------
+  * Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.
+  * Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.
+  * Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
+    into input glyph list and provides scattered writes with a stride length into a
+    client provided output buffer.  Useful for fast access and transfer of advance
+    widths in shaping. Shown to improve Blink performance.
+
+* * *
+
 Milestone 150
 -------------
   * `SkRegion::setRects(const SkIRect[], int)` has been deprecated in favor of `SkRegion::setRects(SkSpan<const SkIRect>)`.

--- a/infra/bots/jobs.json
+++ b/infra/bots/jobs.json
@@ -586,8 +586,7 @@
     "name": "Build-Ubuntu24.04-Clang-x86_64-Release-Wuffs"
   },
   {
-    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit",
-    "cq_config": {}
+    "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit"
   },
   {
     "name": "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit_CPU"
@@ -2036,20 +2035,10 @@
     "name": "Test-Ubuntu24.04-Clang-NUC5PPYH-GPU-IntelHD405-x86_64-Release-All-Vulkan"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
-    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit",
-    "cq_config": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    }
+    "name": "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit"
   },
   {
     "name": "Test-Win11-Clang-AlphaR2-GPU-RadeonR9M470X-x86_64-Debug-All-ANGLE"

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -94659,7 +94659,6 @@
         "src/codec/SkWuffs.*"
       ]
     },
-    "Build-Ubuntu24.04-EMCC-wasm-Debug-CanvasKit": {},
     "Build-Win-Clang-x86-Debug": {},
     "Build-Win-Clang-x86_64-Release-Direct3D": {},
     "Build-Win-Clang-x86_64-Release-Vulkan": {},
@@ -94748,16 +94747,6 @@
       "location_regexes": [
         "tools/gpu/vk/.*",
         "tests/ganesh/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-CPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
-      ]
-    },
-    "Test-Ubuntu24.04-EMCC-GCE-GPU-AVX2-wasm-Release-All-CanvasKit": {
-      "location_regexes": [
-        "modules/canvaskit/.*"
       ]
     },
     "Test-Win11-Clang-GCE-CPU-AVX2-x86_64-Release-All": {},

--- a/relnotes/ext_format_query.md
+++ b/relnotes/ext_format_query.md
@@ -1,1 +1,0 @@
-Added a 'containsExternalFormat' method to 'PrecompileContext'. This allows clients to determine if a serialized key contains an external format.

--- a/relnotes/rust_png_gainmap.md
+++ b/relnotes/rust_png_gainmap.md
@@ -1,1 +1,0 @@
-Added 'fGainmap' and 'fGainmapInfo' to 'SkPngRustEncoder::Options', allowing clients to encode HDR gainmaps in PNG images using the Rust PNG encoder.

--- a/relnotes/strided_getwidths.md
+++ b/relnotes/strided_getwidths.md
@@ -1,4 +1,0 @@
-Add a getWidthsStrided() API to SkStrikeRef which allows scattered memory access
-into input glyph list and provides scattered writes with a stride length into a
-client provided output buffer.  Useful for fast access and transfer of advance
-widths in shaping. Shown to improve Blink performance.


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

## `[skia-sync] Merge upstream chrome/m151`

Same-milestone (m151 → m151) bug-fix sync. Merges the two new commits on
`upstream/chrome/m151` since our last merge into mono/skia's `skiasharp` branch.

### Upstream commits merged

| SHA | Subject |
|-----|---------|
| `1536d39750` | Merge 3 release notes into `RELEASE_NOTES.md` |
| `ac3c0d3fcd` | Filter unsupported CQ try jobs on `chrome/m151` |

Both are release-notes / CI-config only — **no changes** under `src/`, `include/`,
`src/c/`, `include/c/`, `BUILD.gn`, or `DEPS`.

### Merge details

- Merge base: `79e2e1538e94bb1d6b5bbbc56279036aa7574b10`
- Base branch: `skiasharp` at `e1be35b25f` ([gn] Drop redundant `SK_BUILD_FOR_WASM` define)
- Upstream ref: `chrome/m151` at `1536d3975057297af8087d22419f6c95dc96305d`
- Merge commit: `205c36a8afdb8504a6bdaa602996b44a6b1bcc70`
- Merge strategy: `git merge --no-commit upstream/chrome/m151` — merged cleanly
  with **zero conflicts**.

### Files touched

| File | Change |
|------|--------|
| `RELEASE_NOTES.md` | +11 lines (m151 bullets promoted from `relnotes/*.md`) |
| `infra/bots/jobs.json` | +3 / -14 (drop unsupported try jobs) |
| `infra/bots/tasks.json` | +0 / -11 |
| `relnotes/ext_format_query.md` | deleted (promoted) |
| `relnotes/rust_png_gainmap.md` | deleted (promoted) |
| `relnotes/strided_getwidths.md` | deleted (promoted) |

### Conflicts resolved

**None.** No fork patch collided with upstream on these files. The
verify-upstream-or-reapply audit (skill Phase 5) is a no-op because no
conflicts required classification.

### C API impact

**None.** No source files under `src/c/` or `include/c/` were touched by
upstream. All 79 C API `.cpp`/`.h` files remain intact. `sk_types.h`
`SK_C_INCREMENT` unchanged (still `0`).

### Source file verification

`git diff <merge-base>..upstream/chrome/m151 --diff-filter=AD --name-only -- src/ include/`
returned no results — no added/deleted upstream source files, so no
`BUILD.gn` follow-up is needed.

### GN args / dependencies

No `DEPS` change, no new upstream gn arg required.

### Items needing human attention

None.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).