### PR TITLE
Remove per-edge MSVC environment initialization

### DIFF
--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -36,9 +36,6 @@ declare_args() {
   win_toolchain_version = ""
   win_vcvars_version = ""
 
-  # Set to false when the parent process initializes the Visual C++ environment.
-  win_use_vcvars_wrapper = true
-
   clang_win = ""
   clang_win_version = ""
 

--- a/gn/BUILDCONFIG.gn
+++ b/gn/BUILDCONFIG.gn
@@ -36,6 +36,9 @@ declare_args() {
   win_toolchain_version = ""
   win_vcvars_version = ""
 
+  # Set to false when the parent process initializes the Visual C++ environment.
+  win_use_vcvars_wrapper = true
+
   clang_win = ""
   clang_win_version = ""
 

--- a/gn/toolchain/BUILD.gn
+++ b/gn/toolchain/BUILD.gn
@@ -85,21 +85,7 @@ toolchain("msvc") {
 
   bin = "$win_vc/Tools/MSVC/$win_toolchain_version/bin/HostX64/$target_cpu"
 
-  if (win_use_vcvars_wrapper) {
-    if (target_cpu == "x64") {
-      _target = "amd64"
-    } else {
-      _target = "amd64_" + target_cpu
-    }
-    if (is_winrt) {
-      _target += " uwp"
-    }
-    _target += " " + win_sdk_version + " -vcvars_ver=" + win_vcvars_version
-    _vcvarsall = "$win_vc/Auxiliary/Build/vcvarsall.bat"
-    env_setup = "cmd /c set __VSCMD_ARG_NO_LOGO=1 && set VSCMD_START_DIR=%CD% && \"$_vcvarsall\" $_target && "
-  } else {
-    env_setup = ""
-  }
+  env_setup = ""
 
   cl_m32_flag = ""
 

--- a/gn/toolchain/BUILD.gn
+++ b/gn/toolchain/BUILD.gn
@@ -85,17 +85,21 @@ toolchain("msvc") {
 
   bin = "$win_vc/Tools/MSVC/$win_toolchain_version/bin/HostX64/$target_cpu"
 
-  if (target_cpu == "x64") {
-    _target = "amd64"
+  if (win_use_vcvars_wrapper) {
+    if (target_cpu == "x64") {
+      _target = "amd64"
+    } else {
+      _target = "amd64_" + target_cpu
+    }
+    if (is_winrt) {
+      _target += " uwp"
+    }
+    _target += " " + win_sdk_version + " -vcvars_ver=" + win_vcvars_version
+    _vcvarsall = "$win_vc/Auxiliary/Build/vcvarsall.bat"
+    env_setup = "cmd /c set __VSCMD_ARG_NO_LOGO=1 && set VSCMD_START_DIR=%CD% && \"$_vcvarsall\" $_target && "
   } else {
-    _target = "amd64_" + target_cpu
+    env_setup = ""
   }
-  if (is_winrt) {
-    _target += " uwp"
-  }
-  _target += " " + win_sdk_version + " -vcvars_ver=" + win_vcvars_version
-  _vcvarsall = "$win_vc/Auxiliary/Build/vcvarsall.bat"
-  env_setup = "cmd /c set __VSCMD_ARG_NO_LOGO=1 && set VSCMD_START_DIR=%CD% && \"$_vcvarsall\" $_target && "
 
   cl_m32_flag = ""
 


### PR DESCRIPTION
## Summary

Remove the Visual Studio environment wrapper from every Windows GN compile, archive, and link edge.

The generated Windows toolchain already uses absolute compiler/linker paths and explicit MSVC/Windows SDK include and library directories. Re-running `vcvarsall.bat` for every Ninja action is therefore unnecessary and added substantial process/setup overhead.

## Standalone build behavior

Skia remains buildable directly with the documented `gn gen` followed by `ninja` workflow. This was tested from shells with empty `INCLUDE`, `LIB`, and `VCINSTALLDIR`:

- a forced clang-cl compile and full `libSkiaSharp.dll` relink succeeded;
- a fresh standalone GN configuration using MSVC `cl.exe` compiled the `core` target successfully;
- generated commands use absolute `cl.exe`, `clang-cl.exe`, `lib.exe`/`lld-link.exe` paths and explicit SDK/MSVC search paths.

The standalone all-target test encountered missing optional `png.h`/`hb.h` dependency configuration, but compilation reached hundreds of direct MSVC actions; those failures were unrelated to Visual Studio environment initialization.

Callers may still initialize `vcvarsall.bat` once before Ninja when they need its broader environment for adjacent tools, but the generated Skia compile/archive/link actions do not require a per-edge wrapper.

## Validation

Validated through mono/SkiaSharp draft PR https://github.com/mono/SkiaSharp/pull/4570 on the original `Azure Pipelines / windows-2022` pool.

| Architecture | Original `libSkiaSharp` | Without per-edge vcvars | Improvement |
|---|---:|---:|---:|
| x86 | 49:52 | 21:33.863 | **56.8% faster** |
| x64 | 46:33 | 20:17.847 | **56.4% faster** |
| ARM64 | 45:06 | 20:38.700 | **54.2% faster** |

For each architecture:

- the clean native build completed all Ninja edges and linked successfully;
- dependency validation passed;
- the build log contained zero per-edge `vcvarsall.bat` initializations.

Azure build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1532137