### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/src/text/gpu/SubRunAllocator.h
+++ b/src/text/gpu/SubRunAllocator.h
@@ -188,23 +188,30 @@ private:
 template <typename T>
 class SubRunInitializer {
 public:
-    SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
-    ~SubRunInitializer() {
-        ::operator delete(fMemory);
-    }
+    explicit SubRunInitializer(void* memory) : fMemory{memory} { SkASSERT(memory != nullptr); }
+
     template <typename... Args>
     T* initialize(Args&&... args) {
         // Warn on more than one initialization.
         SkASSERT(fMemory != nullptr);
-        return new (std::exchange(fMemory, nullptr)) T(std::forward<Args>(args)...);
+        return new (fMemory.release()) T(std::forward<Args>(args)...);
     }
 
 private:
-    void* fMemory;
+    struct Deleter {
+        // Frees the heap memory without calling a destructor.
+        // We must use `::operator delete(p)` instead of `delete p` because `p` is `void*`.
+        // Deleting a `void*` is undefined behavior in C++.
+        // This is paired with the placement `::operator new` in AllocateClassMemoryAndArena.
+        void operator()(void* p) const { ::operator delete(p); }
+    };
+    std::unique_ptr<void, Deleter> fMemory;
 };
 
-// GrSubRunAllocator provides fast allocation where the user takes care of calling the destructors
-// of the returned pointers, and GrSubRunAllocator takes care of deleting the storage. The
+template <typename T> struct AllocateAndArenaResult;
+
+// SubRunAllocator provides fast allocation where the user takes care of calling the destructors
+// of the returned pointers, and SubRunAllocator takes care of deleting the storage. The
 // unique_ptrs returned, are to assist in assuring the object's destructor is called.
 // A note on zero length arrays: according to the standard a pointer must be returned, and it
 // can't be a nullptr. In such a case, SkArena allocates one byte, but does not initialize it.
@@ -234,20 +241,8 @@ public:
     SubRunAllocator& operator=(SubRunAllocator&&) = default;
 
     template <typename T>
-    static std::tuple<SubRunInitializer<T>, int, SubRunAllocator>
-    AllocateClassMemoryAndArena(int allocSizeHint) {
-        SkASSERT_RELEASE(allocSizeHint >= 0);
-        // Round the size after the object the optimal amount.
-        int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
-
-        // Don't overflow or die.
-        SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
-        int totalMemorySize = sizeof(T) + extraSize;
-
-        void* memory = ::operator new (totalMemorySize);
-        SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
-        return {memory, totalMemorySize, std::move(alloc)};
-    }
+    static AllocateAndArenaResult<T>
+    AllocateClassMemoryAndArena(int allocSizeHint);
 
     template <typename T, typename... Args> T* makePOD(Args&&... args) {
         static_assert(HasNoDestructor<T>, "This is not POD. Use makeUnique.");
@@ -327,6 +322,34 @@ public:
 private:
     BagOfBytes fAlloc;
 };
+
+// Members are destroyed in the reverse order of their declaration:
+// https://isocpp.org/wiki/faq/dtors#order-dtors-for-members
+// `alloc` must be destroyed first because it may contain pointers to memory owned by `initializer`.
+// `initializer` must be destroyed last because it owns the backing memory.
+// See also: https://issues.skia.org/issues/530646115
+template <typename T>
+struct AllocateAndArenaResult {
+    SubRunInitializer<T> initializer;
+    int totalMemorySize;
+    SubRunAllocator alloc;
+};
+
+template <typename T>
+inline AllocateAndArenaResult<T>
+SubRunAllocator::AllocateClassMemoryAndArena(int allocSizeHint) {
+    SkASSERT_RELEASE(allocSizeHint >= 0);
+    // Round the size after the object the optimal amount.
+    int extraSize = BagOfBytes::PlatformMinimumSizeWithOverhead(allocSizeHint, alignof(T));
+
+    // Don't overflow or die.
+    SkASSERT_RELEASE(INT_MAX - SkTo<int>(sizeof(T)) > extraSize);
+    int totalMemorySize = sizeof(T) + extraSize;
+
+    void* memory = ::operator new (totalMemorySize);
+    SubRunAllocator alloc{SkTAddOffset<char>(memory, sizeof(T)), extraSize, extraSize/2};
+    return {SubRunInitializer<T>{memory}, totalMemorySize, std::move(alloc)};
+}
 
 // Helper for defining allocators with inline/reserved storage.
 // For argument declarations, stick to the base type (SubRunAllocator).


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

