### PR TITLE
[skia-sync] Merge upstream chrome/m151

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   # Three lines of non-changing comments so that
   # the commit queue can handle CLs rolling different
   # dependencies without interference from each other.
-  'infra_revision': 'c0e4e8a0a6bd68ffb5d8b01190d99edd9b89ecd5',
+  'infra_revision': '055b758759c89b0cfafc8264ae2100a9aa6582d3',
 
   # ninja CIPD package version.
   # https://chrome-infra-packages.appspot.com/p/infra/3pp/tools/ninja

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/trietmn/go-wiki v1.0.1
 	github.com/vektra/mockery/v2 v2.52.2
 	go.chromium.org/luci v0.0.0-20251208084510-e9565e513ef0
-	go.skia.org/infra v0.0.0-20260626171410-c0e4e8a0a6bd
+	go.skia.org/infra v0.0.0-20260720042914-055b758759c8
 	google.golang.org/api v0.248.0
 	google.golang.org/protobuf v1.36.10
 )

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-go.skia.org/infra v0.0.0-20260626171410-c0e4e8a0a6bd h1:sH4D9hGdYPYg/euwa2nMUEqf9+o+drX9ggXeCVvrXqA=
-go.skia.org/infra v0.0.0-20260626171410-c0e4e8a0a6bd/go.mod h1:IN8jdFPrIDrbWzJuEezIB11r3fTYzUaXSghv98C9/AM=
+go.skia.org/infra v0.0.0-20260720042914-055b758759c8 h1:O4Ktwa//1RmWJdlP0i7zAdXLmLO9As/e1Nc5m8SLMJk=
+go.skia.org/infra v0.0.0-20260720042914-055b758759c8/go.mod h1:UnvP4XqoBuJ0XkO7YhnU+EX7t3bzhfu4Gj8y1G0SN1o=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/infra/bots/deps/deps_gen.go
+++ b/infra/bots/deps/deps_gen.go
@@ -184,7 +184,7 @@ var deps = deps_parser.DepsEntries{
 	},
 	"skia.googlesource.com/buildbot": {
 		Id:      "skia.googlesource.com/buildbot",
-		Version: "c0e4e8a0a6bd68ffb5d8b01190d99edd9b89ecd5",
+		Version: "055b758759c89b0cfafc8264ae2100a9aa6582d3",
 		Path:    "infra/skia-infra",
 	},
 	"skia.googlesource.com/external/github.com/AOMediaCodec/libavif": {
@@ -264,7 +264,7 @@ var deps = deps_parser.DepsEntries{
 	},
 	"skia/tools/sk": {
 		Id:      "skia/tools/sk",
-		Version: "git_revision:c0e4e8a0a6bd68ffb5d8b01190d99edd9b89ecd5",
+		Version: "git_revision:055b758759c89b0cfafc8264ae2100a9aa6582d3",
 		Path:    "bin",
 	},
 	"swiftshader.googlesource.com/SwiftShader": {

--- a/infra/bots/task_drivers/canvaskit_gold/canvaskit_gold.go
+++ b/infra/bots/task_drivers/canvaskit_gold/canvaskit_gold.go
@@ -79,9 +79,11 @@ func main() {
 		// directory (and default Bazel cache) lives, is only 15 GB on our GCE VMs.
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelTest(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config,
 		"--config=linux_rbe", "--test_output=streamed", "--jobs="+strconv.Itoa(rbeJobs)); err != nil {

--- a/infra/bots/task_drivers/check_generated_files/check_generated_files.go
+++ b/infra/bots/task_drivers/check_generated_files/check_generated_files.go
@@ -76,9 +76,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelRun(ctx, skiaPath, "//bazel/deps_parser", *bazelFlags.AdditionalArgs...); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/cpu_tests/cpu_tests.go
+++ b/infra/bots/task_drivers/cpu_tests/cpu_tests.go
@@ -56,9 +56,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelTest(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config, "--test_output=errors"); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/go_linters/go_linters.go
+++ b/infra/bots/task_drivers/go_linters/go_linters.go
@@ -73,9 +73,11 @@ func main() {
 	opts := bazel.BazelOptions{
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	if err := bazelRun(ctx, skiaPath, "//:go", append(*bazelFlags.AdditionalArgs, "--", "fmt", "./...")...); err != nil {
 		td.Fatal(ctx, err)

--- a/infra/bots/task_drivers/toolchain_layering_check/toolchain_layering_check.go
+++ b/infra/bots/task_drivers/toolchain_layering_check/toolchain_layering_check.go
@@ -55,9 +55,11 @@ func main() {
 		// directory (and default Bazel cache) lives, is only 15 GB on our GCE VMs.
 		CachePath: *bazelFlags.CacheDir,
 	}
-	if err := bazel.EnsureBazelRCFile(ctx, opts); err != nil {
+	cleanup, err := bazel.OverrideBazelRC(ctx, opts)
+	if err != nil {
 		td.Fatal(ctx, err)
 	}
+	defer cleanup()
 
 	// This build should succeed
 	if err := bazelBuild(ctx, skiaDir, *bazelFlags.Label, *bazelFlags.Config); err != nil {

--- a/infra/bots/tasks.json
+++ b/infra/bots/tasks.json
@@ -3846,7 +3846,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -3926,7 +3926,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4006,7 +4006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4082,7 +4082,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4162,7 +4162,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4242,7 +4242,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4322,7 +4322,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4398,7 +4398,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4478,7 +4478,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4562,7 +4562,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -4621,7 +4621,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -4682,7 +4682,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4755,7 +4755,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4828,7 +4828,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4901,7 +4901,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -4974,7 +4974,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5047,7 +5047,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5120,7 +5120,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5193,7 +5193,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5266,7 +5266,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5339,7 +5339,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5412,7 +5412,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5485,7 +5485,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5558,7 +5558,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/vpython3/${platform}",
@@ -5639,7 +5639,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -5735,7 +5735,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -5831,7 +5831,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -5927,7 +5927,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6023,7 +6023,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6119,7 +6119,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6215,7 +6215,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6307,7 +6307,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6393,7 +6393,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6479,7 +6479,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6583,7 +6583,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -6680,7 +6680,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6762,7 +6762,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -6866,7 +6866,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -6981,7 +6981,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -7096,7 +7096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -7193,7 +7193,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7279,7 +7279,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7365,7 +7365,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7451,7 +7451,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7537,7 +7537,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7623,7 +7623,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7710,7 +7710,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7797,7 +7797,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7884,7 +7884,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -7971,7 +7971,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8058,7 +8058,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8144,7 +8144,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8248,7 +8248,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8363,7 +8363,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8460,7 +8460,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8546,7 +8546,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8632,7 +8632,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8736,7 +8736,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -8833,7 +8833,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -8919,7 +8919,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9006,7 +9006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9093,7 +9093,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9180,7 +9180,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9267,7 +9267,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9354,7 +9354,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9441,7 +9441,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9527,7 +9527,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9613,7 +9613,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9717,7 +9717,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -9814,7 +9814,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -9922,7 +9922,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10037,7 +10037,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10134,7 +10134,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10220,7 +10220,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10306,7 +10306,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10392,7 +10392,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10496,7 +10496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -10593,7 +10593,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10679,7 +10679,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10765,7 +10765,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10851,7 +10851,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -10937,7 +10937,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11019,7 +11019,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11111,7 +11111,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11203,7 +11203,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11295,7 +11295,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11387,7 +11387,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11478,7 +11478,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11565,7 +11565,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11656,7 +11656,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11743,7 +11743,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11827,7 +11827,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -11911,7 +11911,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12017,7 +12017,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12105,7 +12105,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12189,7 +12189,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12273,7 +12273,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12357,7 +12357,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12441,7 +12441,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12525,7 +12525,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12627,7 +12627,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12740,7 +12740,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -12835,7 +12835,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -12919,7 +12919,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13003,7 +13003,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13087,7 +13087,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13171,7 +13171,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13255,7 +13255,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13357,7 +13357,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13470,7 +13470,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13583,7 +13583,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -13678,7 +13678,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13762,7 +13762,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13846,7 +13846,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -13930,7 +13930,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14014,7 +14014,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14098,7 +14098,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14186,7 +14186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14275,7 +14275,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14377,7 +14377,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -14490,7 +14490,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -14585,7 +14585,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14669,7 +14669,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14753,7 +14753,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14837,7 +14837,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -14925,7 +14925,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15018,7 +15018,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15129,7 +15129,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -15233,7 +15233,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15326,7 +15326,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15419,7 +15419,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15534,7 +15534,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -15638,7 +15638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15731,7 +15731,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -15842,7 +15842,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -15946,7 +15946,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16061,7 +16061,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16187,7 +16187,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16313,7 +16313,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -16417,7 +16417,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16510,7 +16510,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16603,7 +16603,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16702,7 +16702,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16801,7 +16801,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16900,7 +16900,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -16993,7 +16993,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17086,7 +17086,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17179,7 +17179,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17272,7 +17272,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17387,7 +17387,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -17484,7 +17484,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17577,7 +17577,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17670,7 +17670,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17781,7 +17781,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -17885,7 +17885,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -17978,7 +17978,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18071,7 +18071,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18190,7 +18190,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18290,7 +18290,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18383,7 +18383,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18494,7 +18494,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18598,7 +18598,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18691,7 +18691,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18802,7 +18802,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -18899,7 +18899,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -18992,7 +18992,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19085,7 +19085,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19178,7 +19178,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19271,7 +19271,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19364,7 +19364,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19457,7 +19457,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19556,7 +19556,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19655,7 +19655,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19766,7 +19766,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -19870,7 +19870,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -19963,7 +19963,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20056,7 +20056,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20149,7 +20149,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20246,7 +20246,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20341,7 +20341,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20436,7 +20436,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20531,7 +20531,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20626,7 +20626,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20721,7 +20721,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20808,7 +20808,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20894,7 +20894,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -20980,7 +20980,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21066,7 +21066,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21152,7 +21152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21237,7 +21237,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21323,7 +21323,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21409,7 +21409,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21495,7 +21495,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21581,7 +21581,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21667,7 +21667,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21753,7 +21753,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21844,7 +21844,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -21948,7 +21948,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22063,7 +22063,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22178,7 +22178,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22275,7 +22275,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22361,7 +22361,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22447,7 +22447,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22533,7 +22533,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22619,7 +22619,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22705,7 +22705,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -22809,7 +22809,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -22924,7 +22924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -23039,7 +23039,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -23136,7 +23136,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23222,7 +23222,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23308,7 +23308,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23394,7 +23394,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23475,7 +23475,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23556,7 +23556,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23637,7 +23637,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23718,7 +23718,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23799,7 +23799,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23880,7 +23880,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -23961,7 +23961,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24060,7 +24060,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24170,7 +24170,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24280,7 +24280,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24372,7 +24372,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24453,7 +24453,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24534,7 +24534,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24633,7 +24633,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -24725,7 +24725,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24806,7 +24806,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24887,7 +24887,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -24986,7 +24986,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25096,7 +25096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25206,7 +25206,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25298,7 +25298,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25379,7 +25379,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25460,7 +25460,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -25563,7 +25563,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25676,7 +25676,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -25756,7 +25756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -25812,7 +25812,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -25868,7 +25868,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -25924,7 +25924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         }
       ],
       "command": [
@@ -25980,7 +25980,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26055,7 +26055,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26130,7 +26130,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26205,7 +26205,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/android_ndk_linux",
@@ -26285,7 +26285,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bloaty",
@@ -26387,7 +26387,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26491,7 +26491,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26590,7 +26590,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26659,7 +26659,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -26701,7 +26701,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -26743,7 +26743,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "skia/bots/bazelisk_linux_amd64",
@@ -26876,7 +26876,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -26954,7 +26954,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27049,7 +27049,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27341,7 +27341,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/git-credential-luci/${platform}",
@@ -27421,7 +27421,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27507,7 +27507,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27588,7 +27588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27674,7 +27674,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27755,7 +27755,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27836,7 +27836,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27917,7 +27917,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -27998,7 +27998,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28079,7 +28079,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28160,7 +28160,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28241,7 +28241,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28327,7 +28327,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28413,7 +28413,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28494,7 +28494,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28580,7 +28580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28661,7 +28661,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28742,7 +28742,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28823,7 +28823,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28904,7 +28904,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -28985,7 +28985,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29066,7 +29066,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29152,7 +29152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29233,7 +29233,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29314,7 +29314,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29395,7 +29395,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29476,7 +29476,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29557,7 +29557,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29638,7 +29638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29719,7 +29719,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29800,7 +29800,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29881,7 +29881,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -29962,7 +29962,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30043,7 +30043,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30124,7 +30124,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30205,7 +30205,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30286,7 +30286,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30367,7 +30367,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30448,7 +30448,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30529,7 +30529,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30610,7 +30610,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30691,7 +30691,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30772,7 +30772,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30853,7 +30853,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -30934,7 +30934,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31015,7 +31015,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31096,7 +31096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31177,7 +31177,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31258,7 +31258,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31339,7 +31339,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31420,7 +31420,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31501,7 +31501,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31582,7 +31582,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31663,7 +31663,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31744,7 +31744,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31825,7 +31825,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31906,7 +31906,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -31987,7 +31987,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32068,7 +32068,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32149,7 +32149,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32230,7 +32230,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32311,7 +32311,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32392,7 +32392,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32473,7 +32473,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32566,7 +32566,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32659,7 +32659,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32752,7 +32752,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32845,7 +32845,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -32938,7 +32938,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33031,7 +33031,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33124,7 +33124,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33217,7 +33217,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33310,7 +33310,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33403,7 +33403,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33496,7 +33496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33589,7 +33589,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33682,7 +33682,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33775,7 +33775,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33868,7 +33868,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -33961,7 +33961,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34054,7 +34054,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34147,7 +34147,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34240,7 +34240,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34333,7 +34333,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34430,7 +34430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34522,7 +34522,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34614,7 +34614,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34706,7 +34706,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34798,7 +34798,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34890,7 +34890,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -34987,7 +34987,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35080,7 +35080,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35173,7 +35173,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35266,7 +35266,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35363,7 +35363,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35465,7 +35465,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35567,7 +35567,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35664,7 +35664,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35771,7 +35771,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35873,7 +35873,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -35965,7 +35965,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36057,7 +36057,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36149,7 +36149,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36243,7 +36243,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36335,7 +36335,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36427,7 +36427,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36519,7 +36519,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36611,7 +36611,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36703,7 +36703,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36795,7 +36795,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36887,7 +36887,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -36979,7 +36979,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37071,7 +37071,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37163,7 +37163,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37255,7 +37255,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37347,7 +37347,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37439,7 +37439,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37531,7 +37531,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37623,7 +37623,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37715,7 +37715,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37807,7 +37807,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37899,7 +37899,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -37991,7 +37991,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38083,7 +38083,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38175,7 +38175,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38267,7 +38267,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38359,7 +38359,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38451,7 +38451,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38543,7 +38543,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38635,7 +38635,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38727,7 +38727,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38819,7 +38819,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -38911,7 +38911,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39003,7 +39003,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39095,7 +39095,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39187,7 +39187,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39279,7 +39279,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39371,7 +39371,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39463,7 +39463,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39555,7 +39555,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39647,7 +39647,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39739,7 +39739,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39831,7 +39831,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -39927,7 +39927,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40017,7 +40017,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40107,7 +40107,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40197,7 +40197,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40287,7 +40287,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40377,7 +40377,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40467,7 +40467,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40564,7 +40564,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40661,7 +40661,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40758,7 +40758,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40851,7 +40851,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -40939,7 +40939,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41027,7 +41027,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41115,7 +41115,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41203,7 +41203,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41291,7 +41291,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41379,7 +41379,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41467,7 +41467,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41555,7 +41555,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41643,7 +41643,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41731,7 +41731,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41819,7 +41819,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41907,7 +41907,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -41995,7 +41995,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42083,7 +42083,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42171,7 +42171,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42259,7 +42259,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42347,7 +42347,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42435,7 +42435,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42523,7 +42523,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42611,7 +42611,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42699,7 +42699,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42787,7 +42787,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42875,7 +42875,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -42963,7 +42963,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43051,7 +43051,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43139,7 +43139,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43227,7 +43227,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43315,7 +43315,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43403,7 +43403,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43491,7 +43491,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43579,7 +43579,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43667,7 +43667,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43755,7 +43755,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43843,7 +43843,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -43931,7 +43931,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44019,7 +44019,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44107,7 +44107,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44195,7 +44195,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44283,7 +44283,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44371,7 +44371,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44459,7 +44459,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44547,7 +44547,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44635,7 +44635,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44723,7 +44723,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44804,7 +44804,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44885,7 +44885,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -44966,7 +44966,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45054,7 +45054,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45142,7 +45142,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45230,7 +45230,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45318,7 +45318,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45406,7 +45406,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45494,7 +45494,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45582,7 +45582,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45670,7 +45670,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45758,7 +45758,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45846,7 +45846,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -45934,7 +45934,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46022,7 +46022,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46110,7 +46110,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46198,7 +46198,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46286,7 +46286,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46374,7 +46374,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46462,7 +46462,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46550,7 +46550,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46638,7 +46638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46726,7 +46726,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46814,7 +46814,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46902,7 +46902,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -46990,7 +46990,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47078,7 +47078,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47166,7 +47166,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47254,7 +47254,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47342,7 +47342,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47430,7 +47430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47518,7 +47518,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47606,7 +47606,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47694,7 +47694,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47782,7 +47782,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47870,7 +47870,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -47958,7 +47958,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48046,7 +48046,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48134,7 +48134,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48222,7 +48222,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48310,7 +48310,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48398,7 +48398,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48486,7 +48486,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48574,7 +48574,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48662,7 +48662,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48750,7 +48750,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48838,7 +48838,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -48926,7 +48926,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49014,7 +49014,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49102,7 +49102,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49190,7 +49190,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49278,7 +49278,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49378,7 +49378,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49478,7 +49478,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49578,7 +49578,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49678,7 +49678,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49778,7 +49778,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49883,7 +49883,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -49988,7 +49988,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50088,7 +50088,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50188,7 +50188,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50288,7 +50288,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50388,7 +50388,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50488,7 +50488,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50588,7 +50588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50688,7 +50688,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50788,7 +50788,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50893,7 +50893,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -50998,7 +50998,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51098,7 +51098,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51191,7 +51191,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51284,7 +51284,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51384,7 +51384,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51484,7 +51484,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51584,7 +51584,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51689,7 +51689,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51789,7 +51789,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51889,7 +51889,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -51989,7 +51989,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52089,7 +52089,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52189,7 +52189,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52282,7 +52282,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52380,7 +52380,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52485,7 +52485,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52585,7 +52585,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52685,7 +52685,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52785,7 +52785,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52885,7 +52885,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -52985,7 +52985,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53085,7 +53085,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53185,7 +53185,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53290,7 +53290,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53395,7 +53395,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53495,7 +53495,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53588,7 +53588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53681,7 +53681,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53774,7 +53774,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53874,7 +53874,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -53974,7 +53974,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54074,7 +54074,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54179,7 +54179,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54279,7 +54279,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54379,7 +54379,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54479,7 +54479,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54579,7 +54579,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54679,7 +54679,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54772,7 +54772,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54865,7 +54865,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -54969,7 +54969,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55073,7 +55073,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55173,7 +55173,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55273,7 +55273,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55371,7 +55371,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55471,7 +55471,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55571,7 +55571,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55669,7 +55669,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55767,7 +55767,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55877,7 +55877,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -55982,7 +55982,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56092,7 +56092,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56182,7 +56182,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56282,7 +56282,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56382,7 +56382,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56482,7 +56482,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56582,7 +56582,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56682,7 +56682,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56782,7 +56782,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56882,7 +56882,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -56982,7 +56982,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57082,7 +57082,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57180,7 +57180,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57280,7 +57280,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57380,7 +57380,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57480,7 +57480,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57580,7 +57580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57679,7 +57679,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57778,7 +57778,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57878,7 +57878,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -57978,7 +57978,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58078,7 +58078,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58178,7 +58178,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58278,7 +58278,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58378,7 +58378,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58482,7 +58482,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58581,7 +58581,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58680,7 +58680,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58779,7 +58779,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58883,7 +58883,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -58987,7 +58987,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59091,7 +59091,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59183,7 +59183,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59287,7 +59287,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59386,7 +59386,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59490,7 +59490,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59594,7 +59594,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59686,7 +59686,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59785,7 +59785,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59889,7 +59889,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -59989,7 +59989,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60093,7 +60093,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60200,7 +60200,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60309,7 +60309,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60416,7 +60416,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60523,7 +60523,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60630,7 +60630,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60734,7 +60734,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60836,7 +60836,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -60940,7 +60940,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61049,7 +61049,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61153,7 +61153,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61257,7 +61257,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61366,7 +61366,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61454,7 +61454,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61542,7 +61542,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61634,7 +61634,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61726,7 +61726,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61818,7 +61818,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -61910,7 +61910,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62002,7 +62002,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62094,7 +62094,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62186,7 +62186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62278,7 +62278,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62370,7 +62370,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62462,7 +62462,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62554,7 +62554,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62646,7 +62646,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62738,7 +62738,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62830,7 +62830,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -62924,7 +62924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63018,7 +63018,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63112,7 +63112,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63206,7 +63206,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63305,7 +63305,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63409,7 +63409,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63503,7 +63503,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63595,7 +63595,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63687,7 +63687,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63779,7 +63779,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63871,7 +63871,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -63963,7 +63963,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64055,7 +64055,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64147,7 +64147,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64239,7 +64239,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64331,7 +64331,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64423,7 +64423,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64515,7 +64515,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64607,7 +64607,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64699,7 +64699,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64791,7 +64791,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64883,7 +64883,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -64975,7 +64975,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65067,7 +65067,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65159,7 +65159,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65251,7 +65251,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65343,7 +65343,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65435,7 +65435,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65527,7 +65527,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65619,7 +65619,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65711,7 +65711,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65803,7 +65803,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65895,7 +65895,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -65987,7 +65987,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66079,7 +66079,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66171,7 +66171,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66263,7 +66263,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66355,7 +66355,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66447,7 +66447,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66539,7 +66539,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66631,7 +66631,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66723,7 +66723,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66815,7 +66815,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -66912,7 +66912,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67004,7 +67004,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67096,7 +67096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67188,7 +67188,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67280,7 +67280,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67372,7 +67372,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67464,7 +67464,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67556,7 +67556,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67648,7 +67648,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67740,7 +67740,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67832,7 +67832,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -67924,7 +67924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68016,7 +68016,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68108,7 +68108,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68200,7 +68200,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68292,7 +68292,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68384,7 +68384,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68476,7 +68476,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68568,7 +68568,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68660,7 +68660,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68752,7 +68752,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68844,7 +68844,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -68936,7 +68936,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69028,7 +69028,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69120,7 +69120,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69212,7 +69212,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69304,7 +69304,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69396,7 +69396,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69488,7 +69488,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69580,7 +69580,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69672,7 +69672,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69764,7 +69764,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69856,7 +69856,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -69948,7 +69948,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70042,7 +70042,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70136,7 +70136,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70230,7 +70230,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70324,7 +70324,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70416,7 +70416,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70508,7 +70508,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70600,7 +70600,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70692,7 +70692,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70784,7 +70784,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70876,7 +70876,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -70968,7 +70968,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71060,7 +71060,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71152,7 +71152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71244,7 +71244,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71336,7 +71336,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71428,7 +71428,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71520,7 +71520,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71616,7 +71616,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71712,7 +71712,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71808,7 +71808,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -71904,7 +71904,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72000,7 +72000,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72096,7 +72096,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72192,7 +72192,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72288,7 +72288,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72384,7 +72384,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72480,7 +72480,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72576,7 +72576,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72672,7 +72672,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72768,7 +72768,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72871,7 +72871,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -72974,7 +72974,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73077,7 +73077,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73180,7 +73180,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73283,7 +73283,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73386,7 +73386,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73489,7 +73489,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73588,7 +73588,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73670,7 +73670,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73752,7 +73752,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73834,7 +73834,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73916,7 +73916,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -73998,7 +73998,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74080,7 +74080,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74162,7 +74162,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74244,7 +74244,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74326,7 +74326,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74408,7 +74408,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74490,7 +74490,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74572,7 +74572,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74654,7 +74654,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74736,7 +74736,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74818,7 +74818,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74900,7 +74900,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -74982,7 +74982,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75064,7 +75064,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75146,7 +75146,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75228,7 +75228,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75310,7 +75310,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75392,7 +75392,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75474,7 +75474,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75556,7 +75556,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75638,7 +75638,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75720,7 +75720,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75802,7 +75802,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75884,7 +75884,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -75966,7 +75966,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76048,7 +76048,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76130,7 +76130,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76212,7 +76212,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76294,7 +76294,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76376,7 +76376,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76458,7 +76458,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76540,7 +76540,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76622,7 +76622,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76704,7 +76704,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76786,7 +76786,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76868,7 +76868,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -76950,7 +76950,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77032,7 +77032,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77114,7 +77114,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77196,7 +77196,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77278,7 +77278,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77360,7 +77360,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77442,7 +77442,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77524,7 +77524,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77606,7 +77606,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77688,7 +77688,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77770,7 +77770,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77852,7 +77852,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -77934,7 +77934,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78016,7 +78016,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78098,7 +78098,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78180,7 +78180,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78262,7 +78262,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78344,7 +78344,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78426,7 +78426,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78508,7 +78508,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78590,7 +78590,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78672,7 +78672,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78754,7 +78754,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78836,7 +78836,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -78918,7 +78918,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79000,7 +79000,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79082,7 +79082,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79164,7 +79164,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79246,7 +79246,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79328,7 +79328,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79410,7 +79410,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79492,7 +79492,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79574,7 +79574,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79656,7 +79656,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79738,7 +79738,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79820,7 +79820,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79902,7 +79902,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -79984,7 +79984,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80066,7 +80066,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80148,7 +80148,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80230,7 +80230,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80312,7 +80312,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80394,7 +80394,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80476,7 +80476,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80558,7 +80558,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80640,7 +80640,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80722,7 +80722,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80804,7 +80804,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80886,7 +80886,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -80968,7 +80968,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81050,7 +81050,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81132,7 +81132,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81214,7 +81214,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81296,7 +81296,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81378,7 +81378,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81460,7 +81460,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81542,7 +81542,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81624,7 +81624,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81706,7 +81706,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81788,7 +81788,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81870,7 +81870,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -81952,7 +81952,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82034,7 +82034,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82116,7 +82116,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82198,7 +82198,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82280,7 +82280,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82362,7 +82362,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82444,7 +82444,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82526,7 +82526,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82608,7 +82608,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82690,7 +82690,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82772,7 +82772,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82854,7 +82854,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -82936,7 +82936,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83018,7 +83018,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83100,7 +83100,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83182,7 +83182,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83264,7 +83264,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83346,7 +83346,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83428,7 +83428,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83510,7 +83510,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83592,7 +83592,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83674,7 +83674,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83756,7 +83756,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83838,7 +83838,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -83920,7 +83920,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84002,7 +84002,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84084,7 +84084,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84166,7 +84166,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84248,7 +84248,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84330,7 +84330,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84412,7 +84412,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84494,7 +84494,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84576,7 +84576,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84658,7 +84658,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84740,7 +84740,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84822,7 +84822,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84904,7 +84904,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -84986,7 +84986,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85068,7 +85068,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85150,7 +85150,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85232,7 +85232,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85314,7 +85314,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85396,7 +85396,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85478,7 +85478,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85560,7 +85560,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85642,7 +85642,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85724,7 +85724,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85806,7 +85806,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85888,7 +85888,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -85970,7 +85970,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86052,7 +86052,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86134,7 +86134,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86216,7 +86216,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86298,7 +86298,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86380,7 +86380,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86462,7 +86462,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86544,7 +86544,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86626,7 +86626,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86708,7 +86708,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86790,7 +86790,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86872,7 +86872,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -86954,7 +86954,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87036,7 +87036,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87118,7 +87118,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87200,7 +87200,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87282,7 +87282,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87364,7 +87364,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87446,7 +87446,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87528,7 +87528,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87610,7 +87610,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87692,7 +87692,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87774,7 +87774,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87856,7 +87856,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -87938,7 +87938,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88020,7 +88020,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88102,7 +88102,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88184,7 +88184,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88266,7 +88266,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88348,7 +88348,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88430,7 +88430,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88512,7 +88512,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88594,7 +88594,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88676,7 +88676,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88758,7 +88758,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88840,7 +88840,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -88922,7 +88922,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89004,7 +89004,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89086,7 +89086,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89168,7 +89168,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89250,7 +89250,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89332,7 +89332,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89414,7 +89414,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89496,7 +89496,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89578,7 +89578,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89660,7 +89660,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89742,7 +89742,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89824,7 +89824,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89906,7 +89906,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -89988,7 +89988,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90070,7 +90070,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90152,7 +90152,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90234,7 +90234,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90316,7 +90316,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90398,7 +90398,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90480,7 +90480,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90562,7 +90562,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90644,7 +90644,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90726,7 +90726,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90808,7 +90808,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90890,7 +90890,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -90972,7 +90972,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91054,7 +91054,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91136,7 +91136,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91218,7 +91218,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91300,7 +91300,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91382,7 +91382,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91464,7 +91464,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91546,7 +91546,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91628,7 +91628,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91710,7 +91710,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91792,7 +91792,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91874,7 +91874,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -91956,7 +91956,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92038,7 +92038,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92120,7 +92120,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92202,7 +92202,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92284,7 +92284,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92366,7 +92366,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92448,7 +92448,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92530,7 +92530,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92612,7 +92612,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92694,7 +92694,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92776,7 +92776,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92858,7 +92858,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -92940,7 +92940,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93022,7 +93022,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93104,7 +93104,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93186,7 +93186,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93268,7 +93268,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93350,7 +93350,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93432,7 +93432,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93514,7 +93514,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93596,7 +93596,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93678,7 +93678,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93760,7 +93760,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93842,7 +93842,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -93924,7 +93924,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94006,7 +94006,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94088,7 +94088,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94170,7 +94170,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",
@@ -94252,7 +94252,7 @@
         {
           "name": "infra/tools/luci-auth/${platform}",
           "path": "cipd_bin_packages",
-          "version": "git_revision:36402eaf928c7ca7db41448371af1891776d115a"
+          "version": "git_revision:a1b61bd493b7f70e2fb437589caf6f68efcf11d8"
         },
         {
           "name": "infra/tools/luci/kitchen/${platform}",

--- a/src/sksl/codegen/SkSLRasterPipelineCodeGenerator.cpp
+++ b/src/sksl/codegen/SkSLRasterPipelineCodeGenerator.cpp
@@ -1422,10 +1422,13 @@ std::optional<SlotRange> Generator::writeFunction(
             // If we are passing a child effect to a function, we need to add its mapping to our
             // child map.
             if (arg.type().isEffectChild()) {
-                if (int* childIndex = fChildEffectMap.find(arg.as<VariableReference>()
-                                                              .variable())) {
+                if (int* childIndexPtr =
+                            fChildEffectMap.find(arg.as<VariableReference>().variable())) {
+                    // In earlier C++ versions, the map assignment could cause the map to be
+                    // resized, invalidating the pointer.
+                    int childIndex = *childIndexPtr;
                     SkASSERT(!fChildEffectMap.find(&param));
-                    fChildEffectMap[&param] = *childIndex;
+                    fChildEffectMap[&param] = childIndex;
                 }
                 continue;
             }
@@ -2809,8 +2812,9 @@ bool Generator::pushConstructorCompound(const AnyConstructor& c) {
 }
 
 bool Generator::pushChildCall(const ChildCall& c) {
-    int* childIdx = fChildEffectMap.find(&c.child());
-    SkASSERT(childIdx != nullptr);
+    int* childIdxPtr = fChildEffectMap.find(&c.child());
+    SkASSERT(childIdxPtr != nullptr);
+    int childIdx = *childIdxPtr;  // Save this in case pushExpression changes fChildEffectMap
     SkASSERT(!c.arguments().empty());
 
     // All child calls have at least one argument.
@@ -2832,7 +2836,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
 
             // Move the argument into src.rgba while also preserving the execution mask.
             fBuilder.exchange_src();
-            fBuilder.invoke_shader(*childIdx);
+            fBuilder.invoke_shader(childIdx);
             break;
         }
         case Type::TypeKind::kColorFilter: {
@@ -2843,7 +2847,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
 
             // Move the argument into src.rgba while also preserving the execution mask.
             fBuilder.exchange_src();
-            fBuilder.invoke_color_filter(*childIdx);
+            fBuilder.invoke_color_filter(childIdx);
             break;
         }
         case Type::TypeKind::kBlender: {
@@ -2861,7 +2865,7 @@ bool Generator::pushChildCall(const ChildCall& c) {
             }
             fBuilder.pop_dst_rgba();
             fBuilder.exchange_src();
-            fBuilder.invoke_blender(*childIdx);
+            fBuilder.invoke_blender(childIdx);
             break;
         }
         default: {

--- a/tests/RasterPipelineCodeGeneratorTest.cpp
+++ b/tests/RasterPipelineCodeGeneratorTest.cpp
@@ -328,3 +328,31 @@ DEF_TEST(SkSLRasterPipelineSlotOverflow_355465305, r) {
     bool success = rasterProg->appendStages(&pipeline, &alloc, /*callbacks=*/nullptr, {});
     REPORTER_ASSERT(r, !success, "appendStages should fail for very large program");
 }
+
+DEF_TEST(SkSLRasterPipeline_ConvertProgram_b540157141, r) {
+    const char* src = R"__SkSL__(
+        uniform shader c0;
+        uniform shader c1;
+        uniform shader c2;
+        // The noinline is important for reproduction. It is also important that
+        // one of the args be an "EffectChild" to cause fChildEffectMap to grow.
+        noinline half4 f(shader s, float2 p) {
+            return s.eval(p);
+        }
+        half4 main(float2 p) {
+            return c0.eval(float2(f(c1, p).xy) + p);
+        }
+    )__SkSL__";
+
+    SkSL::Compiler compiler;
+    SkSL::ProgramSettings settings;
+    std::unique_ptr<SkSL::Program> program = compiler.convertProgram(
+            SkSL::ProgramKind::kPrivateRuntimeShader, std::string(src), settings);
+    SkASSERTF_RELEASE(program, "Unexpected error compiling %s", compiler.errorText().c_str());
+    const SkSL::FunctionDeclaration* main = program->getFunction("main");
+    SkASSERTF_RELEASE(main, "main is missing!?");
+    // With the buggy code, this triggered a UAF
+    std::unique_ptr<SkSL::RP::Program> rasterProg =
+            SkSL::MakeRasterPipelineProgram(*program, *main->definition());
+    REPORTER_ASSERT(r, rasterProg);
+}


### PR DESCRIPTION
Automated upstream merge of `chrome/m151`.

## Upstream merge

Merges `upstream/chrome/m151` (tip `86bb2f25f4`) into mono/skia `skiasharp` via `skia-sync/m151`.

**New upstream commits (2):**

| SHA | Subject |
|---|---|
| `86bb2f25f4` | [M151] Address incorrect handling of a map pointer in SkRP |
| `f7be6d7766` | Roll infra dep to 055b758759c89b0cfafc8264ae2100a9aa6582d3 |

Merge commit: `7853af4777c21d31ed86924782c90dd1f6994751` (proper two-parent merge).

## Conflicts resolved

**None.** `git merge --no-commit upstream/chrome/m151` reported only an auto-merge on `DEPS` (no conflict markers). Files touched by the merge:

- `DEPS` — auto-merged; only upstream's `infra_revision` bump (`c0e4e8a…` → `055b758…`). Our fork pins remain intact.
- `infra/**`, `.disabled.go.*`, `tasks.json` — upstream-only infra churn from the infra roll.
- `src/sksl/codegen/SkSLRasterPipelineCodeGenerator.cpp` + `tests/RasterPipelineCodeGeneratorTest.cpp` — upstream-only SkRP map-pointer fix.

No fork patches touched any of the merged files, so the verify-upstream-or-reapply audit is a no-op for this sync.

## C API fixes

**None.** No changes under `src/c/` or `include/c/`. All 87 C API files intact after merge.

## Items needing human attention

None from the mono/skia side.

Created by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).