### PR TITLE
[skia-sync] Merge upstream chrome/m150

### DIFF
--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -507,8 +507,9 @@ static void resolve_and_mipmap(GrGpu* gpu, GrSurfaceProxy* proxy) {
     if (auto* textureProxy = proxy->asTextureProxy()) {
         if (textureProxy->mipmapsAreDirty()) {
             SkASSERT(textureProxy->peekTexture());
-            gpu->regenerateMipMapLevels(textureProxy->peekTexture());
-            textureProxy->markMipmapsClean();
+            if (gpu->regenerateMipMapLevels(textureProxy->peekTexture())) {
+                textureProxy->markMipmapsClean();
+            }
         }
     }
 }

--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -175,6 +175,7 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
     }
 
     bool cachePurgeNeeded = false;
+    bool flushSuccessful = false;
 
     if (preFlushSuccessful) {
         bool usingReorderedDAG = false;
@@ -205,8 +206,10 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
             resourceAllocator.assign();
         }
 
-        cachePurgeNeeded = !resourceAllocator.failedInstantiation() &&
-                           this->executeRenderTasks(&flushState);
+        if (!resourceAllocator.failedInstantiation()) {
+            cachePurgeNeeded = this->executeRenderTasks(&flushState);
+            flushSuccessful = true;
+        }
     }
     this->removeRenderTasks();
 
@@ -226,7 +229,7 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
     }
     fFlushing = false;
 
