### PR TITLE
[skia-sync] Merge upstream chrome/m150

### DIFF
--- a/include/gpu/ganesh/GrDriverBugWorkaroundsAutogen.h
+++ b/include/gpu/ganesh/GrDriverBugWorkaroundsAutogen.h
@@ -21,6 +21,8 @@
          disallow_large_instanced_draw)                 \
   GPU_OP(EMULATE_ABS_INT_FUNCTION,                      \
          emulate_abs_int_function)                      \
+  GPU_OP(ENSURE_PREVIOUS_FRAMEBUFFER_NOT_DELETED,       \
+         ensure_previous_framebuffer_not_deleted)       \
   GPU_OP(FLUSH_ON_FRAMEBUFFER_CHANGE,                   \
          flush_on_framebuffer_change)                   \
   GPU_OP(FORCE_UPDATE_SCISSOR_STATE_WHEN_BINDING_FBO0,  \

--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -126,7 +126,9 @@ bool GrDrawingManager::flush(SkSpan<GrSurfaceProxy*> proxies,
             if (info.fSubmittedProc) {
                 info.fSubmittedProc(info.fSubmittedContext, true);
             }
-            return false;
+            // Nothing to flush is a success (fSubmittedProc is already called with `true`
+            // above).
+            return true;
         }
     }
 
