### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/src/gpu/ganesh/GrAttachment.h
+++ b/src/gpu/ganesh/GrAttachment.h
@@ -122,6 +122,9 @@ private:
     skgpu::Mipmapped fMipmapped;
     // Track which area of the attachment has already been cleared to cut down on unnecessary clear
     // operations, which can be more expensive on desktop GPUs than loads.
+    // NOTE: stored in native (backend) coordinate space, NOT surface-origin space -- this
+    // attachment can be shared by render targets with different GrSurfaceOrigin (origin is not
+    // part of the shared-attachment UniqueKey).
     SkIRect fClearedArea = SkIRect::MakeEmpty();
     GrMemoryless fMemoryless;
 

--- a/src/gpu/ganesh/ops/OpsTask.cpp
+++ b/src/gpu/ganesh/ops/OpsTask.cpp
@@ -589,6 +589,19 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
     // Determine whether the stencil attachment's cleared area should be updated.
     bool updateClearedStencilArea = false;
     SkIRect boundsRequiredByStencil = fClippedContentBounds;
+    // fClearedArea on the shared stencil GrAttachment must be tracked in native space, not
+    // surface-origin space. The stencil attachment is shared across render targets by a UniqueKey
+    // that does not include GrSurfaceOrigin, so a kTopLeft RT and a kBottomLeft RT with equal
+    // logical bounds map to disjoint native regions after the possible Y-flip in backends.
+    // Without this conversion, hasAreaBeenCleared() can return true for a native region that was
+    // never LOAD_OP_CLEAR'd, exposing uninitialised gpu memory to the stencil-then-cover pass.
+    // GrNativeRect::MakeIRectRelativeTo is self-inverse for a fixed (origin,height) pair, so it
+    // also serves as native->surface below.
+    const int rtHeight = renderTarget->dimensions().height();
+    auto toNative = [&](SkIRect r) {
+        return GrNativeRect::MakeIRectRelativeTo(fTargetOrigin, rtHeight, r);
+    };
+    SkIRect nativeBoundsRequiredByStencil = toNative(boundsRequiredByStencil);
     switch (fInitialStencilContent) {
         case StencilContent::kDontCare:
             if (!stencil || caps.performStencilClearsAsDraws()) {
@@ -629,17 +642,21 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
             // boundsRequiredByStencil has not already been cleared, calculate new, expanded
             // renderpass bounds by joining boundsRequiredByStencil with the cleared stencil area.
             // Using this joint area simplifies tracking of cleared areas on the stencil attachment.
-            if (!stencil->hasAreaBeenCleared(boundsRequiredByStencil)) {
+            if (!stencil->hasAreaBeenCleared(nativeBoundsRequiredByStencil)) {
                 stencilLoadOp = GrLoadOp::kClear;
                 if (!stencil->clearedArea().isEmpty()) {
-                    boundsRequiredByStencil.join(stencil->clearedArea());
+                    // Join in native space (fClearedArea is native-space).
+                    nativeBoundsRequiredByStencil.join(stencil->clearedArea());
                     // We need to also intersect the bounds with the color attachment's bounds since
                     // the stencil may be bigger. This could mean that we end up "forgetting" we
                     // cleared the user bits in the portion of the stencil that doesn't overlap with
                     // the color attachment - but that shouldn't have a large performance impact if
                     // we later on need to reclear that area.
-                    boundsRequiredByStencil.intersect(
+                    nativeBoundsRequiredByStencil.intersect(
                         SkIRect::MakeSize(renderTarget->dimensions()));
+                    // Convert back to surface-origin space for create_render_pass()
+                    // (self-inverse transform).
+                    boundsRequiredByStencil = toNative(nativeBoundsRequiredByStencil);
                 }
                 // We should update the stencil's cleared area if renderpass creation succeeds.
                 updateClearedStencilArea = true;
@@ -688,7 +705,7 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
         return false;
     }
     if (updateClearedStencilArea) {
-        stencil->markAreaCleared(boundsRequiredByStencil);
+        stencil->markAreaCleared(nativeBoundsRequiredByStencil);
     }
 
 #if defined(SK_DEBUG)


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

# [skia-sync] Merge upstream chrome/m151 bug fixes

Merges new upstream bug-fix commits from `google/skia` `chrome/m151` into the `skiasharp` fork.

## Upstream merge

- **Base**: `skiasharp` (m151)
- **Merged from**: `upstream/chrome/m151` @ `87424bcdba68e14ff3b40524ed09ad150ce3c92e`
- **New upstream commits merged**: 1
  - `87424bcdba` [M151] Make sure tracked stencil clear rect is done in native coords.

## Conflicts resolved

None — clean merge. The single upstream commit touched `src/gpu/ganesh/GrAttachment.h` and
`src/gpu/ganesh/ops/OpsTask.cpp` (internal Ganesh GPU code); no fork patches touch those files.

## C API changes

None. Upstream change is internal GPU code, no `include/c/` or `src/c/` impact.

## Verification

- ✅ C API files intact (79 files under `src/c/` + `include/c/`)
- ✅ `git diff --check` clean, no conflict markers
- ✅ Native Linux x64 build succeeded (`externals-linux --arch=x64`)
- ✅ Binding regeneration produced no diff (C API signatures unchanged)

## Items needing human attention

None.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).