### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -507,8 +507,9 @@ static void resolve_and_mipmap(GrGpu* gpu, GrSurfaceProxy* proxy) {
     if (auto* textureProxy = proxy->asTextureProxy()) {
         if (textureProxy->mipmapsAreDirty()) {
             SkASSERT(textureProxy->peekTexture());
-            gpu->regenerateMipMapLevels(textureProxy->peekTexture());
-            textureProxy->markMipmapsClean();
+            if (gpu->regenerateMipMapLevels(textureProxy->peekTexture())) {
+                textureProxy->markMipmapsClean();
+            }
         }
     }
 }

--- a/src/gpu/ganesh/GrTextureResolveRenderTask.cpp
+++ b/src/gpu/ganesh/GrTextureResolveRenderTask.cpp
@@ -94,29 +94,53 @@ bool GrTextureResolveRenderTask::onExecute(GrOpFlushState* flushState) {
     // Resolve all msaa back-to-back, before regenerating mipmaps.
     SkASSERT(fResolves.size() == this->numTargets());
     for (int i = 0; i < fResolves.size(); ++i) {
-        const Resolve& resolve = fResolves[i];
+        Resolve& resolve = fResolves[i];
         if (GrSurfaceProxy::ResolveFlags::kMSAA & resolve.fFlags) {
             GrSurfaceProxy* proxy = this->target(i);
             // peekRenderTarget might be null if there was an instantiation error.
             if (GrRenderTarget* renderTarget = proxy->peekRenderTarget()) {
                 flushState->gpu()->resolveRenderTarget(renderTarget, resolve.fMSAAResolveRect);
+                resolve.fFlags &= ~GrSurfaceProxy::ResolveFlags::kMSAA;
             }
         }
     }
     // Regenerate all mipmaps back-to-back.
     for (int i = 0; i < fResolves.size(); ++i) {
-        const Resolve& resolve = fResolves[i];
+        Resolve& resolve = fResolves[i];
         if (GrSurfaceProxy::ResolveFlags::kMipMaps & resolve.fFlags) {
             // peekTexture might be null if there was an instantiation error.
             GrTexture* texture = this->target(i)->peekTexture();
-            if (texture && texture->mipmapsAreDirty()) {
-                flushState->gpu()->regenerateMipMapLevels(texture);
-                SkASSERT(!texture->mipmapsAreDirty());
+            if (texture && (!texture->mipmapsAreDirty() ||
+                            flushState->gpu()->regenerateMipMapLevels(texture))) {
+                resolve.fFlags &= ~GrSurfaceProxy::ResolveFlags::kMipMaps;
             }
         }
     }
 
     return true;
+}
+
+void GrTextureResolveRenderTask::endFlush(GrDrawingManager* drawingMgr) {
+    // Any flags still set here correspond to resolves that were recorded by addProxy() but never
+    // executed (the flush was dropped before render-task execution, this task was skipped because
+    // its targets failed to instantiate, or a per-target operation failed). Re-mark those proxies
+    // dirty so a subsequent flush will re-record the resolve.
+    SkASSERT(fResolves.size() == this->numTargets());
+    for (int i = 0; i < fResolves.size(); ++i) {
+        const Resolve& resolve = fResolves[i];
+        GrSurfaceProxy* proxy = this->target(i);
+        if (GrSurfaceProxy::ResolveFlags::kMSAA & resolve.fFlags) {
+            if (GrRenderTargetProxy* rtProxy = proxy->asRenderTargetProxy()) {
+                rtProxy->markMSAADirty(resolve.fMSAAResolveRect);
+            }
+        }
+        if (GrSurfaceProxy::ResolveFlags::kMipMaps & resolve.fFlags) {
+            if (GrTextureProxy* texProxy = proxy->asTextureProxy()) {
+                texProxy->markMipmapsDirty();
+            }
+        }
+    }
+    this->GrRenderTask::endFlush(drawingMgr);
 }
 
 #ifdef SK_DEBUG

--- a/src/gpu/ganesh/GrTextureResolveRenderTask.h
+++ b/src/gpu/ganesh/GrTextureResolveRenderTask.h
@@ -44,6 +44,12 @@ private:
 
     bool onExecute(GrOpFlushState*) override;
 
+    // addProxy() optimistically marks the proxy resolved/clean at recording time. If the flush
+    // is dropped before this task executes (or a per-target operation fails) we must restore the
+    // proxy's dirty state so a later flush will re-record the resolve.
+    bool requiresExplicitCleanup() const override { return true; }
+    void endFlush(GrDrawingManager*) override;
+
 #if defined(GPU_TEST_UTILS)
     const char* name() const final { return "TextureResolve"; }
 #endif

--- a/src/gpu/ganesh/ops/OpsTask.cpp
+++ b/src/gpu/ganesh/ops/OpsTask.cpp
@@ -637,12 +637,22 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
                 stencilLoadOp = GrLoadOp::kClear;
                 break;
             }
