### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -175,6 +175,7 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
     }
 
     bool cachePurgeNeeded = false;
+    bool flushSuccessful = false;
 
     if (preFlushSuccessful) {
         bool usingReorderedDAG = false;
@@ -205,8 +206,10 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
             resourceAllocator.assign();
         }
 
-        cachePurgeNeeded = !resourceAllocator.failedInstantiation() &&
-                           this->executeRenderTasks(&flushState);
+        if (!resourceAllocator.failedInstantiation()) {
+            cachePurgeNeeded = this->executeRenderTasks(&flushState);
+            flushSuccessful = true;
+        }
     }
     this->removeRenderTasks();
 
@@ -226,7 +229,7 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
     }
     fFlushing = false;
 
-    return true;
+    return flushSuccessful;
 }
 
 bool GrDrawingManager::submitToGpu() {

--- a/src/gpu/ganesh/SurfaceContext.cpp
+++ b/src/gpu/ganesh/SurfaceContext.cpp
@@ -292,7 +292,12 @@ bool SurfaceContext::readPixels(GrDirectContext* dContext, GrPixmap dst, SkIPoin
         pt.fY = flip ? srcSurface->height() - pt.fY - dst.height() : pt.fY;
     }
 
-    dContext->priv().flushSurface(srcProxy.get());
+    bool hasPendingTasks =
+            dContext->priv().drawingManager()->getLastRenderTask(srcProxy.get()) != nullptr;
+    GrSemaphoresSubmitted flushResult = dContext->priv().flushSurface(srcProxy.get());
+    if (flushResult == GrSemaphoresSubmitted::kNo && hasPendingTasks) {
+        return false;
+    }
     dContext->submit();
     if (!dContext->priv().getGpu()->readPixels(srcSurface,
                                                SkIRect::MakePtSize(pt, dst.dimensions()),

--- a/tests/ReadWritePixelsGpuTest.cpp
+++ b/tests/ReadWritePixelsGpuTest.cpp
@@ -43,7 +43,9 @@
 #include "src/gpu/ganesh/GrCaps.h"
 #include "src/gpu/ganesh/GrDataUtils.h"
 #include "src/gpu/ganesh/GrDirectContextPriv.h"
+#include "src/gpu/ganesh/GrDrawingManager.h"
 #include "src/gpu/ganesh/GrImageInfo.h"
+#include "src/gpu/ganesh/GrOnFlushResourceProvider.h"
 #include "src/gpu/ganesh/GrPixmap.h"
 #include "src/gpu/ganesh/GrSamplerState.h"
 #include "src/gpu/ganesh/GrSurfaceProxy.h"
@@ -242,6 +244,19 @@ using GpuWriteDstFn = Result(const T&, const SkIPoint& offset, const SkPixmap&);
 // converting read (i.e. the image info of the returned pixmap matches that of the T).
 template <typename T>
 using GpuReadDstFn = SkAutoPixmapStorage(const T&);
+
+class FailingFlushCallback : public GrOnFlushCallbackObject {
+public:
+    bool preFlush(GrOnFlushResourceProvider*) override {
+        ++fCount;
+        return false;
+    }
+
+    int count() const { return fCount; }
+
+private:
+    int fCount = 0;
+};
 
 }  // anonymous namespace
 
@@ -1513,3 +1528,61 @@ DEF_GANESH_TEST_FOR_GL_CONTEXT(GLReadPixelsUnbindPBO,
 
     ComparePixels(syncResult.pixmap(), asyncResult, tol, error);
 }
+
+// readPixels() that uses an intermediate scratch surface should not return stale recycled scratch
+// contents if the implicit flush of the queued draw into that surface drops its render tasks.
+DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(ReadPixelsIntermediateFailedFlush,
+                                       reporter,
+                                       ctxInfo,
+                                       CtsEnforcement::kNextRelease) {
+    auto dContext = ctxInfo.directContext();
+    if (dContext->supportsProtectedContent()) {
+        return;
+    }
+
+    static constexpr int kSize = 100;
+    static constexpr SkColor kStaleColor = 0xFF112233;
+    static constexpr SkColor kSrcColor = 0xFF008800;
+
+    auto srcII = SkImageInfo::Make({kSize, kSize}, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+    auto dstII = srcII.makeAlphaType(kUnpremul_SkAlphaType);
+    auto surf = SkSurfaces::RenderTarget(dContext, skgpu::Budgeted::kYes, srcII);
+    if (!surf) {
+        return;
+    }
+
+    SkAutoPixmapStorage pixels;
+    pixels.alloc(dstII);
+
+    // Reading the unpremul destination from the premul source draws through an intermediate
+    // approx-fit surface. Do this once so a matching scratch surface lands in the resource cache
+    // with known stale contents.
+    surf->getCanvas()->clear(kStaleColor);
+    if (!surf->readPixels(pixels, 0, 0)) {
+        return;
+    }
+
+    surf->getCanvas()->clear(kSrcColor);
+    dContext->flushAndSubmit(GrSyncCpu::kYes);
+
+    // From here on the flush-time callback fails so any queued render tasks are discarded.
+    FailingFlushCallback failingCallback;
+    dContext->priv().addOnFlushCallbackObject(&failingCallback);
+
+    pixels.erase(SkColors::kTransparent);
+    bool ok = surf->readPixels(pixels, 0, 0);
+
+    dContext->priv().drawingManager()->testingOnly_removeOnFlushCallbackObject(&failingCallback);
+
+    if (ok) {
+        SkColor result = pixels.getColor(0, 0);
+        REPORTER_ASSERT(reporter,
+                        result == kSrcColor,
+                        "readPixels reported success but returned 0x%08x, expected 0x%08x",
+                        result,
+                        kSrcColor);
+    } else {
+        REPORTER_ASSERT(reporter, failingCallback.count() > 0);
+    }
+}
+


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

## Skia sync — chrome/m151 (bug-fix, same milestone)

Merges 1 new upstream commit from `google/skia` `chrome/m151` into mono/skia `skiasharp`.

### Upstream commits merged

| SHA | Subject |
|-----|---------|
| `b4204f7ff9` | [M151] [ganesh] prevent stale readbacks |

Upstream tip merged: `b4204f7ff931ec662a690d00b2d1c19afeb3a4fe`

### Merge

- Strategy: recursive/ort merge, **no conflicts**.
- Base: `skiasharp` (mono/skia) at `5952f46c4d`.
- Head: `skia-sync/m151`.

### Files touched by the upstream commit

```
src/gpu/ganesh/GrDrawingManager.cpp |  9 +++--
src/gpu/ganesh/SurfaceContext.cpp   |  7 +++-
tests/ReadWritePixelsGpuTest.cpp    | 73 +++++++++++++++++++++++++++++++++++++
```

All changes are **internal Ganesh (GPU) implementation** — no public headers,
no `include/c/` C API, no `src/c/` shim changes.

### C API / binding impact

- Diff of `include/c/`, `src/c/`, `include/core/`, `include/gpu/`, `include/ports/`,
  `include/effects/` between `skiasharp..HEAD`: **empty**.
- No new `SK_API` declarations.
- No binding regeneration needed on the SkiaSharp side.

### Items needing human attention

None. This is a targeted GPU bug-fix cherry-pick with no API surface change.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).