@@ -542,8 +544,11 @@ GrSemaphoresSubmitted GrDrawingManager::flushSurfaces(SkSpan<GrSurfaceProxy*> pr
     // portion of the DAG required by 'proxies' in order to restore some of the
     // semantics of this method.
     bool didFlush = this->flush(proxies, access, info, newState);
-    for (GrSurfaceProxy* proxy : proxies) {
-        resolve_and_mipmap(gpu, proxy);
+    if (didFlush) {
+        // Only resolve/regen mips if the flush actually executed the render tasks.
+        for (GrSurfaceProxy* proxy : proxies) {
+            resolve_and_mipmap(gpu, proxy);
+        }
     }
 
     SkDEBUGCODE(this->validate());

--- a/src/gpu/ganesh/GrDrawingManager.cpp
+++ b/src/gpu/ganesh/GrDrawingManager.cpp
@@ -995,16 +995,6 @@ bool GrDrawingManager::newWritePixelsTask(sk_sp<GrSurfaceProxy> dst,
     SkASSERT(fContext);
 
     this->closeActiveOpsTask();
-    const GrCaps& caps = *fContext->priv().caps();
-
-    // On platforms that prefer flushes over VRAM use (i.e., ANGLE) we're better off forcing a
-    // complete flush here.
-    if (!caps.preferVRAMUseOverFlushes()) {
-        this->flushSurfaces(SkSpan<GrSurfaceProxy*>{},
-                            SkSurfaces::BackendSurfaceAccess::kNoAccess,
-                            GrFlushInfo{},
-                            nullptr);
-    }
 
     GrRenderTask* task = this->appendTask(GrWritePixelsTask::Make(this,
                                                                   std::move(dst),

--- a/src/gpu/ganesh/SurfaceContext.cpp
+++ b/src/gpu/ganesh/SurfaceContext.cpp
@@ -585,6 +585,22 @@ bool SurfaceContext::internalWritePixels(GrDirectContext* dContext,
     }
     pt.fY = flip ? dstSurface->height() - pt.fY - src[0].height() : pt.fY;
 
+    auto flushSurfaceAndCheckSuccess = [dContext](GrSurfaceProxy* dstProxy, bool expectsTasks) {
+        const bool hasPendingTasks =
+                dContext->priv().drawingManager()->getLastRenderTask(dstProxy) != nullptr;
+        SkASSERT(!expectsTasks || hasPendingTasks);
+        GrSemaphoresSubmitted flushResult = dContext->priv().flushSurface(dstProxy);
+        return flushResult == GrSemaphoresSubmitted::kYes || !hasPendingTasks;
+    };
+
+    // On platforms that prefer flushes over VRAM use (i.e., ANGLE) we're better off forcing a
+    // complete flush here.
+    if (!caps->preferVRAMUseOverFlushes()) {
+        if (!flushSurfaceAndCheckSuccess(dstProxy, /*expectsTasks=*/false)) {
+            return false;
+        }
+    }
+
     if (!dContext->priv().drawingManager()->newWritePixelsTask(
                 sk_ref_sp(dstProxy),
                 SkIRect::MakePtSize(pt, src[0].dimensions()),
@@ -600,7 +616,9 @@ bool SurfaceContext::internalWritePixels(GrDirectContext* dContext,
     if (!ownAllStorage) {
         // If any pixmap doesn't own its pixels then we must flush so that the pixels are pushed to
         // the GPU before we return.
-        dContext->priv().flushSurface(dstProxy);
+        if (!flushSurfaceAndCheckSuccess(dstProxy, /*expectsTasks=*/true)) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/gpu/ganesh/gl/GrGLCaps.cpp
+++ b/src/gpu/ganesh/gl/GrGLCaps.cpp
@@ -4786,6 +4786,12 @@ void GrGLCaps::applyDriverCorrectnessWorkarounds(const GrGLContextInfo& ctxInfo,
         fShaderCaps->fShaderDerivativeSupport = false;
     }
 
+    // b/532941869
+    if (ctxInfo.vendor() == GrGLVendor::kImagination ||
+        ctxInfo.driver() == GrGLDriver::kImagination) {
+        fDriverBugWorkarounds.ensure_previous_framebuffer_not_deleted = true;
+    }
+
     if (ctxInfo.driver() == GrGLDriver::kFreedreno) {
         formatWorkarounds->fDisallowUnorm16Transfers = true;
     }

--- a/src/gpu/ganesh/gl/GrGLGpu.cpp
+++ b/src/gpu/ganesh/gl/GrGLGpu.cpp
@@ -3228,18 +3228,25 @@ void GrGLGpu::deleteFramebuffer(GrGLuint fboid) {
     // We're relying on the GL state shadowing being correct in the workaround code below so we
     // need to handle a dirty context.
     this->handleDirtyContext();
-    if (fboid == fBoundDrawFramebuffer &&
-        this->caps()->workarounds().unbind_attachments_on_bound_render_fbo_delete) {
-        // This workaround only applies to deleting currently bound framebuffers
-        // on Adreno 420.  Because this is a somewhat rare case, instead of
-        // tracking all the attachments of every framebuffer instead just always
-        // unbind all attachments.
-        GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_COLOR_ATTACHMENT0,
-                                        GR_GL_RENDERBUFFER, 0));
-        GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_STENCIL_ATTACHMENT,
-                                        GR_GL_RENDERBUFFER, 0));
-        GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_DEPTH_ATTACHMENT,
-                                        GR_GL_RENDERBUFFER, 0));
+    if (fboid == fBoundDrawFramebuffer) {
+        if (this->caps()->workarounds().unbind_attachments_on_bound_render_fbo_delete) {
+            // This workaround only applies to deleting currently bound framebuffers
+            // on Adreno 420.  Because this is a somewhat rare case, instead of
+            // tracking all the attachments of every framebuffer instead just always
+            // unbind all attachments.
+            GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_COLOR_ATTACHMENT0,
+                                            GR_GL_RENDERBUFFER, 0));
+            GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_STENCIL_ATTACHMENT,
+                                            GR_GL_RENDERBUFFER, 0));
+            GL_CALL(FramebufferRenderbuffer(GR_GL_FRAMEBUFFER, GR_GL_DEPTH_ATTACHMENT,
+                                            GR_GL_RENDERBUFFER, 0));
+        }
+
+        if (this->caps()->workarounds().ensure_previous_framebuffer_not_deleted) {
+            // Some drivers keep an internal reference to the previously bound
+            // framebuffer, so make sure it isn't the one being deleted.
+            this->bindFramebuffer(GR_GL_FRAMEBUFFER, 0);
+        }
     }
 
     GL_CALL(DeleteFramebuffers(1, &fboid));

--- a/src/gpu/gpu_workaround_list.txt
+++ b/src/gpu/gpu_workaround_list.txt
@@ -4,6 +4,7 @@ disable_discard_framebuffer
 disable_texture_storage
 disallow_large_instanced_draw
 emulate_abs_int_function
+ensure_previous_framebuffer_not_deleted
 flush_on_framebuffer_change
 force_update_scissor_state_when_binding_fbo0
 gl_clear_broken

--- a/tests/GrSurfaceResolveTest.cpp
+++ b/tests/GrSurfaceResolveTest.cpp
@@ -512,3 +512,125 @@ DEF_GANESH_TEST(SurfaceResolveProxyStateAfterFailedFlush,
         }
     }
 }