-
+            [[fallthrough]];
+        case StencilContent::kPreserved:
+            SkASSERT(stencil);
             // If the area of the stencil attachment corresponding to this renderpass's
             // boundsRequiredByStencil has not already been cleared, calculate new, expanded
             // renderpass bounds by joining boundsRequiredByStencil with the cleared stencil area.
             // Using this joint area simplifies tracking of cleared areas on the stencil attachment.
-            if (!stencil->hasAreaBeenCleared(nativeBoundsRequiredByStencil)) {
+            //
+            // This also applies to kPreserved: this task's content bounds may extend beyond the
+            // region cleared by the predecessor task on this surface, so we must clear rather than
+            // load in that case. Re-clearing the previously-cleared portion is a no-op because
+            // SurfaceDrawContexts leave the user stencil bits in a cleared state between ops. When
+            // performStencilClearsAsDraws() is true, an explicit full-surface clear draw was
+            // recorded into the predecessor task instead, so kLoad is correct.
+            if (!caps.performStencilClearsAsDraws() &&
+                !stencil->hasAreaBeenCleared(nativeBoundsRequiredByStencil)) {
                 stencilLoadOp = GrLoadOp::kClear;
                 if (!stencil->clearedArea().isEmpty()) {
                     // Join in native space (fClearedArea is native-space).
@@ -662,14 +672,6 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
                 updateClearedStencilArea = true;
                 break;
             }
-
-            // SurfaceDrawContexts are required to leave the user stencil bits in a cleared state
-            // once finished, meaning the stencil values will always remain cleared after the
-            // initial clear. Just fall through to reloading the existing (cleared) stencil values
-            // from memory.
-            [[fallthrough]];
-        case StencilContent::kPreserved:
-            SkASSERT(stencil);
             stencilLoadOp = GrLoadOp::kLoad;
             break;
         default:
@@ -714,6 +716,14 @@ bool OpsTask::onExecute(GrOpFlushState* flushState) {
         //    there is no stencil buffer
         //    or stencil clears are being performed by draws
         SkASSERT(!stencil || caps.performStencilClearsAsDraws());
+    }
+    if (stencilLoadOp == GrLoadOp::kLoad) {
+        // We should only load stencil values from a region that has already been cleared. When
+        // performStencilClearsAsDraws() is true, an explicit full-surface clear op was recorded
+        // into the predecessor task instead, and cleared-area tracking is not maintained.
+        SkASSERT(stencil);
+        SkASSERT(caps.performStencilClearsAsDraws() ||
+                 stencil->hasAreaBeenCleared(nativeBoundsRequiredByStencil));
     }
 #endif
 

--- a/tests/GrSurfaceResolveTest.cpp
+++ b/tests/GrSurfaceResolveTest.cpp
@@ -21,18 +21,23 @@
 #include "include/core/SkTypes.h"
 #include "include/gpu/GpuTypes.h"
 #include "include/gpu/ganesh/GrBackendSurface.h"
+#include "include/gpu/ganesh/GrContextOptions.h"
 #include "include/gpu/ganesh/GrDirectContext.h"
 #include "include/gpu/ganesh/GrTypes.h"
 #include "include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "include/gpu/ganesh/mock/GrMockTypes.h"
 #include "include/private/gpu/ganesh/GrTypesPriv.h"
 #include "src/core/SkColorData.h"
 #include "src/gpu/SkBackingFit.h"
 #include "src/gpu/Swizzle.h"
 #include "src/gpu/ganesh/GrCaps.h"
 #include "src/gpu/ganesh/GrDirectContextPriv.h"
+#include "src/gpu/ganesh/GrDrawingManager.h"
 #include "src/gpu/ganesh/GrFragmentProcessor.h"
+#include "src/gpu/ganesh/GrOnFlushResourceProvider.h"
 #include "src/gpu/ganesh/GrPaint.h"
 #include "src/gpu/ganesh/GrProxyProvider.h"
+#include "src/gpu/ganesh/GrRenderTargetProxy.h"
 #include "src/gpu/ganesh/GrSamplerState.h"
 #include "src/gpu/ganesh/GrSurfaceProxy.h"
 #include "src/gpu/ganesh/GrSurfaceProxyView.h"
@@ -353,6 +358,157 @@ DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(NonmippedDrawBeforeMippedDraw,
         if (resolveTask->flagsForProxy(mmProxy) != expectedFlags) {
             ERRORF(reporter, "Expected resolve flags to be %s", expectedStr);
             return;
+        }
+    }
+}
+
+namespace {
+// A preFlush callback that fails the first N flushes, simulating an allocation failure in an
+// onFlush callback (e.g. atlas instantiation under memory pressure).
+class FailingPreFlushCallback : public GrOnFlushCallbackObject {
+public:
+    explicit FailingPreFlushCallback(int failCount) : fRemainingFailures(failCount) {}
+    bool preFlush(GrOnFlushResourceProvider*) override {
+        if (fRemainingFailures > 0) {
+            --fRemainingFailures;
+            return false;
+        }
+        return true;
+    }
+    bool retainOnFreeGpuResources() override { return true; }
+
+private:
+    int fRemainingFailures;
+};
+}  // namespace
+
+// GrTextureResolveRenderTask::addProxy() optimistically marks a proxy's mipmaps clean / MSAA
+// resolved at recording time. If the owning flush is dropped without executing render tasks
+// (e.g., a preFlush callback or the resource allocator fails) the proxy must be re-dirtied so a
+// later flush will record a new resolve.
+DEF_GANESH_TEST(SurfaceResolveProxyStateAfterFailedFlush,
+                reporter,
+                /* options */,
+                CtsEnforcement::kNever) {
+    using ResolveFlags = GrSurfaceProxy::ResolveFlags;
+    using Enable = GrContextOptions::Enable;
+    using MipmapMode = GrSamplerState::MipmapMode;
+
+    for (auto reduceOpsTaskSplitting : {Enable::kYes, Enable::kNo}) {
+        for (int sampleCount : {1, 4}) {
+            GrMockOptions mockOptions;
+            mockOptions.fMipmapSupport = true;
+            mockOptions.fConfigOptions[(int)GrColorType::kRGBA_8888].fRenderability =
+                    GrMockOptions::ConfigOptions::Renderability::kMSAA;
+            GrContextOptions ctxOptions;
+            ctxOptions.fReduceOpsTaskSplitting = reduceOpsTaskSplitting;
+            sk_sp<GrDirectContext> dContext = GrDirectContext::MakeMock(&mockOptions, ctxOptions);
+            if (!dContext) {
+                ERRORF(reporter, "could not create mock context");
+                continue;
+            }
+            GrDrawingManager* drawingManager = dContext->priv().drawingManager();
+            auto bef = dContext->priv().caps()->getDefaultBackendFormat(GrColorType::kRGBA_8888,
+                                                                        GrRenderable::kYes);
+
+            sk_sp<GrSurfaceProxy> proxy =
+                    dContext->priv().proxyProvider()->createProxy(bef,
+                                                                  {64, 64},
+                                                                  GrRenderable::kYes,
+                                                                  sampleCount,
+                                                                  skgpu::Mipmapped::kYes,
+                                                                  SkBackingFit::kExact,
+                                                                  skgpu::Budgeted::kYes,
+                                                                  GrProtected::kNo,
+                                                                  "ResolveProxyStateTest");
+            if (!proxy) {
+                ERRORF(reporter, "could not create proxy");
+                continue;
+            }
+            GrTextureProxy* texProxy = proxy->asTextureProxy();
+            GrRenderTargetProxy* rtProxy = proxy->asRenderTargetProxy();
+            GrSurfaceProxyView proxyView{proxy,
+                                         kTopLeft_GrSurfaceOrigin,
+                                         skgpu::Swizzle::RGBA()};
+
+            const bool testMSAA = sampleCount > 1;
+            REPORTER_ASSERT(reporter, !testMSAA || proxy->requiresManualMSAAResolve());
+
+            auto recordDirtyingDrawAndMipmappedDependency = [&]() {
+                auto srcSDC =
+                        skgpu::ganesh::SurfaceDrawContext::Make(dContext.get(),
+                                                                GrColorType::kRGBA_8888,
+                                                                proxy,
+                                                                nullptr,
+                                                                kTopLeft_GrSurfaceOrigin,
+                                                                SkSurfaceProps{});
+                srcSDC->fillWithFP(GrFragmentProcessor::MakeColor(SK_PMColor4fWHITE));
+
+                auto dstSDC =
+                        skgpu::ganesh::SurfaceDrawContext::Make(dContext.get(),
+                                                                GrColorType::kRGBA_8888,
+                                                                nullptr,
+                                                                SkBackingFit::kExact,
+                                                                {8, 8},
+                                                                SkSurfaceProps{},
+                                                                "ResolveProxyStateTestDst");
+                auto te = GrTextureEffect::Make(
+                        proxyView,
+                        kPremul_SkAlphaType,
+                        SkMatrix::I(),
+                        GrSamplerState{SkFilterMode::kLinear, MipmapMode::kLinear},
+                        *dContext->priv().caps());
+                GrPaint paint;
+                paint.setColorFragmentProcessor(std::move(te));
+                dstSDC->drawRect(nullptr,
+                                 std::move(paint),
+                                 GrAA::kNo,
+                                 SkMatrix::Scale(1/8.f, 1/8.f),
+                                 SkRect::Make(proxy->dimensions()));
+                return dstSDC;
+            };
+
+            // Record a flush whose preFlush callback fails. The resolve task records the proxy
+            // as resolved/clean and is then discarded without executing.
+            {
+                FailingPreFlushCallback failCB(1);
+                dContext->priv().addOnFlushCallbackObject(&failCB);
+
+                auto dstSDC = recordDirtyingDrawAndMipmappedDependency();
+
+                ResolveFlags expectedFlags = ResolveFlags::kMipMaps;
+                if (testMSAA) {
+                    expectedFlags |= ResolveFlags::kMSAA;
+                }
+                const GrTextureResolveRenderTask* resolveTask =
+                        dstSDC->getOpsTask()->resolveTask();
+                REPORTER_ASSERT(reporter,
+                                resolveTask &&
+                                        resolveTask->flagsForProxy(proxy) == expectedFlags);
+                REPORTER_ASSERT(reporter, !texProxy->mipmapsAreDirty());
+                REPORTER_ASSERT(reporter, !testMSAA || !rtProxy->isMSAADirty());
+
+                dContext->flush();
+                drawingManager->testingOnly_removeOnFlushCallbackObject(&failCB);
+            }
+
+            // The resolve never executed so the proxy must once again report dirty mips/MSAA.
+            REPORTER_ASSERT(reporter, texProxy->mipmapsAreDirty());
+            if (testMSAA) {
+                REPORTER_ASSERT(reporter, rtProxy->isMSAADirty());
+                REPORTER_ASSERT(reporter,
+                                rtProxy->msaaDirtyRect() == SkIRect::MakeSize(proxy->dimensions()));
+            }
+
+            // A subsequent dependency must therefore record a new resolve task and the proxy
+            // should be clean once that flush succeeds.
+            {
+                auto dstSDC = recordDirtyingDrawAndMipmappedDependency();
+                REPORTER_ASSERT(reporter, dstSDC->getOpsTask()->resolveTask());
+                dContext->flush();
+            }
+            REPORTER_ASSERT(reporter, !texProxy->mipmapsAreDirty());
+            REPORTER_ASSERT(reporter, !testMSAA || !rtProxy->isMSAADirty());
         }
     }
 }

--- a/tests/StencilClearTest.cpp
+++ b/tests/StencilClearTest.cpp
@@ -129,3 +129,66 @@ DEF_GANESH_TEST_FOR_CONTEXTS(StencilClearTest,
     dContext->flush();
     dContext->submit(GrSyncCpu::kYes);
 }
+
+// The goal here is to:
+//    create an OpsTask (O1) whose stencil-using ops cover only a small region
+//    split the SDC's ops task while fNeedsStencil is already latched, so the
+//        successor OpsTask (O2) gets initial stencil content "preserved"
+//    add a stencil-using op to O2 whose bounds extend beyond O1's bounds
+// O1 only clears its own (small) region of the shared stencil attachment, so
+// O2 must not simply load the stencil over its own (larger) bounds. When
+// executed this test will trigger an assert if O2 loads stencil values from a
+// region that was never cleared.
+DEF_GANESH_TEST_FOR_CONTEXTS(StencilClearTest_PreservedAcrossSplit,
+                             skgpu::IsRenderingContext,
+                             reporter,
+                             ctxInfo,
+                             disable_split_reduction,
+                             CtsEnforcement::kNextRelease) {
+    GrDirectContext* dContext = ctxInfo.directContext();
+
+    SkPath star = make_star();
+
+    sk_sp<SkSurface> s = gpu_surface(dContext);
+    if (!s) {
+        return;  // Dynamic MSAA isn't supported everywhere
+    }
+
+    SkCanvas* canvas = s->getCanvas();
+
+    // First stencil-using draw with small bounds. This creates O1 which will clear only its
+    // own content bounds on the shared stencil attachment.
+    {
+        SkPaint paint;
+        paint.setColor(SK_ColorBLUE);
+        paint.setAntiAlias(true);
+
+        canvas->save();
+        canvas->translate(32, 40);
+        canvas->drawPath(star, paint);
+        canvas->restore();
+    }
+
+    // saveLayer creates a temporary SDC whose first ops task closes O1. On restore, the SDC
+    // creates O2; because fNeedsStencil is already set, O2's initial stencil content is
+    // "preserved" and later setNeedsStencil() calls are no-ops.
+    canvas->saveLayerAlphaf(nullptr, 0.5f);
+    canvas->clear(SK_ColorGREEN);
+    canvas->restore();
+
+    // Second stencil-using draw with large bounds, recorded into O2.
+    {
+        SkPaint paint;
+        paint.setColor(SK_ColorYELLOW);
+        paint.setAntiAlias(true);
+
+        canvas->save();
+        canvas->concat(SkMatrix::ScaleTranslate(4, 4, 128, 128));
+        canvas->drawPath(star, paint);
+        canvas->restore();
+    }
+
+    dContext->flush();
+    dContext->submit(GrSyncCpu::kYes);
+}
+


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

# [skia-sync] Merge upstream chrome/m151

Bug-fix sync of the mono/skia `skiasharp` branch with upstream `google/skia` `chrome/m151`.
Same milestone — no C API, `BUILD.gn`, `DEPS`, or version-file changes.

## Upstream commits merged (2)

| SHA | Subject |
|-----|---------|
| `c3226a9bcd` | [M151] [Ganesh] If a resolve task fails to execute unwind the dirty tracking |
| `496631a9db` | [M151] [Ganesh] Make sure stencil is cleared on kPreserve |

Merge base: `87424bcdba68e14ff3b40524ed09ad150ce3c92e`
Merge commit: `80ba1418a67efa434107877d3d090d889f9a6286`

## Files changed by upstream

Only internal Ganesh sources + upstream test files:

- `src/gpu/ganesh/GrDrawingManager.cpp`
- `src/gpu/ganesh/GrTextureResolveRenderTask.{h,cpp}`
- `src/gpu/ganesh/ops/OpsTask.cpp`
- `tests/GrSurfaceResolveTest.cpp`
- `tests/StencilClearTest.cpp`

No changes to `include/`, `src/c/`, `BUILD.gn`, `DEPS`, or any file used by the C API shim.

## Conflicts resolved

None — automatic merge, zero conflict markers. All 1032 fork patches on the base
branch merged cleanly against upstream (verified via merge-base snapshot in
`/tmp/gh-aw/agent/fork-patches-before.txt`).

## Verification

- `ls src/c/*.cpp include/c/*.h` — all C API files intact
- `git diff --check` — zero conflict markers
- Two-parent merge commit with proper history

## Items needing human attention

None from this merge. A pre-existing broken host-provisioned `pwsh` install (missing base
utility module binaries under `/opt/microsoft/powershell/7/Modules/`) blocked
`update-versions.ps1` / `regenerate-bindings.ps1`; work performed manually with equivalent
steps. Worth fixing the workflow's PowerShell install so future automated syncs can run the
skill scripts unchanged.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).