### PR TITLE
Add C API for async rescale-and-read-pixels (SkImage/SkSurface/Ganesh)

### DIFF
--- a/include/c/gr_context.h
+++ b/include/c/gr_context.h
@@ -109,6 +109,10 @@ SK_C_API int gr_backendrendertarget_get_stencils(const gr_backendrendertarget_t*
 SK_C_API gr_backend_t gr_backendrendertarget_get_backend(const gr_backendrendertarget_t* rendertarget);
 SK_C_API bool gr_backendrendertarget_get_gl_framebufferinfo(const gr_backendrendertarget_t* rendertarget, gr_gl_framebufferinfo_t* glInfo);
 
+// Drives completion of asynchronous work (e.g. sk_image/sk_surface_async_rescale_and_read_pixels)
+// on the Ganesh backend. A submit must also occur to guarantee a finite time before callbacks fire.
+SK_C_API void gr_direct_context_check_async_work_completion(gr_direct_context_t* context);
+
 
 SK_C_PLUS_PLUS_END_GUARD
 

--- a/include/c/sk_image.h
+++ b/include/c/sk_image.h
@@ -50,6 +50,11 @@ SK_C_API sk_image_t* sk_image_make_raster_image(const sk_image_t* cimage);
 SK_C_API sk_image_t* sk_image_make_with_filter_raster(const sk_image_t* cimage, const sk_imagefilter_t* filter, const sk_irect_t* subset, const sk_irect_t* clipBounds, sk_irect_t* outSubset, sk_ipoint_t* outOffset);
 SK_C_API sk_image_t* sk_image_make_with_filter(const sk_image_t* cimage, gr_recording_context_t* context, const sk_imagefilter_t* filter, const sk_irect_t* subset, const sk_irect_t* clipBounds, sk_irect_t* outSubset, sk_ipoint_t* outOffset);
 
+SK_C_API int32_t sk_image_async_read_result_get_count(const sk_image_async_read_result_t* result);
+SK_C_API const void* sk_image_async_read_result_get_data(const sk_image_async_read_result_t* result, int32_t planeIndex);
+SK_C_API size_t sk_image_async_read_result_get_row_bytes(const sk_image_async_read_result_t* result, int32_t planeIndex);
+SK_C_API void sk_image_async_rescale_and_read_pixels(const sk_image_t* image, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context);
+
 SK_C_PLUS_PLUS_END_GUARD
 
 #endif

--- a/include/c/sk_surface.h
+++ b/include/c/sk_surface.h
@@ -45,6 +45,8 @@ SK_C_API void sk_surfaceprops_delete(sk_surfaceprops_t* props);
 SK_C_API uint32_t sk_surfaceprops_get_flags(sk_surfaceprops_t* props);
 SK_C_API sk_pixelgeometry_t sk_surfaceprops_get_pixel_geometry(sk_surfaceprops_t* props);
 
+SK_C_API void sk_surface_async_rescale_and_read_pixels(sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context);
+
 SK_C_PLUS_PLUS_END_GUARD
 
 #endif

--- a/include/c/sk_types.h
+++ b/include/c/sk_types.h
@@ -804,6 +804,31 @@ typedef void (*sk_surface_raster_release_proc)(void* addr, void* context);
 
 typedef void (*sk_glyph_path_proc)(const sk_path_t* pathOrNull, const sk_matrix_t* matrix, void* context);
 
+// The result of an asynchronous rescale-and-read-pixels request. This maps directly to the core
+// SkImage::AsyncReadResult and is shared by the SkImage, SkSurface and (GPU backend) context
+// readback APIs. The pointer is non-owning and is only valid for the duration of the
+// sk_image_async_read_pixels_proc callback.
+typedef struct sk_image_async_read_result_t sk_image_async_read_result_t;
+
+// Controls the gamma that rescaling occurs in. Maps to SkImage::RescaleGamma.
+typedef enum {
+    SRC_SK_IMAGE_RESCALE_GAMMA,
+    LINEAR_SK_IMAGE_RESCALE_GAMMA,
+} sk_image_rescale_gamma_t;
+
+// Controls the technique (and cost) of the rescaling. Maps to SkImage::RescaleMode.
+typedef enum {
+    NEAREST_SK_IMAGE_RESCALE_MODE,
+    LINEAR_SK_IMAGE_RESCALE_MODE,
+    REPEATED_LINEAR_SK_IMAGE_RESCALE_MODE,
+    REPEATED_CUBIC_SK_IMAGE_RESCALE_MODE,
+} sk_image_rescale_mode_t;
+
+// Called when an asynchronous read is ready or on failure. Maps to SkImage::ReadPixelsCallback.
+// 'result' is non-owning and is only valid for the duration of the callback; it is nullptr on
+// failure.
+typedef void (*sk_image_async_read_pixels_proc)(void* context, const sk_image_async_read_result_t* result);
+
 typedef enum {
     ALLOW_SK_IMAGE_CACHING_HINT,
     DISALLOW_SK_IMAGE_CACHING_HINT,

--- a/src/c/gr_context.cpp
+++ b/src/c/gr_context.cpp
@@ -158,6 +158,10 @@ void gr_direct_context_flush_and_submit(gr_direct_context_t* context, bool syncC
     SK_ONLY_GPU(AsGrDirectContext(context)->flushAndSubmit((GrSyncCpu)syncCpu));
 }
 
+void gr_direct_context_check_async_work_completion(gr_direct_context_t* context) {
+    SK_ONLY_GPU(AsGrDirectContext(context)->checkAsyncWorkCompletion());
+}
+
 void gr_direct_context_flush_image(gr_direct_context_t* context, const sk_image_t* image) {
     SK_ONLY_GPU(AsGrDirectContext(context)->flush(sk_ref_sp(AsImage(image)), GrFlushInfo()));
 }

--- a/src/c/sk_image.cpp
+++ b/src/c/sk_image.cpp
@@ -140,6 +140,41 @@ bool sk_image_scale_pixels(const sk_image_t* image, const sk_pixmap_t* dst, cons
     return AsImage(image)->scalePixels(*AsPixmap(dst), *AsSamplingOptions(sampling), (SkImage::CachingHint)cachingHint);
 }
 
+int32_t sk_image_async_read_result_get_count(const sk_image_async_read_result_t* result) {
+    return AsImageAsyncReadResult(result)->count();
+}
+
+const void* sk_image_async_read_result_get_data(const sk_image_async_read_result_t* result, int32_t planeIndex) {
+    return AsImageAsyncReadResult(result)->data(planeIndex);
+}
+
+size_t sk_image_async_read_result_get_row_bytes(const sk_image_async_read_result_t* result, int32_t planeIndex) {
+    return AsImageAsyncReadResult(result)->rowBytes(planeIndex);
+}
+
+void sk_image_async_rescale_and_read_pixels(const sk_image_t* image, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context) {
+    // The read may complete asynchronously (Ganesh), so the (proc + context) pair is heap-allocated
+    // and freed by the trampoline once the callback fires. Mirrors the sk_font_get_paths bridge idiom.
+    struct Bridge {
+        void* fContext;
+        sk_image_async_read_pixels_proc fProc;
+    };
+    auto* bridge = new Bridge { context, callback };
+    auto proc = [](SkImage::ReadPixelsContext c, std::unique_ptr<const SkImage::AsyncReadResult> result) {
+        auto* bridge = static_cast<Bridge*>(c);
+        bridge->fProc(bridge->fContext, ToImageAsyncReadResult(result.get()));
+        delete bridge;
+        // 'result' (and the pointer the callback saw) is destroyed here as the unique_ptr goes out of scope.
+    };
+    AsImage(image)->asyncRescaleAndReadPixels(
+        AsImageInfo(dstInfo),
+        *AsIRect(srcRect),
+        (SkImage::RescaleGamma)rescaleGamma,
+        (SkImage::RescaleMode)rescaleMode,
+        proc,
+        bridge);
+}
+
 sk_data_t* sk_image_ref_encoded(const sk_image_t* cimage) {
     // refEncodedData() returns sk_sp<const SkData> in m147
     sk_sp<const SkData> data = AsImage(cimage)->refEncodedData();

--- a/src/c/sk_image.cpp
+++ b/src/c/sk_image.cpp
@@ -153,6 +153,8 @@ size_t sk_image_async_read_result_get_row_bytes(const sk_image_async_read_result
 }
 
 void sk_image_async_rescale_and_read_pixels(const sk_image_t* image, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context) {
+    if (!callback)
+        return;
     // The read may complete asynchronously (Ganesh), so the (proc + context) pair is heap-allocated
     // and freed by the trampoline once the callback fires. Mirrors the sk_font_get_paths bridge idiom.
     struct Bridge {

--- a/src/c/sk_surface.cpp
+++ b/src/c/sk_surface.cpp
@@ -97,6 +97,28 @@ bool sk_surface_read_pixels(sk_surface_t* surface, sk_imageinfo_t* dstInfo, void
     return AsSurface(surface)->readPixels(AsImageInfo(dstInfo), dstPixels, dstRowBytes, srcX, srcY);
 }
 
+void sk_surface_async_rescale_and_read_pixels(sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context) {
+    // The read may complete asynchronously (Ganesh), so the (proc + context) pair is heap-allocated
+    // and freed by the trampoline once the callback fires. Mirrors the sk_font_get_paths bridge idiom.
+    struct Bridge {
+        void* fContext;
+        sk_image_async_read_pixels_proc fProc;
+    };
+    auto* bridge = new Bridge { context, callback };
+    auto proc = [](SkImage::ReadPixelsContext c, std::unique_ptr<const SkImage::AsyncReadResult> result) {
+        auto* bridge = static_cast<Bridge*>(c);
+        bridge->fProc(bridge->fContext, ToImageAsyncReadResult(result.get()));
+        delete bridge;
+    };
+    AsSurface(surface)->asyncRescaleAndReadPixels(
+        AsImageInfo(dstInfo),
+        *AsIRect(srcRect),
+        (SkImage::RescaleGamma)rescaleGamma,
+        (SkImage::RescaleMode)rescaleMode,
+        proc,
+        bridge);
+}
+
 const sk_surfaceprops_t* sk_surface_get_props(sk_surface_t* surface) {
     return ToSurfaceProps(&AsSurface(surface)->props());
 }

--- a/src/c/sk_surface.cpp
+++ b/src/c/sk_surface.cpp
@@ -98,6 +98,8 @@ bool sk_surface_read_pixels(sk_surface_t* surface, sk_imageinfo_t* dstInfo, void
 }
 
 void sk_surface_async_rescale_and_read_pixels(sk_surface_t* surface, const sk_imageinfo_t* dstInfo, const sk_irect_t* srcRect, sk_image_rescale_gamma_t rescaleGamma, sk_image_rescale_mode_t rescaleMode, sk_image_async_read_pixels_proc callback, void* context) {
+    if (!callback)
+        return;
     // The read may complete asynchronously (Ganesh), so the (proc + context) pair is heap-allocated
     // and freed by the trampoline once the callback fires. Mirrors the sk_font_get_paths bridge idiom.
     struct Bridge {

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -13,6 +13,7 @@
 #include "include/c/sk_types.h"
 
 #include "include/core/SkTypes.h" // required to make sure SK_GANESH is defined
+#include "include/core/SkImage.h" // for the SkImage::AsyncReadResult mapping below
 
 #define SK_SKIP_ARG__(keep, skip, ...) skip
 #define SK_SKIP_ARG_(args) SK_SKIP_ARG__ args
@@ -126,6 +127,9 @@ DEF_CLASS_MAP(SkFontMgr, sk_fontmgr_t, FontMgr)
 DEF_CLASS_MAP(SkFontStyle, sk_fontstyle_t, FontStyle)
 DEF_CLASS_MAP(SkFontStyleSet, sk_fontstyleset_t, FontStyleSet)
 DEF_CLASS_MAP(SkImage, sk_image_t, Image)
+// SkImage::AsyncReadResult is a class-nested type, so it uses the namespace-qualified map
+// (like DEF_CLASS_MAP_WITH_NS(skottie::Animation, Builder, ...)) rather than a plain DEF_CLASS_MAP.
+DEF_MAP_WITH_NS(SkImage, AsyncReadResult, sk_image_async_read_result_t, ImageAsyncReadResult)
 DEF_CLASS_MAP(SkImageFilter, sk_imagefilter_t, ImageFilter)
 DEF_CLASS_MAP(SkMaskFilter, sk_maskfilter_t, MaskFilter)
 DEF_CLASS_MAP(SkMemoryStream, sk_stream_memorystream_t, MemoryStream)


### PR DESCRIPTION
## Description

Exposes an async rescale-and-read-pixels C API so SkiaSharp can offer a backend-neutral `RequestReadPixels` on `SKImage` and `SKSurface`.

The underlying C++ types — `SkImage::AsyncReadResult`, `SkImage::RescaleGamma`, `SkImage::RescaleMode`, `SkImage::ReadPixelsCallback` — are **core** and shared by the raster, Ganesh and Graphite backends (`SkSurface` merely *aliases* the `SkImage` ones). The C API therefore uses neutral names rather than a backend prefix. The async-read entry lives on `SkImage`/`SkSurface` (raster runs synchronously; Ganesh runs asynchronously and is drained via `GrDirectContext::checkAsyncWorkCompletion`), matching Skia's own design where the deprecated-for-Graphite path is replaced by `skgpu::graphite::Context`.

This lets the in-flight Graphite PR (mono/SkiaSharp#3968) drop its Graphite-prefixed `sk_graphite_async_read_result_*` + rescale enums and consume these neutral ones instead.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/4545 — bumps the submodule, regenerates the P/Invoke bindings, and adds the managed wrapper + tests.

**Areas affected**

- [x] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [ ] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

New (additive-only) C API:

- Types (`sk_types.h`): `sk_image_async_read_result_t` (opaque), `sk_image_rescale_gamma_t`, `sk_image_rescale_mode_t`, `sk_image_async_read_pixels_proc`.
- `sk_image.h`/`.cpp`: `sk_image_async_read_result_get_count` / `_get_data` / `_get_row_bytes`, and `sk_image_async_rescale_and_read_pixels`.
- `sk_surface.h`/`.cpp`: `sk_surface_async_rescale_and_read_pixels`.
- `gr_context.h`/`.cpp`: `gr_direct_context_check_async_work_completion` (drives Ganesh async work so the callback fires).
- `sk_types_priv.h`: `DEF_MAP_WITH_NS` mapping for the nested `SkImage::AsyncReadResult`.

The `(proc + context)` pair is bundled into a heap bridge freed by a non-capturing lambda trampoline once the callback fires — mirroring the existing `sk_font_get_paths` idiom. No existing exports changed.