+
+// Directly read back 'tex' and return the first pixel color.
+static bool read_backing_pixel(GrDirectContext* dContext,
+                               const GrBackendTexture& tex,
+                               const SkImageInfo& info,
+                               SkColor* outPixel) {
+    sk_sp<SkSurface> reader = SkSurfaces::WrapBackendTexture(dContext,
+                                                             tex,
+                                                             kTopLeft_GrSurfaceOrigin,
+                                                             /*sampleCnt=*/1,
+                                                             kRGBA_8888_SkColorType,
+                                                             nullptr,
+                                                             nullptr);
+    if (!reader) {
+        return false;
+    }
+    SkBitmap bm;
+    bm.allocPixels(info);
+    if (!reader->readPixels(bm, 0, 0)) {
+        return false;
+    }
+    *outPixel = bm.getColor(0, 0);
+    return true;
+}
+
+// This test wraps a backend texture as an MSAA render target twice. The first wrap establishes a
+// known baseline color in the single-sample texture via a *successful* flush. The second wrap
+// creates a *fresh, never-written* MSAA color attachment (on GL a new renderbuffer, on Vulkan a
+// scratch/new GrVkImage), records a draw, forces the flush to fail via a failing preFlush
+// callback, and then reads back the single-sample texture. The read-back must not show the
+// uninitialized MSAA attachment contents; if it does, resolve_and_mipmap() ran despite the failed
+// flush and copied uninitialized GPU memory into the client-visible texture.
+DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(SurfaceResolveAfterFailedFlush,
+                                       reporter,
+                                       ctxInfo,
+                                       CtsEnforcement::kNever) {
+    auto dContext = ctxInfo.directContext();
+    const GrCaps* caps = dContext->priv().caps();
+
+    // Only meaningful on backends that require an explicit resolve of a persistent MSAA attachment.
+    if (caps->msaaResolvesAutomatically() || caps->preferDiscardableMSAAAttachment()) {
+        return;
+    }
+
+    SkImageInfo info = SkImageInfo::Make(8, 8, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+
+    auto managedTex = ManagedBackendTexture::MakeFromInfo(
+            dContext, info, skgpu::Mipmapped::kNo, GrRenderable::kYes);
+    if (!managedTex) {
+        return;
+    }
+    const GrBackendTexture& tex = managedTex->texture();
+
+    constexpr SkColor kBaseline = SK_ColorBLUE;   // known content of the single-sample texture
+    constexpr SkColor kIntended = SK_ColorGREEN;  // what the failed flush *would* have drawn
+
+    // 1. Wrap once and successfully draw kBaseline so the single-sample texture holds known bytes.
+    {
+        sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(dContext,
+                                                                  tex,
+                                                                  kTopLeft_GrSurfaceOrigin,
+                                                                  /*sampleCnt=*/4,
+                                                                  kRGBA_8888_SkColorType,
+                                                                  nullptr,
+                                                                  nullptr);
+        if (!surface) {
+            return;  // MSAA=4 unsupported on this config.
+        }
+        surface->getCanvas()->clear(kBaseline);
+        dContext->flush(surface.get());
+        dContext->submit(GrSyncCpu::kYes);
+    }
+    // Ensure the second wrap below allocates a *fresh* MSAA attachment rather than recycling the
+    // one from the wrap above (whose contents would coincidentally match kBaseline).
+    dContext->purgeUnlockedResources(GrPurgeResourceOptions::kAllResources);
+
+    SkColor pixel = 0;
+    REPORTER_ASSERT(reporter, read_backing_pixel(dContext, tex, info, &pixel));
+    REPORTER_ASSERT(reporter, pixel == kBaseline,
+                    "baseline flush failed to resolve, got 0x%x", pixel);
+
+    // 2. Re-wrap: this creates a *new* persistent MSAA color attachment that has never been
+    //    written by any render pass in this test.
+    sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(dContext,
+                                                              tex,
+                                                              kTopLeft_GrSurfaceOrigin,
+                                                              /*sampleCnt=*/4,
+                                                              kRGBA_8888_SkColorType,
+                                                              nullptr,
+                                                              nullptr);
+    if (!surface) {
+        return;
+    }
+
+    // 3. Record a full-surface draw so OpsTask::onMakeClosed() returns kTargetDirty and
+    //    markMSAADirty() is called during closeAllTasks(). Force the flush to fail.
+    FailingPreFlushCallback failCB(1);
+    dContext->priv().addOnFlushCallbackObject(&failCB);
+
+    surface->getCanvas()->clear(kIntended);
+    GrSemaphoresSubmitted result = dContext->flush(surface.get(), GrFlushInfo{});
+    dContext->submit(GrSyncCpu::kYes);
+
+    GrDrawingManager* drawingManager = dContext->priv().drawingManager();
+    drawingManager->testingOnly_removeOnFlushCallbackObject(&failCB);
+
+    REPORTER_ASSERT(reporter, result == GrSemaphoresSubmitted::kNo,
+                    "expected flush to report semaphores not submitted");
+
+    // 4. Read back the single-sample backing texture.
+    REPORTER_ASSERT(reporter, read_backing_pixel(dContext, tex, info, &pixel));
+
+    // The recorded draw never executed, so kIntended should not appear.
+    REPORTER_ASSERT(reporter, pixel != kIntended,
+                    "flush failed but draw, somehow, occurred (got 0x%x)", pixel);
+
+    // Since the flush failed the MSAA resolve step should not have occurred and the contents
+    // of the backend texture should have remained at 'kBaseline'.
+    REPORTER_ASSERT(reporter, pixel == kBaseline,
+                    "Invalid resolve after a failed flush: expected 0x%x, actual 0x%x",
+                    kBaseline, pixel);
+}

--- a/tests/ReadWritePixelsGpuTest.cpp
+++ b/tests/ReadWritePixelsGpuTest.cpp
@@ -1577,3 +1577,87 @@ DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(ReadPixelsIntermediateFailedFlush,
     }
 }
 