-    return true;
+    return flushSuccessful;
 }
 
 bool GrDrawingManager::submitToGpu() {

--- a/src/gpu/ganesh/GrTextureResolveRenderTask.cpp
+++ b/src/gpu/ganesh/GrTextureResolveRenderTask.cpp
@@ -94,29 +94,53 @@ bool GrTextureResolveRenderTask::onExecute(GrOpFlushState* flushState) {
     // Resolve all msaa back-to-back, before regenerating mipmaps.
     SkASSERT(fResolves.size() == this->numTargets());
     for (int i = 0; i < fResolves.size(); ++i) {
-        const Resolve& resolve = fResolves[i];
+        Resolve& resolve = fResolves[i];
         if (GrSurfaceProxy::ResolveFlags::kMSAA & resolve.fFlags) {
             GrSurfaceProxy* proxy = this->target(i);
             // peekRenderTarget might be null if there was an instantiation error.
             if (GrRenderTarget* renderTarget = proxy->peekRenderTarget()) {
                 flushState->gpu()->resolveRenderTarget(renderTarget, resolve.fMSAAResolveRect);
+                resolve.fFlags &= ~GrSurfaceProxy::ResolveFlags::kMSAA;
             }
         }
     }
     // Regenerate all mipmaps back-to-back.
     for (int i = 0; i < fResolves.size(); ++i) {
-        const Resolve& resolve = fResolves[i];
+        Resolve& resolve = fResolves[i];
         if (GrSurfaceProxy::ResolveFlags::kMipMaps & resolve.fFlags) {
             // peekTexture might be null if there was an instantiation error.
             GrTexture* texture = this->target(i)->peekTexture();
-            if (texture && texture->mipmapsAreDirty()) {
-                flushState->gpu()->regenerateMipMapLevels(texture);
-                SkASSERT(!texture->mipmapsAreDirty());
+            if (texture && (!texture->mipmapsAreDirty() ||
+                            flushState->gpu()->regenerateMipMapLevels(texture))) {
+                resolve.fFlags &= ~GrSurfaceProxy::ResolveFlags::kMipMaps;
             }
         }
     }
 
     return true;
+}
+
+void GrTextureResolveRenderTask::endFlush(GrDrawingManager* drawingMgr) {
+    // Any flags still set here correspond to resolves that were recorded by addProxy() but never
+    // executed (the flush was dropped before render-task execution, this task was skipped because
+    // its targets failed to instantiate, or a per-target operation failed). Re-mark those proxies
+    // dirty so a subsequent flush will re-record the resolve.
+    SkASSERT(fResolves.size() == this->numTargets());
+    for (int i = 0; i < fResolves.size(); ++i) {
+        const Resolve& resolve = fResolves[i];
+        GrSurfaceProxy* proxy = this->target(i);
+        if (GrSurfaceProxy::ResolveFlags::kMSAA & resolve.fFlags) {
+            if (GrRenderTargetProxy* rtProxy = proxy->asRenderTargetProxy()) {
+                rtProxy->markMSAADirty(resolve.fMSAAResolveRect);
+            }
+        }
+        if (GrSurfaceProxy::ResolveFlags::kMipMaps & resolve.fFlags) {
+            if (GrTextureProxy* texProxy = proxy->asTextureProxy()) {
+                texProxy->markMipmapsDirty();
+            }
+        }
+    }
+    this->GrRenderTask::endFlush(drawingMgr);
 }
 
 #ifdef SK_DEBUG

--- a/src/gpu/ganesh/GrTextureResolveRenderTask.h
+++ b/src/gpu/ganesh/GrTextureResolveRenderTask.h
@@ -44,6 +44,12 @@ private:
 
     bool onExecute(GrOpFlushState*) override;
 
+    // addProxy() optimistically marks the proxy resolved/clean at recording time. If the flush
+    // is dropped before this task executes (or a per-target operation fails) we must restore the
+    // proxy's dirty state so a later flush will re-record the resolve.
+    bool requiresExplicitCleanup() const override { return true; }
+    void endFlush(GrDrawingManager*) override;
+
 #if defined(GPU_TEST_UTILS)
     const char* name() const final { return "TextureResolve"; }
 #endif

--- a/src/gpu/ganesh/SurfaceContext.cpp
+++ b/src/gpu/ganesh/SurfaceContext.cpp
@@ -292,7 +292,12 @@ bool SurfaceContext::readPixels(GrDirectContext* dContext, GrPixmap dst, SkIPoin
         pt.fY = flip ? srcSurface->height() - pt.fY - dst.height() : pt.fY;
     }
 
-    dContext->priv().flushSurface(srcProxy.get());
+    bool hasPendingTasks =
+            dContext->priv().drawingManager()->getLastRenderTask(srcProxy.get()) != nullptr;
+    GrSemaphoresSubmitted flushResult = dContext->priv().flushSurface(srcProxy.get());
+    if (flushResult == GrSemaphoresSubmitted::kNo && hasPendingTasks) {
+        return false;
+    }
     dContext->submit();
     if (!dContext->priv().getGpu()->readPixels(srcSurface,
                                                SkIRect::MakePtSize(pt, dst.dimensions()),

--- a/tests/GrSurfaceResolveTest.cpp
+++ b/tests/GrSurfaceResolveTest.cpp
@@ -21,18 +21,23 @@
 #include "include/core/SkTypes.h"
 #include "include/gpu/GpuTypes.h"
 #include "include/gpu/ganesh/GrBackendSurface.h"
+#include "include/gpu/ganesh/GrContextOptions.h"
 #include "include/gpu/ganesh/GrDirectContext.h"
 #include "include/gpu/ganesh/GrTypes.h"
 #include "include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "include/gpu/ganesh/mock/GrMockTypes.h"
 #include "include/private/gpu/ganesh/GrTypesPriv.h"
 #include "src/core/SkColorData.h"
 #include "src/gpu/SkBackingFit.h"
 #include "src/gpu/Swizzle.h"
 #include "src/gpu/ganesh/GrCaps.h"
 #include "src/gpu/ganesh/GrDirectContextPriv.h"
+#include "src/gpu/ganesh/GrDrawingManager.h"
 #include "src/gpu/ganesh/GrFragmentProcessor.h"
+#include "src/gpu/ganesh/GrOnFlushResourceProvider.h"
 #include "src/gpu/ganesh/GrPaint.h"
 #include "src/gpu/ganesh/GrProxyProvider.h"
+#include "src/gpu/ganesh/GrRenderTargetProxy.h"
 #include "src/gpu/ganesh/GrSamplerState.h"
 #include "src/gpu/ganesh/GrSurfaceProxy.h"
 #include "src/gpu/ganesh/GrSurfaceProxyView.h"
@@ -353,6 +358,157 @@ DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(NonmippedDrawBeforeMippedDraw,
         if (resolveTask->flagsForProxy(mmProxy) != expectedFlags) {
             ERRORF(reporter, "Expected resolve flags to be %s", expectedStr);
             return;
+        }
+    }
+}
+
+namespace {
+// A preFlush callback that fails the first N flushes, simulating an allocation failure in an
+// onFlush callback (e.g. atlas instantiation under memory pressure).
+class FailingPreFlushCallback : public GrOnFlushCallbackObject {
+public:
+    explicit FailingPreFlushCallback(int failCount) : fRemainingFailures(failCount) {}
+    bool preFlush(GrOnFlushResourceProvider*) override {
+        if (fRemainingFailures > 0) {
+            --fRemainingFailures;
+            return false;
+        }
+        return true;
+    }
+    bool retainOnFreeGpuResources() override { return true; }
+
+private:
+    int fRemainingFailures;
+};
+}  // namespace
+
+// GrTextureResolveRenderTask::addProxy() optimistically marks a proxy's mipmaps clean / MSAA
+// resolved at recording time. If the owning flush is dropped without executing render tasks
+// (e.g., a preFlush callback or the resource allocator fails) the proxy must be re-dirtied so a
+// later flush will record a new resolve.
+DEF_GANESH_TEST(SurfaceResolveProxyStateAfterFailedFlush,
+                reporter,
+                /* options */,
+                CtsEnforcement::kNever) {
+    using ResolveFlags = GrSurfaceProxy::ResolveFlags;
+    using Enable = GrContextOptions::Enable;
+    using MipmapMode = GrSamplerState::MipmapMode;
+
+    for (auto reduceOpsTaskSplitting : {Enable::kYes, Enable::kNo}) {
+        for (int sampleCount : {1, 4}) {
+            GrMockOptions mockOptions;
+            mockOptions.fMipmapSupport = true;
+            mockOptions.fConfigOptions[(int)GrColorType::kRGBA_8888].fRenderability =
+                    GrMockOptions::ConfigOptions::Renderability::kMSAA;
+            GrContextOptions ctxOptions;
+            ctxOptions.fReduceOpsTaskSplitting = reduceOpsTaskSplitting;
+            sk_sp<GrDirectContext> dContext = GrDirectContext::MakeMock(&mockOptions, ctxOptions);
+            if (!dContext) {
+                ERRORF(reporter, "could not create mock context");
+                continue;
+            }
+            GrDrawingManager* drawingManager = dContext->priv().drawingManager();
+            auto bef = dContext->priv().caps()->getDefaultBackendFormat(GrColorType::kRGBA_8888,
+                                                                        GrRenderable::kYes);
+
+            sk_sp<GrSurfaceProxy> proxy =
+                    dContext->priv().proxyProvider()->createProxy(bef,
+                                                                  {64, 64},
+                                                                  GrRenderable::kYes,
+                                                                  sampleCount,
+                                                                  skgpu::Mipmapped::kYes,
+                                                                  SkBackingFit::kExact,
+                                                                  skgpu::Budgeted::kYes,
+                                                                  GrProtected::kNo,
+                                                                  "ResolveProxyStateTest");
+            if (!proxy) {
+                ERRORF(reporter, "could not create proxy");
+                continue;
+            }
+            GrTextureProxy* texProxy = proxy->asTextureProxy();
+            GrRenderTargetProxy* rtProxy = proxy->asRenderTargetProxy();
+            GrSurfaceProxyView proxyView{proxy,
+                                         kTopLeft_GrSurfaceOrigin,
+                                         skgpu::Swizzle::RGBA()};
+
+            const bool testMSAA = sampleCount > 1;
+            REPORTER_ASSERT(reporter, !testMSAA || proxy->requiresManualMSAAResolve());
+
+            auto recordDirtyingDrawAndMipmappedDependency = [&]() {
+                auto srcSDC =
+                        skgpu::ganesh::SurfaceDrawContext::Make(dContext.get(),
+                                                                GrColorType::kRGBA_8888,
+                                                                proxy,
+                                                                nullptr,
+                                                                kTopLeft_GrSurfaceOrigin,
+                                                                SkSurfaceProps{});
+                srcSDC->fillWithFP(GrFragmentProcessor::MakeColor(SK_PMColor4fWHITE));
+
+                auto dstSDC =
+                        skgpu::ganesh::SurfaceDrawContext::Make(dContext.get(),
+                                                                GrColorType::kRGBA_8888,
+                                                                nullptr,
+                                                                SkBackingFit::kExact,
+                                                                {8, 8},
+                                                                SkSurfaceProps{},
+                                                                "ResolveProxyStateTestDst");
+                auto te = GrTextureEffect::Make(
+                        proxyView,
+                        kPremul_SkAlphaType,
+                        SkMatrix::I(),
+                        GrSamplerState{SkFilterMode::kLinear, MipmapMode::kLinear},
+                        *dContext->priv().caps());
+                GrPaint paint;
+                paint.setColorFragmentProcessor(std::move(te));
+                dstSDC->drawRect(nullptr,
+                                 std::move(paint),
+                                 GrAA::kNo,
+                                 SkMatrix::Scale(1/8.f, 1/8.f),
+                                 SkRect::Make(proxy->dimensions()));
+                return dstSDC;
+            };
+
+            // Record a flush whose preFlush callback fails. The resolve task records the proxy
+            // as resolved/clean and is then discarded without executing.
+            {
+                FailingPreFlushCallback failCB(1);
+                dContext->priv().addOnFlushCallbackObject(&failCB);
+
+                auto dstSDC = recordDirtyingDrawAndMipmappedDependency();
+
+                ResolveFlags expectedFlags = ResolveFlags::kMipMaps;
+                if (testMSAA) {
+                    expectedFlags |= ResolveFlags::kMSAA;
+                }
+                const GrTextureResolveRenderTask* resolveTask =
+                        dstSDC->getOpsTask()->resolveTask();
+                REPORTER_ASSERT(reporter,
+                                resolveTask &&
+                                        resolveTask->flagsForProxy(proxy) == expectedFlags);
+                REPORTER_ASSERT(reporter, !texProxy->mipmapsAreDirty());
+                REPORTER_ASSERT(reporter, !testMSAA || !rtProxy->isMSAADirty());
+
+                dContext->flush();
+                drawingManager->testingOnly_removeOnFlushCallbackObject(&failCB);
+            }
+
+            // The resolve never executed so the proxy must once again report dirty mips/MSAA.
+            REPORTER_ASSERT(reporter, texProxy->mipmapsAreDirty());
+            if (testMSAA) {
+                REPORTER_ASSERT(reporter, rtProxy->isMSAADirty());
+                REPORTER_ASSERT(reporter,
+                                rtProxy->msaaDirtyRect() == SkIRect::MakeSize(proxy->dimensions()));
+            }
+
+            // A subsequent dependency must therefore record a new resolve task and the proxy
+            // should be clean once that flush succeeds.
+            {
+                auto dstSDC = recordDirtyingDrawAndMipmappedDependency();
+                REPORTER_ASSERT(reporter, dstSDC->getOpsTask()->resolveTask());
+                dContext->flush();
+            }
+            REPORTER_ASSERT(reporter, !texProxy->mipmapsAreDirty());
+            REPORTER_ASSERT(reporter, !testMSAA || !rtProxy->isMSAADirty());
         }
     }
 }

--- a/tests/ReadWritePixelsGpuTest.cpp
+++ b/tests/ReadWritePixelsGpuTest.cpp
@@ -43,7 +43,9 @@
 #include "src/gpu/ganesh/GrCaps.h"
 #include "src/gpu/ganesh/GrDataUtils.h"
 #include "src/gpu/ganesh/GrDirectContextPriv.h"
+#include "src/gpu/ganesh/GrDrawingManager.h"
 #include "src/gpu/ganesh/GrImageInfo.h"
+#include "src/gpu/ganesh/GrOnFlushResourceProvider.h"
 #include "src/gpu/ganesh/GrPixmap.h"
 #include "src/gpu/ganesh/GrSamplerState.h"
 #include "src/gpu/ganesh/GrSurfaceProxy.h"
@@ -242,6 +244,19 @@ using GpuWriteDstFn = Result(const T&, const SkIPoint& offset, const SkPixmap&);
 // converting read (i.e. the image info of the returned pixmap matches that of the T).
 template <typename T>
 using GpuReadDstFn = SkAutoPixmapStorage(const T&);
+
+class FailingFlushCallback : public GrOnFlushCallbackObject {
+public:
+    bool preFlush(GrOnFlushResourceProvider*) override {
+        ++fCount;
+        return false;
+    }
+
+    int count() const { return fCount; }
+
+private:
+    int fCount = 0;
+};
 
 }  // anonymous namespace
 
@@ -1504,3 +1519,61 @@ DEF_GANESH_TEST_FOR_GL_CONTEXT(GLReadPixelsUnbindPBO,
 
     ComparePixels(syncResult.pixmap(), asyncResult, tol, error);
 }
+
+// readPixels() that uses an intermediate scratch surface should not return stale recycled scratch
+// contents if the implicit flush of the queued draw into that surface drops its render tasks.
+DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(ReadPixelsIntermediateFailedFlush,
+                                       reporter,
+                                       ctxInfo,
+                                       CtsEnforcement::kNextRelease) {
+    auto dContext = ctxInfo.directContext();
+    if (dContext->supportsProtectedContent()) {
+        return;
+    }
+
+    static constexpr int kSize = 100;
+    static constexpr SkColor kStaleColor = 0xFF112233;
+    static constexpr SkColor kSrcColor = 0xFF008800;
+
+    auto srcII = SkImageInfo::Make({kSize, kSize}, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+    auto dstII = srcII.makeAlphaType(kUnpremul_SkAlphaType);
+    auto surf = SkSurfaces::RenderTarget(dContext, skgpu::Budgeted::kYes, srcII);
+    if (!surf) {
+        return;
+    }
+
+    SkAutoPixmapStorage pixels;
+    pixels.alloc(dstII);
+
+    // Reading the unpremul destination from the premul source draws through an intermediate
+    // approx-fit surface. Do this once so a matching scratch surface lands in the resource cache
+    // with known stale contents.
+    surf->getCanvas()->clear(kStaleColor);
+    if (!surf->readPixels(pixels, 0, 0)) {
+        return;
+    }
+
+    surf->getCanvas()->clear(kSrcColor);
+    dContext->flushAndSubmit(GrSyncCpu::kYes);
+
+    // From here on the flush-time callback fails so any queued render tasks are discarded.
+    FailingFlushCallback failingCallback;
+    dContext->priv().addOnFlushCallbackObject(&failingCallback);
+
+    pixels.erase(SkColors::kTransparent);
+    bool ok = surf->readPixels(pixels, 0, 0);
+
+    dContext->priv().drawingManager()->testingOnly_removeOnFlushCallbackObject(&failingCallback);
+
+    if (ok) {
+        SkColor result = pixels.getColor(0, 0);
+        REPORTER_ASSERT(reporter,
+                        result == kSrcColor,
+                        "readPixels reported success but returned 0x%08x, expected 0x%08x",
+                        result,
+                        kSrcColor);
+    } else {
+        REPORTER_ASSERT(reporter, failingCallback.count() > 0);
+    }
+}
+


### PR DESCRIPTION
Automated upstream merge of `chrome/m150`.

# [skia-sync] Merge upstream chrome/m150 into release/4.150.x

Release-line bug-fix sync — merges the latest 2 upstream `chrome/m150` commits into `release/4.150.x`.

## Upstream commits merged

| SHA | Subject |
|-----|---------|
| `587c5b0f5a` | [M150] [ganesh] prevent stale readbacks |
| `37d3aa648b` | [Ganesh] If a resolve task fails to execute unwind the dirty tracking |

Merge commit: `9280c2de35` (two-parent).

## Conflicts resolved

None — merge was clean (`Automatic merge went well`). Only upstream Ganesh source files touched:
`src/gpu/ganesh/GrDrawingManager.cpp`, `GrTextureResolveRenderTask.{cpp,h}`, `SurfaceContext.cpp`,
and two test files. No fork patches touch these files, so no upstream-or-reapply classification was
needed.

## C API changes

None. All `src/c/` and `include/c/` files intact (79 files unchanged).

## Items needing human attention

None.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).