Automated upstream merge of `chrome/m151` bug fixes.

# [skia-sync] Merge upstream chrome/m151 bug fixes — mono/skia

**Base branch:** `skiasharp`
**Head branch:** `skia-sync/m151`
**Upstream ref merged:** `chrome/m151` (google/skia)
**Mode:** same-milestone bug-fix sync (`CURRENT == TARGET == m151`, `IS_RELEASE == false`)

## Merge summary

One new upstream commit was pulled in from `upstream/chrome/m151`:

| SHA | Subject |
|-----|---------|
| `0208108c7a` | [M151] Fix Use-After-Free in SubRunAllocator |

- **Merge base with upstream:** `1536d3975057297af8087d22419f6c95dc96305d`
- **Upstream tip after merge:** `0208108c7aed5f4e0faa525cbba52c238005a1ef`
- **Merge commit:** `ff9099d9964f0b7f5871287cf1d05be570cd0ff4` (proper two-parent merge)
- **Fork patches on `skiasharp` since merge-base:** 1028 (audit snapshot uploaded as workflow artifact `fork-patches-before.txt`)

## Conflicts resolved

**None.** The merge was clean — `git merge --no-commit upstream/chrome/m151` reported
`Automatic merge went well; stopped before committing as requested`. Only one file
was modified (`src/text/gpu/SubRunAllocator.h`) and it merged automatically.

**Verify-upstream-or-reapply audit:** the required snapshot was still taken. The only
fork commit on `skiasharp` that touches `src/text/gpu/SubRunAllocator.h` since the
merge-base is the previous merge commit itself (`a2147f95b9 Merge remote-tracking
branch 'upstream/chrome/m151' into skia-sync/m151`) — no standalone fork patch on
this file was at risk of being lost or double-applied.

Post-merge sanity:
- `git diff --check` → 0 conflict markers
- `ls src/c/*.cpp include/c/*.h` → 40 cpp + 39 h files intact
- `git blame src/c/sk_canvas.cpp | head` shows original attribution preserved

## C API fixes

**None required.** The upstream commit is an internal C++ implementation detail —
it replaces `std::tuple` in `SubRunAllocator.h` with a custom struct
(`AllocateAndArenaResult`) to guarantee destruction order and fix a Use-After-Free.
It does not touch:

- `include/c/*.h` (C API headers)
- `src/c/*.cpp` (C API implementations)
- Any public C++ API

Verified:

```
git diff 1536d39750..0208108c7a --stat -- src/c/ include/c/   # empty
grep -r "SubRunAllocator\|SubRunInitializer" src/c/ include/c/  # no matches
```

## Upstream change details

**Bug fix:** Use-After-Free in `SubRunAllocator` during deserialization of a
corrupt `Slug` buffer (`SlugImpl::MakeFromBuffer`). The old `std::tuple` return
type had unspecified member destruction order — `SubRunInitializer` (tuple index 0)
was destructed first and freed the backing memory. `SubRunAllocator` (tuple
index 2) was destructed next; its `~BagOfBytes` destructor then accessed
`fEndByte` inside the freed memory (UAF read) followed by a wild-free /
double-free.

**The fix:** introduces `AllocateAndArenaResult`, a plain struct where the
allocator is declared last (and therefore destructed first, i.e. before the
initializer frees the memory). `SubRunInitializer` is also refactored to use
`std::unique_ptr` with a custom deleter, making ownership transfer explicit
via `release()`.

- **Skia CL (m151 cherry-pick):** https://skia-review.googlesource.com/c/skia/+/1288616
- **Original CL (main):** https://skia-review.googlesource.com/c/skia/+/1284796
- **Bug:** skia:530646115 / Chromium 532103445

This is the same fix that already landed on `chrome/m150` as commit `3273c66a68`
and was pulled into our fork on the `release/4.150.x` branch (companion sync PR
[mono/skia#281](https://github.com/mono/skia/pull/281)).

## Files changed

```
src/text/gpu/SubRunAllocator.h | 67 +++++++++++++++++++++++++-------------
1 file changed, 45 insertions(+), 22 deletions(-)
```

## Items needing human attention

None. This is a minimal, low-risk internal C++ bug fix with no API surface
impact and no cross-platform build implications.

The pre-existing benign clang warning about `-stdlib=libc++` being unused when
compiling plain-C fork files (`sk_mulodi4.c`, `SkiaKeeper.c`) is unrelated to
this sync.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).