+DEF_GANESH_TEST_FOR_RENDERING_CONTEXTS(WritePixelsFailedFlushLeaksScratch,
+                                       reporter,
+                                       ctxInfo,
+                                       CtsEnforcement::kNextRelease) {
+    auto dContext = ctxInfo.directContext();
+    if (dContext->supportsProtectedContent()) {
+        return; // This test performs readbacks
+    }
+
+    // internalWritePixels() calls this function, which flushes work the first time it's called. We
+    // don't want that to happen while the test's FailOnceCallback is installed, so trigger it now.
+    (void) dContext->priv().validPMUPMConversionExists();
+
+    static constexpr int kSize = 16;
+    // alpha=0xFF so the unpremul->premul shader is a no-op and we can compare exact bytes.
+    static constexpr SkColor kStalePixel = SkColorSetARGB(0xFF, 0x33, 0x22, 0x11);
+    static constexpr SkColor kSrcPixel   = SkColorSetARGB(0xFF, 0x00, 0x88, 0x44);
+
+    auto dstII = SkImageInfo::Make({kSize, kSize}, kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+    auto srcII = dstII.makeAlphaType(kUnpremul_SkAlphaType);
+    auto surf = SkSurfaces::RenderTarget(dContext, skgpu::Budgeted::kYes, dstII);
+    if (!surf) {
+        return;
+    }
+
+    SkBitmap srcBM;
+    srcBM.allocPixels(srcII, srcII.minRowBytes());
+    srcBM.eraseColor(kStalePixel);
+
+    // Prime: writePixels(unpremul kStalePixel). canvas2DFastPath uploads kStalePixel into a
+    // fresh kApprox scratch texture and draws it into |surf|. After the flush the scratch
+    // texture (still holding kStalePixel) is returned to the resource cache.
+    if (!surf->getCanvas()->writePixels(srcBM, 0, 0)) {
+        return;
+    }
+    dContext->flushAndSubmit(GrSyncCpu::kYes);
+
+    // Arm a preFlush() that fails exactly once. When it fires on the flush for uploading to a
+    // temporary texture, we should propagate the failure and not use the temporary texture as the
+    // input for the draw that performs the final "write".
+    class FailOnceFlushCallback : public GrOnFlushCallbackObject {
+    public:
+        bool preFlush(GrOnFlushResourceProvider*) override { return ++fCount > 1; }
+        int count() const { return fCount; }
+    private:
+        int fCount = 0;
+    };
+    FailOnceFlushCallback cb;
+    dContext->priv().addOnFlushCallbackObject(&cb);
+
+    // writePixels(unpremul kSrcPixel): tempProxy is instantiated from the recycled
+    // scratch texture (still kStalePixel). The GrWritePixelsTask that would overwrite it with
+    // kSrcPixel is queued and then dropped by the failed flush, leaving the tempProxy stale.
+    srcBM.eraseColor(kSrcPixel);
+    bool ok = surf->getCanvas()->writePixels(srcBM, 0, 0);
+
+    dContext->priv().drawingManager()->testingOnly_removeOnFlushCallbackObject(&cb);
+
+    if (!ok) {
+        // Assuming the various branches are taken inside internalWritePixels to trigger the
+        // FailOnceFlushCallback, it should be propagated as a failure of the overall writePixels().
+        REPORTER_ASSERT(reporter, cb.count() > 0);
+        return;
+    }
+
+    // If none of the code paths triggered an internal flush from the write pixels, it should
+    // execute successfully when we flush here.
+    dContext->flushAndSubmit(GrSyncCpu::kYes);
+
+    SkBitmap readback;
+    readback.allocPixels(dstII);
+    if (!surf->readPixels(readback, 0, 0)) {
+        ERRORF(reporter, "readback failed");
+        return;
+    }
+
+    SkColor got = readback.getColor(0, 0);
+    // Bug: |got| == kStalePixel (recycled scratch contents) instead of kSrcPixel.
+    REPORTER_ASSERT(reporter,
+                    got == kSrcPixel,
+                    "writePixels reported success but destination holds stale scratch "
+                    "contents 0x%08x (expected 0x%08x, stale=0x%08x, preFlush hits=%d)",
+                    got, kSrcPixel, kStalePixel, cb.count());
+}


### PR DESCRIPTION
Automated upstream merge of `chrome/m150`.

# Merge upstream chrome/m150 bug fixes

Release-line bug-fix sync — merges 3 new upstream commits from `chrome/m150`
into `release/4.150.x`. No version bumps.

## Upstream commits merged

| SHA | Subject |
|-----|---------|
| `a7fb0b3c2e` | [M150] [ganesh][gl] Imagination FBO deletion workaround |
| `22fced903a` | [M150] [ganesh] Check results of internal flushes for internalWritePixels success |
| `8ceeb9b788` | [M150] [ganesh] Skip resolve/mipmap step on flush failure |

Merge base: `587c5b0f5a7b0260826a0c19094c2d952195066e`
Merge commit: `79528134cf18c73b9247116611d2f8bf4c13a226`
Upstream tip merged: `a7fb0b3c2e109e4e68f50bf823cf6b8d524c4a0c`

## Conflicts resolved

None. `git merge --no-commit upstream/chrome/m150` reported:

```
Auto-merging src/gpu/ganesh/gl/GrGLGpu.cpp
Automatic merge went well; stopped before committing as requested
```

The single auto-merge in `src/gpu/ganesh/gl/GrGLGpu.cpp` was resolved by git
without conflict markers — upstream's edits landed in a region disjoint from
our fork patches on the same file. No fork patch classification was needed.

## C API changes

None. `include/c/**` and `src/c/**` were untouched by upstream.

## Items needing human attention

None. Clean upstream bug-fix merge into a release line.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).