### PR TITLE
[skia-sync] Merge upstream chrome/m150

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling different
   # dependencies without interference from each other.
-  'infra_revision': '2da962880dc779b04bdb70ca3f908e095704e592',
+  'infra_revision': '055b758759c89b0cfafc8264ae2100a9aa6582d3',
 
   # ninja CIPD package version.
   # https://chrome-infra-packages.appspot.com/p/infra/3pp/tools/ninja

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/trietmn/go-wiki v1.0.1
 	github.com/vektra/mockery/v2 v2.52.2
 	go.chromium.org/luci v0.0.0-20251208084510-e9565e513ef0
-	go.skia.org/infra v0.0.0-20260529060140-2da962880dc7
+	go.skia.org/infra v0.0.0-20260720042914-055b758759c8
 	google.golang.org/api v0.248.0
 	google.golang.org/protobuf v1.36.10
 )

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-go.skia.org/infra v0.0.0-20260529060140-2da962880dc7 h1:68OvrosznnWKFmJeOKYJ/zkzWlqsdxHrsUBg+YRZixU=
-go.skia.org/infra v0.0.0-20260529060140-2da962880dc7/go.mod h1:IN8jdFPrIDrbWzJuEezIB11r3fTYzUaXSghv98C9/AM=
+go.skia.org/infra v0.0.0-20260720042914-055b758759c8 h1:O4Ktwa//1RmWJdlP0i7zAdXLmLO9As/e1Nc5m8SLMJk=
+go.skia.org/infra v0.0.0-20260720042914-055b758759c8/go.mod h1:UnvP4XqoBuJ0XkO7YhnU+EX7t3bzhfu4Gj8y1G0SN1o=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/infra/bots/deps/deps_gen.go
+++ b/infra/bots/deps/deps_gen.go
@@ -184,7 +184,7 @@ var deps = deps_parser.DepsEntries{
 	},
 	"skia.googlesource.com/buildbot": {
 		Id:      "skia.googlesource.com/buildbot",
-		Version: "2da962880dc779b04bdb70ca3f908e095704e592",
+		Version: "055b758759c89b0cfafc8264ae2100a9aa6582d3",
 		Path:    "infra/skia-infra",
 	},
 	"skia.googlesource.com/external/github.com/AOMediaCodec/libavif": {
@@ -264,7 +264,7 @@ var deps = deps_parser.DepsEntries{
 	},
 	"skia/tools/sk": {
 		Id:      "skia/tools/sk",
-		Version: "git_revision:2da962880dc779b04bdb70ca3f908e095704e592",
+		Version: "git_revision:055b758759c89b0cfafc8264ae2100a9aa6582d3",
 		Path:    "bin",
 	},
 	"swiftshader.googlesource.com/SwiftShader": {

--- a/infra/bots/task_drivers/canvaskit_gold/canvaskit_gold.go
+++ b/infra/bots/task_drivers/canvaskit_gold/canvaskit_gold.go
@@ -79,9 +79,11 @@ func main() {
 		// directory (and default Bazel cache) lives, is only 15 GB on our GCE VMs.
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelTest(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config,
 		"--config=linux_rbe", "--test_output=streamed", "--jobs="+strconv.Itoa(rbeJobs)); err != nil {

--- a/infra/bots/task_drivers/check_generated_files/check_generated_files.go
+++ b/infra/bots/task_drivers/check_generated_files/check_generated_files.go
@@ -76,9 +76,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelRun(ctx, skiaPath, "//bazel/deps_parser", *bazelFlags.AdditionalArgs...); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/codesize/codesize.go
+++ b/infra/bots/task_drivers/codesize/codesize.go
@@ -138,7 +138,10 @@ func main() {
 	}
 
 	// Make a Gitiles client.
-	gitilesRepo := gitiles.NewRepo(repoState.Repo, httpClient)
+	gitilesRepo, err := gitiles.NewRepo(ctx, repoState.Repo)
+	if err != nil {
+		td.Fatal(ctx, skerr.Wrap(err))
+	}
 
 	args := runStepsArgs{
 		repoState:              repoState,

--- a/infra/bots/task_drivers/cpu_tests/cpu_tests.go
+++ b/infra/bots/task_drivers/cpu_tests/cpu_tests.go
@@ -56,9 +56,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelTest(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config, "--test_output=errors"); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/go_linters/go_linters.go
+++ b/infra/bots/task_drivers/go_linters/go_linters.go
@@ -73,9 +73,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelRun(ctx, skiaPath, "//:go", append(*bazelFlags.AdditionalArgs, "--", "fmt", "./...")...); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/toolchain_layering_check/toolchain_layering_check.go
+++ b/infra/bots/task_drivers/toolchain_layering_check/toolchain_layering_check.go
@@ -55,9 +55,11 @@ func main() {
 		// directory (and default Bazel cache) lives, is only 15 GB on our GCE VMs.
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	// This build should succeed
 	if err := bazelBuild(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config); err != nil {

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -3946,7 +3946,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4026,7 +4026,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4106,7 +4106,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4182,7 +4182,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4262,7 +4262,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4342,7 +4342,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4422,7 +4422,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4498,7 +4498,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4578,7 +4578,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4662,7 +4662,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4721,7 +4721,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -4782,7 +4782,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4855,7 +4855,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4928,7 +4928,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5001,7 +5001,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5074,7 +5074,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5147,7 +5147,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5220,7 +5220,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5293,7 +5293,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5366,7 +5366,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5439,7 +5439,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5512,7 +5512,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5585,7 +5585,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5658,7 +5658,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5739,7 +5739,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -5835,7 +5835,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -5931,7 +5931,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6027,7 +6027,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6123,7 +6123,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6219,7 +6219,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6315,7 +6315,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6407,7 +6407,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6493,7 +6493,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6579,7 +6579,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6683,7 +6683,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -6780,7 +6780,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6862,7 +6862,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6966,7 +6966,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -7081,7 +7081,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -7196,7 +7196,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -7293,7 +7293,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7379,7 +7379,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7465,7 +7465,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7551,7 +7551,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7637,7 +7637,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7723,7 +7723,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7810,7 +7810,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7897,7 +7897,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7984,7 +7984,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8071,7 +8071,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8158,7 +8158,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8244,7 +8244,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8348,7 +8348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8463,7 +8463,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8560,7 +8560,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8646,7 +8646,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8732,7 +8732,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8836,7 +8836,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8933,7 +8933,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9019,7 +9019,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9106,7 +9106,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9193,7 +9193,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9280,7 +9280,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9367,7 +9367,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9454,7 +9454,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9541,7 +9541,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9627,7 +9627,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9713,7 +9713,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9817,7 +9817,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -9914,7 +9914,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10022,7 +10022,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10137,7 +10137,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10234,7 +10234,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10320,7 +10320,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10406,7 +10406,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10492,7 +10492,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10596,7 +10596,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10693,7 +10693,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10779,7 +10779,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10865,7 +10865,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10951,7 +10951,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11037,7 +11037,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11119,7 +11119,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11211,7 +11211,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11303,7 +11303,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11395,7 +11395,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11487,7 +11487,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11578,7 +11578,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11665,7 +11665,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11756,7 +11756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11843,7 +11843,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11927,7 +11927,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12011,7 +12011,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12117,7 +12117,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12205,7 +12205,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12289,7 +12289,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12373,7 +12373,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12457,7 +12457,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12541,7 +12541,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12625,7 +12625,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12727,7 +12727,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12840,7 +12840,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12935,7 +12935,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13019,7 +13019,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13103,7 +13103,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13187,7 +13187,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13271,7 +13271,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13355,7 +13355,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13457,7 +13457,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13570,7 +13570,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13683,7 +13683,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13778,7 +13778,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13862,7 +13862,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13946,7 +13946,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14030,7 +14030,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14114,7 +14114,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14198,7 +14198,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14286,7 +14286,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14375,7 +14375,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14477,7 +14477,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -14590,7 +14590,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -14685,7 +14685,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14769,7 +14769,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14853,7 +14853,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14937,7 +14937,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15025,7 +15025,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15118,7 +15118,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15229,7 +15229,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -15333,7 +15333,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15426,7 +15426,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15519,7 +15519,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15634,7 +15634,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -15738,7 +15738,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15831,7 +15831,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15942,7 +15942,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16046,7 +16046,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16161,7 +16161,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16287,7 +16287,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16413,7 +16413,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16517,7 +16517,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16610,7 +16610,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16703,7 +16703,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16796,7 +16796,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16895,7 +16895,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16994,7 +16994,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17093,7 +17093,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17186,7 +17186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17279,7 +17279,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17372,7 +17372,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17465,7 +17465,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17580,7 +17580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -17677,7 +17677,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17770,7 +17770,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17863,7 +17863,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17974,7 +17974,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18078,7 +18078,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18171,7 +18171,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18264,7 +18264,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18383,7 +18383,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18483,7 +18483,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18576,7 +18576,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18687,7 +18687,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18791,7 +18791,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18884,7 +18884,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18995,7 +18995,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -19092,7 +19092,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19185,7 +19185,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19278,7 +19278,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19371,7 +19371,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19464,7 +19464,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19557,7 +19557,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19650,7 +19650,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19749,7 +19749,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19848,7 +19848,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19959,7 +19959,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -20063,7 +20063,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20156,7 +20156,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20249,7 +20249,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20342,7 +20342,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20439,7 +20439,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20534,7 +20534,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20629,7 +20629,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20724,7 +20724,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20819,7 +20819,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20914,7 +20914,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21001,7 +21001,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21087,7 +21087,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21173,7 +21173,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21259,7 +21259,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21345,7 +21345,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21430,7 +21430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21516,7 +21516,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21602,7 +21602,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21688,7 +21688,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21774,7 +21774,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21860,7 +21860,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21946,7 +21946,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22037,7 +22037,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22141,7 +22141,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22256,7 +22256,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22371,7 +22371,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22468,7 +22468,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22554,7 +22554,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22640,7 +22640,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22726,7 +22726,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22812,7 +22812,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22898,7 +22898,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23002,7 +23002,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -23117,7 +23117,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -23232,7 +23232,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -23329,7 +23329,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23415,7 +23415,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23501,7 +23501,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23587,7 +23587,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23668,7 +23668,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23749,7 +23749,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23830,7 +23830,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23911,7 +23911,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23992,7 +23992,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24073,7 +24073,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24154,7 +24154,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24253,7 +24253,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24363,7 +24363,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24473,7 +24473,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24565,7 +24565,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24646,7 +24646,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24727,7 +24727,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24826,7 +24826,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24918,7 +24918,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24999,7 +24999,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25080,7 +25080,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25179,7 +25179,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25289,7 +25289,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25399,7 +25399,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25491,7 +25491,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25572,7 +25572,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25653,7 +25653,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25756,7 +25756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25869,7 +25869,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25949,7 +25949,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -26005,7 +26005,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -26061,7 +26061,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -26117,7 +26117,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -26173,7 +26173,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26248,7 +26248,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26323,7 +26323,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26398,7 +26398,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/android_ndk_linux",
@@ -26478,7 +26478,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26588,7 +26588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26701,7 +26701,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26800,7 +26800,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26869,7 +26869,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -26911,7 +26911,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -26953,7 +26953,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -27086,7 +27086,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27164,7 +27164,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27259,7 +27259,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27559,7 +27559,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27648,7 +27648,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27734,7 +27734,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27815,7 +27815,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27901,7 +27901,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27982,7 +27982,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28063,7 +28063,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28144,7 +28144,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28225,7 +28225,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28306,7 +28306,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28387,7 +28387,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28468,7 +28468,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28549,7 +28549,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28630,7 +28630,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28716,7 +28716,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28802,7 +28802,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28883,7 +28883,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28969,7 +28969,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29050,7 +29050,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29131,7 +29131,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29212,7 +29212,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29293,7 +29293,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29374,7 +29374,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29455,7 +29455,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29536,7 +29536,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29617,7 +29617,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29698,7 +29698,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29779,7 +29779,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29860,7 +29860,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29941,7 +29941,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30022,7 +30022,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30108,7 +30108,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30189,7 +30189,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30270,7 +30270,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30351,7 +30351,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30432,7 +30432,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30513,7 +30513,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30594,7 +30594,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30675,7 +30675,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30756,7 +30756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30837,7 +30837,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30918,7 +30918,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30999,7 +30999,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31080,7 +31080,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31161,7 +31161,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31242,7 +31242,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31323,7 +31323,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31404,7 +31404,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31485,7 +31485,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31566,7 +31566,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31647,7 +31647,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31728,7 +31728,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31809,7 +31809,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31890,7 +31890,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31971,7 +31971,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32052,7 +32052,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32133,7 +32133,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32214,7 +32214,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32295,7 +32295,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32376,7 +32376,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32457,7 +32457,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32538,7 +32538,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32619,7 +32619,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32700,7 +32700,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32781,7 +32781,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32862,7 +32862,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32943,7 +32943,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33024,7 +33024,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33105,7 +33105,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33186,7 +33186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33267,7 +33267,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33348,7 +33348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33429,7 +33429,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33522,7 +33522,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33615,7 +33615,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33708,7 +33708,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33801,7 +33801,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33894,7 +33894,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33987,7 +33987,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34080,7 +34080,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34173,7 +34173,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34266,7 +34266,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34359,7 +34359,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34452,7 +34452,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34545,7 +34545,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34638,7 +34638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34731,7 +34731,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34824,7 +34824,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34917,7 +34917,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35010,7 +35010,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35103,7 +35103,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35196,7 +35196,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35289,7 +35289,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35382,7 +35382,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35475,7 +35475,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35572,7 +35572,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35664,7 +35664,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35756,7 +35756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35848,7 +35848,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35940,7 +35940,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36032,7 +36032,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36129,7 +36129,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36222,7 +36222,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36315,7 +36315,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36408,7 +36408,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36505,7 +36505,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36607,7 +36607,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36709,7 +36709,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36806,7 +36806,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36913,7 +36913,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37015,7 +37015,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37107,7 +37107,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37199,7 +37199,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37291,7 +37291,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37385,7 +37385,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37477,7 +37477,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37569,7 +37569,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37661,7 +37661,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37753,7 +37753,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37845,7 +37845,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37937,7 +37937,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38029,7 +38029,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38121,7 +38121,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38213,7 +38213,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38305,7 +38305,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38397,7 +38397,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38489,7 +38489,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38581,7 +38581,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38673,7 +38673,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38765,7 +38765,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38857,7 +38857,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38949,7 +38949,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39041,7 +39041,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39133,7 +39133,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39225,7 +39225,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39317,7 +39317,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39409,7 +39409,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39501,7 +39501,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39593,7 +39593,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39685,7 +39685,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39777,7 +39777,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39869,7 +39869,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39961,7 +39961,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40053,7 +40053,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40145,7 +40145,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40237,7 +40237,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40329,7 +40329,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40421,7 +40421,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40513,7 +40513,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40605,7 +40605,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40701,7 +40701,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40791,7 +40791,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40881,7 +40881,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40971,7 +40971,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41061,7 +41061,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41151,7 +41151,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41241,7 +41241,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41338,7 +41338,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41435,7 +41435,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41532,7 +41532,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41625,7 +41625,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41713,7 +41713,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41801,7 +41801,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41889,7 +41889,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41977,7 +41977,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42065,7 +42065,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42153,7 +42153,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42241,7 +42241,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42329,7 +42329,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42417,7 +42417,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42505,7 +42505,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42593,7 +42593,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42681,7 +42681,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42769,7 +42769,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42857,7 +42857,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42945,7 +42945,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43033,7 +43033,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43121,7 +43121,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43209,7 +43209,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43297,7 +43297,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43385,7 +43385,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43473,7 +43473,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43561,7 +43561,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43649,7 +43649,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43737,7 +43737,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43825,7 +43825,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43913,7 +43913,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44001,7 +44001,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44089,7 +44089,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44177,7 +44177,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44265,7 +44265,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44353,7 +44353,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44441,7 +44441,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44529,7 +44529,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44617,7 +44617,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44705,7 +44705,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44793,7 +44793,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44881,7 +44881,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44969,7 +44969,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45057,7 +45057,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45145,7 +45145,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45233,7 +45233,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45321,7 +45321,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45409,7 +45409,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45497,7 +45497,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45585,7 +45585,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45673,7 +45673,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45761,7 +45761,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45849,7 +45849,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45937,7 +45937,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46025,7 +46025,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46113,7 +46113,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46201,7 +46201,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46289,7 +46289,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46377,7 +46377,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46465,7 +46465,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46553,7 +46553,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46641,7 +46641,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46722,7 +46722,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46803,7 +46803,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46884,7 +46884,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46972,7 +46972,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47060,7 +47060,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47148,7 +47148,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47236,7 +47236,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47324,7 +47324,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47412,7 +47412,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47500,7 +47500,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47588,7 +47588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47676,7 +47676,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47764,7 +47764,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47852,7 +47852,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47940,7 +47940,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48028,7 +48028,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48116,7 +48116,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48204,7 +48204,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48292,7 +48292,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48380,7 +48380,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48468,7 +48468,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48556,7 +48556,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48644,7 +48644,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48732,7 +48732,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48820,7 +48820,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48908,7 +48908,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48996,7 +48996,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49084,7 +49084,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49172,7 +49172,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49260,7 +49260,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49348,7 +49348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49436,7 +49436,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49524,7 +49524,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49612,7 +49612,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49700,7 +49700,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49788,7 +49788,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49876,7 +49876,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49964,7 +49964,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50052,7 +50052,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50140,7 +50140,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50228,7 +50228,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50316,7 +50316,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50404,7 +50404,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50492,7 +50492,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50580,7 +50580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50668,7 +50668,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50756,7 +50756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50844,7 +50844,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50932,7 +50932,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51020,7 +51020,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51108,7 +51108,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51196,7 +51196,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51296,7 +51296,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51396,7 +51396,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51496,7 +51496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51596,7 +51596,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51696,7 +51696,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51796,7 +51796,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51896,7 +51896,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51996,7 +51996,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52096,7 +52096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52196,7 +52196,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52301,7 +52301,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52406,7 +52406,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52506,7 +52506,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52606,7 +52606,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52706,7 +52706,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52806,7 +52806,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52906,7 +52906,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53006,7 +53006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53106,7 +53106,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53206,7 +53206,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53311,7 +53311,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53416,7 +53416,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53516,7 +53516,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53609,7 +53609,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53702,7 +53702,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53802,7 +53802,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53902,7 +53902,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54002,7 +54002,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54107,7 +54107,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54207,7 +54207,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54307,7 +54307,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54407,7 +54407,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54507,7 +54507,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54607,7 +54607,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54700,7 +54700,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54798,7 +54798,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54903,7 +54903,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55003,7 +55003,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55103,7 +55103,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55203,7 +55203,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55303,7 +55303,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55403,7 +55403,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55503,7 +55503,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55603,7 +55603,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55708,7 +55708,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55813,7 +55813,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55913,7 +55913,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56006,7 +56006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56099,7 +56099,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56192,7 +56192,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56292,7 +56292,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56392,7 +56392,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56492,7 +56492,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56597,7 +56597,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56697,7 +56697,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56797,7 +56797,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56897,7 +56897,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56997,7 +56997,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57097,7 +57097,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57190,7 +57190,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57283,7 +57283,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57387,7 +57387,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57491,7 +57491,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57591,7 +57591,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57691,7 +57691,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57789,7 +57789,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57889,7 +57889,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57989,7 +57989,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58087,7 +58087,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58185,7 +58185,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58295,7 +58295,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58400,7 +58400,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58510,7 +58510,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58600,7 +58600,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58700,7 +58700,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58800,7 +58800,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58900,7 +58900,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59000,7 +59000,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59100,7 +59100,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59200,7 +59200,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59300,7 +59300,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59400,7 +59400,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59500,7 +59500,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59600,7 +59600,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59698,7 +59698,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59798,7 +59798,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59898,7 +59898,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59998,7 +59998,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60098,7 +60098,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60197,7 +60197,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60296,7 +60296,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60396,7 +60396,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60496,7 +60496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60596,7 +60596,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60696,7 +60696,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60796,7 +60796,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60896,7 +60896,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61000,7 +61000,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61099,7 +61099,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61198,7 +61198,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61297,7 +61297,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61401,7 +61401,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61505,7 +61505,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61609,7 +61609,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61701,7 +61701,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61805,7 +61805,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61904,7 +61904,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62008,7 +62008,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62112,7 +62112,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62204,7 +62204,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62303,7 +62303,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62407,7 +62407,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62507,7 +62507,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62611,7 +62611,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62718,7 +62718,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62827,7 +62827,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62934,7 +62934,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63041,7 +63041,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63148,7 +63148,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63252,7 +63252,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63354,7 +63354,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63458,7 +63458,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63567,7 +63567,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63671,7 +63671,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63775,7 +63775,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63884,7 +63884,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63972,7 +63972,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64060,7 +64060,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64152,7 +64152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64244,7 +64244,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64336,7 +64336,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64428,7 +64428,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64520,7 +64520,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64612,7 +64612,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64704,7 +64704,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64796,7 +64796,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64888,7 +64888,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64980,7 +64980,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65072,7 +65072,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65164,7 +65164,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65256,7 +65256,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65348,7 +65348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65442,7 +65442,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65536,7 +65536,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65630,7 +65630,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65724,7 +65724,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65823,7 +65823,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65927,7 +65927,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66021,7 +66021,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66113,7 +66113,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66205,7 +66205,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66297,7 +66297,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66389,7 +66389,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66481,7 +66481,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66573,7 +66573,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66665,7 +66665,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66757,7 +66757,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66849,7 +66849,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66941,7 +66941,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67033,7 +67033,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67125,7 +67125,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67217,7 +67217,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67309,7 +67309,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67401,7 +67401,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67493,7 +67493,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67585,7 +67585,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67677,7 +67677,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67769,7 +67769,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67861,7 +67861,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67953,7 +67953,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68045,7 +68045,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68137,7 +68137,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68229,7 +68229,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68321,7 +68321,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68413,7 +68413,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68505,7 +68505,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68597,7 +68597,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68689,7 +68689,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68786,7 +68786,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68878,7 +68878,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68970,7 +68970,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69062,7 +69062,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69154,7 +69154,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69246,7 +69246,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69338,7 +69338,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69430,7 +69430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69522,7 +69522,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69614,7 +69614,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69706,7 +69706,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69798,7 +69798,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69890,7 +69890,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69982,7 +69982,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70074,7 +70074,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70166,7 +70166,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70258,7 +70258,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70350,7 +70350,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70442,7 +70442,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70534,7 +70534,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70626,7 +70626,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70718,7 +70718,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70810,7 +70810,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70902,7 +70902,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70994,7 +70994,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71086,7 +71086,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71178,7 +71178,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71270,7 +71270,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71362,7 +71362,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71454,7 +71454,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71546,7 +71546,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71638,7 +71638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71730,7 +71730,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71822,7 +71822,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71916,7 +71916,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72010,7 +72010,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72104,7 +72104,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72198,7 +72198,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72290,7 +72290,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72382,7 +72382,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72474,7 +72474,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72566,7 +72566,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72658,7 +72658,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72750,7 +72750,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72842,7 +72842,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72934,7 +72934,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73026,7 +73026,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73118,7 +73118,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73210,7 +73210,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73302,7 +73302,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73394,7 +73394,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73490,7 +73490,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73586,7 +73586,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73682,7 +73682,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73778,7 +73778,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73874,7 +73874,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73970,7 +73970,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74066,7 +74066,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74162,7 +74162,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74258,7 +74258,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74354,7 +74354,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74450,7 +74450,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74546,7 +74546,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74642,7 +74642,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74745,7 +74745,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74848,7 +74848,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74951,7 +74951,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75054,7 +75054,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75157,7 +75157,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75260,7 +75260,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75363,7 +75363,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75462,7 +75462,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75544,7 +75544,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75626,7 +75626,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75708,7 +75708,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75790,7 +75790,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75872,7 +75872,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75954,7 +75954,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76036,7 +76036,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76118,7 +76118,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76200,7 +76200,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76282,7 +76282,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76364,7 +76364,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76446,7 +76446,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76528,7 +76528,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76610,7 +76610,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76692,7 +76692,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76774,7 +76774,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76856,7 +76856,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76938,7 +76938,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77020,7 +77020,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77102,7 +77102,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77184,7 +77184,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77266,7 +77266,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77348,7 +77348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77430,7 +77430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77512,7 +77512,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77594,7 +77594,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77676,7 +77676,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77758,7 +77758,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77840,7 +77840,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77922,7 +77922,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78004,7 +78004,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78086,7 +78086,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78168,7 +78168,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78250,7 +78250,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78332,7 +78332,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78414,7 +78414,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78496,7 +78496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78578,7 +78578,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78660,7 +78660,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78742,7 +78742,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78824,7 +78824,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78906,7 +78906,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78988,7 +78988,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79070,7 +79070,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79152,7 +79152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79234,7 +79234,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79316,7 +79316,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79398,7 +79398,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79480,7 +79480,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79562,7 +79562,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79644,7 +79644,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79726,7 +79726,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79808,7 +79808,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79890,7 +79890,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79972,7 +79972,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80054,7 +80054,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80136,7 +80136,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80218,7 +80218,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80300,7 +80300,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80382,7 +80382,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80464,7 +80464,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80546,7 +80546,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80628,7 +80628,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80710,7 +80710,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80792,7 +80792,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80874,7 +80874,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80956,7 +80956,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81038,7 +81038,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81120,7 +81120,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81202,7 +81202,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81284,7 +81284,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81366,7 +81366,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81448,7 +81448,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81530,7 +81530,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81612,7 +81612,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81694,7 +81694,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81776,7 +81776,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81858,7 +81858,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81940,7 +81940,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82022,7 +82022,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82104,7 +82104,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82186,7 +82186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82268,7 +82268,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82350,7 +82350,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82432,7 +82432,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82514,7 +82514,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82596,7 +82596,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82678,7 +82678,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82760,7 +82760,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82842,7 +82842,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82924,7 +82924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83006,7 +83006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83088,7 +83088,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83170,7 +83170,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83252,7 +83252,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83334,7 +83334,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83416,7 +83416,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83498,7 +83498,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83580,7 +83580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83662,7 +83662,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83744,7 +83744,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83826,7 +83826,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83908,7 +83908,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83990,7 +83990,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84072,7 +84072,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84154,7 +84154,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84236,7 +84236,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84318,7 +84318,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84400,7 +84400,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84482,7 +84482,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84564,7 +84564,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84646,7 +84646,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84728,7 +84728,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84810,7 +84810,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84892,7 +84892,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84974,7 +84974,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85056,7 +85056,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85138,7 +85138,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85220,7 +85220,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85302,7 +85302,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85384,7 +85384,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85466,7 +85466,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85548,7 +85548,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85630,7 +85630,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85712,7 +85712,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85794,7 +85794,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85876,7 +85876,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85958,7 +85958,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86040,7 +86040,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86122,7 +86122,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86204,7 +86204,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86286,7 +86286,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86368,7 +86368,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86450,7 +86450,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86532,7 +86532,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86614,7 +86614,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86696,7 +86696,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86778,7 +86778,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86860,7 +86860,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86942,7 +86942,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87024,7 +87024,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87106,7 +87106,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87188,7 +87188,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87270,7 +87270,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87352,7 +87352,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87434,7 +87434,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87516,7 +87516,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87598,7 +87598,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87680,7 +87680,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87762,7 +87762,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87844,7 +87844,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87926,7 +87926,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88008,7 +88008,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88090,7 +88090,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88172,7 +88172,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88254,7 +88254,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88336,7 +88336,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88418,7 +88418,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88500,7 +88500,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88582,7 +88582,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88664,7 +88664,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88746,7 +88746,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88828,7 +88828,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88910,7 +88910,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88992,7 +88992,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89074,7 +89074,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89156,7 +89156,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89238,7 +89238,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89320,7 +89320,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89402,7 +89402,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89484,7 +89484,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89566,7 +89566,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89648,7 +89648,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89730,7 +89730,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89812,7 +89812,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89894,7 +89894,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89976,7 +89976,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90058,7 +90058,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90140,7 +90140,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90222,7 +90222,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90304,7 +90304,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90386,7 +90386,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90468,7 +90468,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90550,7 +90550,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90632,7 +90632,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90714,7 +90714,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90796,7 +90796,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90878,7 +90878,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90960,7 +90960,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91042,7 +91042,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91124,7 +91124,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91206,7 +91206,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91288,7 +91288,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91370,7 +91370,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91452,7 +91452,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91534,7 +91534,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91616,7 +91616,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91698,7 +91698,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91780,7 +91780,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91862,7 +91862,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91944,7 +91944,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92026,7 +92026,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92108,7 +92108,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92190,7 +92190,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92272,7 +92272,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92354,7 +92354,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92436,7 +92436,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92518,7 +92518,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92600,7 +92600,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92682,7 +92682,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92764,7 +92764,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92846,7 +92846,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92928,7 +92928,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93010,7 +93010,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93092,7 +93092,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93174,7 +93174,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93256,7 +93256,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93338,7 +93338,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93420,7 +93420,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93502,7 +93502,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93584,7 +93584,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93666,7 +93666,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93748,7 +93748,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93830,7 +93830,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93912,7 +93912,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93994,7 +93994,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94076,7 +94076,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94158,7 +94158,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94240,7 +94240,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94322,7 +94322,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94404,7 +94404,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94486,7 +94486,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94568,7 +94568,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94650,7 +94650,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94732,7 +94732,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94814,7 +94814,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94896,7 +94896,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94978,7 +94978,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95060,7 +95060,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95142,7 +95142,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95224,7 +95224,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95306,7 +95306,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95388,7 +95388,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95470,7 +95470,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95552,7 +95552,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95634,7 +95634,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95716,7 +95716,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95798,7 +95798,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95880,7 +95880,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -95962,7 +95962,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -96044,7 +96044,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -96126,7 +96126,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:c0d9a7db3308d7192000932f3fb5c2056d553c27"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",

--- a/src/sksl/codegen/SkSLRasterPipelineCodeGenerator.cpp
+++ b/src/sksl/codegen/SkSLRasterPipelineCodeGenerator.cpp
@@ -1422,10 +1422,13 @@ std::optional<SlotRange> Generator::writeFunction(
             // If we are passing a child effect to a function, we need to add its mapping to our
             // child map.
             if (arg.type().isEffectChild()) {
-                if (int* childIndex = fChildEffectMap.find(arg.as<VariableReference>()
-                                                              .variable())) {
+                if (int* childIndexPtr =
+                            fChildEffectMap.find(arg.as<VariableReference>().variable())) {
+                    // In earlier C++ versions, the map assignment could cause the map to be
+                    // resized, invalidating the pointer.
+                    int childIndex = *childIndexPtr;
                     SkASSERT(!fChildEffectMap.find(&param));
-                    fChildEffectMap[&param] = *childIndex;
+                    fChildEffectMap[&param] = childIndex;
                 }
                 continue;
             }
@@ -2809,8 +2812,9 @@ bool Generator::pushConstructorCompound(const AnyConstructor& c) {
 }
 
 bool Generator::pushChildCall(const ChildCall& c) {
-    int* childIdx = fChildEffectMap.find(&c.child());
-    SkASSERT(childIdx != nullptr);
+    int* childIdxPtr = fChildEffectMap.find(&c.child());
+    SkASSERT(childIdxPtr != nullptr);
+    int childIdx = *childIdxPtr;  // Save this in case pushExpression changes fChildEffectMap
     SkASSERT(!c.arguments().empty());
 
     // All child calls have at least one argument.
@@ -2832,7 +2836,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
 
             // Move the argument into src.rgba while also preserving the execution mask.
             fBuilder.exchange_src();
-            fBuilder.invoke_shader(*childIdx);
+            fBuilder.invoke_shader(childIdx);
             break;
         }
         case Type::TypeKind::kColorFilter: {
@@ -2843,7 +2847,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
 
             // Move the argument into src.rgba while also preserving the execution mask.
             fBuilder.exchange_src();
-            fBuilder.invoke_color_filter(*childIdx);
+            fBuilder.invoke_color_filter(childIdx);
             break;
         }
         case Type::TypeKind::kBlender: {
@@ -2861,7 +2865,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
             }
             fBuilder.pop_dst_rgba();
             fBuilder.exchange_src();
-            fBuilder.invoke_blender(*childIdx);
+            fBuilder.invoke_blender(childIdx);
             break;
         }
         default: {

--- a/tests/RasterPipelineCodeGeneratorTest.cpp
+++ b/tests/RasterPipelineCodeGeneratorTest.cpp
@@ -328,3 +328,31 @@ DEF_TEST(SkSLRasterPipelineSlotOverflow_355465305, r) {
     bool success = rasterProg->appendStages(&pipeline, &alloc, /*callbacks=*/nullptr, {});
     REPORTER_ASSERT(r, !success, "appendStages should fail for very large program");
 }
+
+DEF_TEST(SkSLRasterPipeline_ConvertProgram_b540157141, r) {
+    const char* src = R"__SkSL__(
+        uniform shader c0;
+        uniform shader c1;
+        uniform shader c2;
+        // The noinline is important for reproduction. It is also important that
+        // one of the args be an "EffectChild" to cause fChildEffectMap to grow.
+        noinline half4 f(shader s, float2 p) {
+            return s.eval(p);
+        }
+        half4 main(float2 p) {
+            return c0.eval(float2(f(c1, p).xy) + p);
+        }
+    )__SkSL__";
+
+    SkSL::Compiler compiler;
+    SkSL::ProgramSettings settings;
+    std::unique_ptr<SkSL::Program> program = compiler.convertProgram(
+            SkSL::ProgramKind::kPrivateRuntimeShader, std::string(src), settings);
+    SkASSERTF_RELEASE(program, "Unexpected error compiling %s", compiler.errorText().c_str());
+    const SkSL::FunctionDeclaration* main = program->getFunction("main");
+    SkASSERTF_RELEASE(main, "main is missing!?");
+    // With the buggy code, this triggered a UAF
+    std::unique_ptr<SkSL::RP::Program> rasterProg =
+            SkSL::MakeRasterPipelineProgram(*program, *main->definition());
+    REPORTER_ASSERT(r, rasterProg);
+}


### PR DESCRIPTION
Automated upstream merge of `chrome/m150`.

# [skia-sync] Merge upstream chrome/m150 into release/4.150.x

## Upstream merge

Merged `upstream/chrome/m150` into `skia-sync/release-4.150.x` (base: mono/skia `release/4.150.x`).

**New upstream commits merged: 1**

| SHA | Author | Subject |
|-----|--------|---------|
| `4452d2cbf4` | Eric Boren | Roll infra dep to `055b758759c89b0cfafc8264ae2100a9aa6582d3` (b/535581863) |

## Scope of change

This single upstream commit is an **infra-only** roll. It touches:

- `DEPS` — `infra_revision` variable only (Skia's build/CI infra dep; not a runtime/vendored library).
- `go.mod`, `go.sum` — Go tooling for Skia's CI (present on our fork as `.disabled.go.*`).
- `infra/bots/deps/deps_gen.go`, `infra/bots/task_drivers/**` — CI task drivers (not built by SkiaSharp).
- `infra/bots/tasks.json` — CI task definitions.

**No C/C++ source, no C API, no public headers, no `BUILD.gn`, no third-party dep bumps.** The
produced `libSkiaSharp` binary is unaffected.

## Conflicts resolved

One conflict, in `DEPS`:

- `infra_revision`: our fork carried `5997e0271ce752c20f475f4e76c92917d81b02eb` (from a prior mono/skia infra roll);
  upstream advanced to `055b758759c89b0cfafc8264ae2100a9aa6582d3`.
- **Resolution:** took upstream's value (`--theirs`). This is the intended tip of `chrome/m150` and
  matches the semantic of the merge (fast-forward to upstream's infra revision). No SkiaSharp-facing
  behavior depends on this value.

All other files (`.disabled.go.*`, `infra/bots/**`) merged cleanly.

## C API / bindings

None. No changes to `include/c/**` or `src/c/**`.

## Verify-upstream-or-reapply audit

- Files with fork patches that appear in upstream: none — the only conflict was on a single
  ever-changing variable (`infra_revision`) that both sides bump independently. Took upstream's tip
  value; no fork patch was dropped.

## Items needing human attention

- **None from this merge.** The upstream change is infra-only and does not affect the built product.
- (Pre-existing, unrelated) Local Linux x64 native rebuild in this workflow failed at the expat
  compile step with a missing `third_party/externals/expat/expat/lib/random_dev_urandom.c`
  referenced by `third_party/expat/BUILD.gn`. The vendored expat pin (2.8.1 /
  `6154446fccefbf3ca644894f598969113b0c7bcd`) no longer ships that file. This is a pre-existing
  mismatch between the expat 2.8.1 bump (mono/skia PR #245) and `third_party/expat/BUILD.gn`, not a
  regression from this sync — the same code was on the base branch before this merge. Flagged here
  for follow-up; it does NOT block this sync because the upstream commit merged here is infra-only
  and does not alter any produced binary.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).