### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,51 +1,104 @@
-**Description of Change**
-
 <!--
-    Describe your changes here.
+Thanks for contributing to the SkiaSharp fork of Skia!
+
+• Target the `skiasharp` branch (our long-lived integration branch) — not `main`.
+• This fork adds the C API shim in include/c/ and src/c/ plus build tweaks.
+  Keep changes minimal and additive so upstream Skia merges stay clean.
+• Just fill in the Description — the other sections have sensible defaults. Each
+  section's comment holds a copy-paste block; drop it in only when you have something.
 -->
 
-**SkiaSharp Issue**
+## Description
 
 <!--
-    Provide links to SkiaSharp issues here.
-    Ensure that a GitHub issue was created for your feature or bug fix before sending PR.
+What does this change do, and why?
+
+• New or changed C API? Say what SkiaSharp scenario it unblocks, and list the
+  exact exports under Changes below.
+• Upstream merge / milestone bump? Note the milestone number and the upstream
+  Skia ref (tag or commit) you merged/rebased onto, plus any C API fix-ups needed.
+• Dependency bump (DEPS)? Note the dependency, old → new version, and any CVE(s)
+  it addresses, with a link to the upstream changelog.
 -->
+
+**SkiaSharp issue**
 
 Related to https://github.com/mono/SkiaSharp/issues/<issue-number>
 
-**API Changes**
-
-None.
-
-<!--
-List all API changes here (or just put None), example:
-
-Added: 
-- `void skobject_method_name()`
-
-Changed:
- - `void skobject_old_method_name()` => `void skobject_new_method_name()`
--->
-
-**Behavioral Changes**
-
-None.
-
-<!--
-    Describe any non-bug related behavioral changes that may change how users app behaves
-    when upgrading to this version of the codebase.
--->
+<!-- Ensure a SkiaSharp issue exists for the feature or bug before opening this PR. -->
 
 **Required SkiaSharp PR**
 
 Requires https://github.com/mono/SkiaSharp/pull/<pr-number>
 
 <!--
-    Replace this with the full URL to the skia PR.
+Every change here — including build, CI, or infrastructure — needs a companion
+SkiaSharp PR to actually take effect: at minimum one that bumps the SkiaSharp
+submodule to this commit. A C API change additionally needs that PR to regenerate
+the P/Invoke bindings (pwsh ./utils/generate.ps1) and add the managed wrapper +
+tests. Link it above; open the SkiaSharp PR first if it doesn't exist yet.
 -->
 
-**PR Checklist**
+**Areas affected**
 
-- [ ] Rebased on top of `skiasharp` at time of PR
-- [ ] Changes adhere to coding standard
-- [ ] Updated documentation
+- [ ] C API (`include/c`, `src/c`)
+- [ ] Native dependency / `DEPS`
+- [ ] Build (gn / build files)
+- [ ] Upstream Skia merge or rebase
+- [ ] Rendering output / behavior
+- [ ] Other
+
+## Changes
+
+None.
+
+<!--
+Scope: the exported C API surface and any observable BEHAVIOR — NOT a file-by-file
+list. The diff already shows which files changed; the "what & why" belongs in
+Description above. An upstream-merge or build-only PR that changes neither can
+just leave "None."
+
+The C API is consumed by SkiaSharp's generated P/Invoke bindings, so any change
+here must be paired with a SkiaSharp PR that regenerates them. Copy the parts that
+apply over "None." and delete the rest:
+
+**C API**
+
+```c
+// added
+void sk_canvas_draw_foo(sk_canvas_t* canvas, float x, float y, const sk_paint_t* paint);
+
+// renamed / changed
+void sk_object_old_name()  =>  void sk_object_new_name()
+```
+
+**Behavior**
+
+A change to rendering output, defaults, or behavior an upgrading app would notice.
+-->
+
+## Testing
+
+<!--
+How did you verify this builds and behaves correctly? Note which platforms/backends
+you built/ran on (CPU, GPU/Metal/Vulkan/ANGLE, Windows/macOS/Linux/Android/iOS/WASM)
+and anything you could NOT test. Most functional verification happens in the
+companion SkiaSharp PR — link its tests.
+
+Rendering change? Copy this in to show the difference:
+
+<details>
+<summary>Screenshots (before / after)</summary>
+
+| Before | After |
+| --- | --- |
+|  |  |
+
+</details>
+-->
+
+## Checklist
+
+- [ ] Targets the `skiasharp` branch
+- [ ] `Changes` above lists every added/changed C API export (or "None.")
+- [ ] Companion `mono/SkiaSharp` PR linked above (submodule bump at minimum; regenerates bindings + adds tests for C API changes)


### PR DESCRIPTION
This pull request updates the `.github/pull_request_template.md` file to provide clearer guidance for contributors to the SkiaSharp fork of Skia. The template now emphasizes the correct target branch, the requirement for minimal and additive changes, and the need for a corresponding SkiaSharp PR. It also introduces structured sections for describing the change, affected areas, and testing.

The most important changes are:

**Contribution Guidelines and Process:**
* Clarified that all pull requests should target the `skiasharp` branch, not `main`, and outlined the fork’s policy for minimal, additive changes to keep upstream merges clean.
* Added instructions that every change requires a companion SkiaSharp PR, especially for C API changes, and that the SkiaSharp PR should be opened first if it does not already exist.

**Template Structure and Content:**
* Reorganized sections to focus on a clear description of the change, including specific guidance for C API, upstream merges, and dependency bumps.
* Added a checklist for contributors to ensure all requirements are met, including listing all C API changes and linking the companion SkiaSharp PR.
* Provided explicit sections for listing affected areas, summarizing C API and behavioral changes, and describing testing steps, with examples and copy-paste blocks to guide contributors.