### PR TITLE
[skia-sync] Merge upstream chrome/m150

### DIFF
--- a/src/text/gpu/SubRunAllocator.h
+++ b/src/text/gpu/SubRunAllocator.h
@@ -188,23 +188,30 @@ private:
 template <typename T>
 class SubRunInitializer {
 public:
-    SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
-    ~SubRunInitializer() {
-        ::operator delete(fMemory);
-    }
+    explicit SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
+
     template <typename... Args>
     T* initialize(Args&&... args) {
         // Warn on more than one initialization.
         SkASSERT(fMemory != nullptr);
-        return new (std::exchange(fMemory, nullptr)) T(std::forward<Args>(args)...);
+        return new (fMemory.release()) T(std::forward<Args>(args)...);
     }
 
 private:
-    void* fMemory;
+    struct Deleter {
+        // Frees the heap memory without calling a destructor.
+        // We must use `::operator delete(p)` instead of `delete p` because `p` is `void*`.
+        // Deleting a `void*` is undefined behavior in C++.
+        // This is paired with the placement `::operator new` in AllocateClassMemoryAndArena.
+        void operator()(void* p) const { ::operator delete(p); }
+    };
+    std::unique_ptr<void, Deleter> fMemory;
 };
 
-// GrSubRunAllocator provides fast allocation where the user takes care of calling the destructors
-// of the returned pointers, and GrSubRunAllocator takes care of deleting the storage. The
+template <typename T> struct AllocateAndArenaResult;
+
+// SubRunAllocator provides fast allocation where the user takes care of calling the destructors
+// of the returned pointers, and SubRunAllocator takes care of deleting the storage. The
 // unique_ptrs returned, are to assist in assuring the object's destructor is called.
 // A note on zero length arrays: according to the standard a pointer must be returned, and it
 // can't be a nullptr. In such a case, SkArena allocates one byte, but does not initialize it.
@@ -234,20 +241,8 @@ public:
     SubRunAllocator& operator=(SubRunAllocator&&) = default;
 
     template <typename T>
-    static std::tuple<SubRunInitializer<T>, int, SubRunAllocator>
-    AllocateClassMemoryAndArena(int allocSizeHint) {
-        SkASSERT_RELEASE(allocSizeHint >= 0);
-        // Round the size after the object the optimal amount.
-        int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
-
-        // Don't overflow or die.
-        SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
-        int totalMemorySize = sizeof(T) + extraSize;
-
-        void* memory = ::operator new (totalMemorySize);
-        SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
-        return {memory, totalMemorySize, std::move(alloc)};
-    }
+    static AllocateAndArenaResult<T>
+    AllocateClassMemoryAndArena(int allocSizeHint);
 
     template <typename T, typename... Args> T* makePOD(Args&&... args) {
         static_assert(HasNoDestructor<T>, "This is not POD. Use makeUnique.");
@@ -327,6 +322,34 @@ public:
 private:
     BagOfBytes fAlloc;
 };
+
+// Members are destroyed in the reverse order of their declaration:
+// https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
+// `alloc` must be destroyed first because it may contain pointers to memory owned by `initializer`.
+// `initializer` must be destroyed last because it owns the backing memory.
+// See also: https://issues.skia.org/issues/530646115
+template <typename T>
+struct AllocateAndArenaResult {
+    SubRunInitializer<T> initializer;
+    int totalMemorySize;
+    SubRunAllocator alloc;
+};
+
+template <typename T>
+inline AllocateAndArenaResult<T>
+SubRunAllocator::AllocateClassMemoryAndArena(int allocSizeHint) {
+    SkASSERT_RELEASE(allocSizeHint >= 0);
+    // Round the size after the object the optimal amount.
+    int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
+
+    // Don't overflow or die.
+    SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
+    int totalMemorySize = sizeof(T) + extraSize;
+
+    void* memory = ::operator new (totalMemorySize);
+    SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
+    return {SubRunInitializer<T>{memory}, totalMemorySize, std::move(alloc)};
+}
 
 // Helper for defining allocators with inline/reserved storage.
 // For argument declarations, stick to the base type (SubRunAllocator).


### PR DESCRIPTION
Automated upstream merge of `chrome/m150`.

# [skia-sync] Merge upstream chrome/m150 bug fixes — mono/skia

**Base branch:** `release/4.150.x`
**Head branch:** `skia-sync/release-4.150.x`
**Upstream ref merged:** `chrome/m150` (google/skia)
**Mode:** release-line bug-fix sync (same milestone, no version bump)

## Merge summary

One new upstream commit was pulled in from `upstream/chrome/m150`:

| SHA | Subject |
|-----|---------|
| `3273c66a68` | [M150] Fix Use-After-Free in SubRunAllocator |

**Merge base with upstream:** `14d05ec761`
**Upstream tip after merge:** `3273c66a68`
**Merge commit:** `06f50d1c05` (proper two-parent merge)

## Conflicts resolved

**None.** The merge was clean — automatic merge succeeded on the single changed
file (`src/text/gpu/SubRunAllocator.h`) with no manual conflict resolution
required. Verified via `git diff --check` (zero conflict markers) and
`git diff --cached --stat` (only `src/text/gpu/SubRunAllocator.h` modified).

The verify-upstream-or-reapply audit was still performed: no fork patch on
`release/4.150.x` touches `src/text/gpu/SubRunAllocator.h`, so no fork work
was at risk of being lost or double-applied.

## C API fixes

**None required.** The upstream commit is an internal C++ implementation
detail — it replaces a `std::tuple` in `SubRunAllocator.h` with a custom
struct to guarantee destruction order and fix a UAF. It does not touch:

- `include/c/*.h` (C API headers)
- `src/c/*.cpp` (C API implementations)
- Any public C++ API

Verified: `grep "SubRunAllocator\|SubRunInitializer" src/c/*.cpp include/c/*.h`
returns nothing. All fork C API files still present after merge (verified
with `ls src/c/*.cpp include/c/*.h`).

## Upstream change details

**Bug fix:** Use-After-Free in `SubRunAllocator` during deserialization of a
corrupt `Slug` buffer. The old `std::tuple` return type had unspecified
member destruction order — `SubRunInitializer` (destructed first) freed the
backing memory before `SubRunAllocator` (destructed later) accessed
`fEndByte` in its `~BagOfBytes` destructor, causing a UAF read followed by
a wild-free/double-free.

The fix introduces `AllocateAndArenaResult`, a plain struct where the
allocator is declared last (and therefore destructed first, i.e. before the
initializer frees the memory). `SubRunInitializer` is also refactored to
use `std::unique_ptr` with a custom deleter, making ownership transfer
explicit via `release()`.

**Skia CL:** https://skia-review.googlesource.com/c/skia/+/1288679
**Bug:** skia:530646115 / Chromium 532102500 / 502102500

## Files changed

```
 src/text/gpu/SubRunAllocator.h | 67 +++++++++++++++++++++++++-------------
 1 file changed, 45 insertions(+), 22 deletions(-)
```

## Items needing human attention

None. This is a minimal, low-risk internal C++ bug fix with no API surface
impact and no cross-platform build implications. The clang warning about
`-stdlib=libc++` being unused during compilation of the fork's plain-C
files (`sk_mulodi4.c`, `SkiaKeeper.c`) is pre-existing and unrelated to
this sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).