### PR TITLE
Add Graphite presentation interop

### DIFF
--- a/include/c/sk_graphite.h
+++ b/include/c/sk_graphite.h
@@ -20,6 +20,8 @@ typedef struct sk_graphite_recording_t          sk_graphite_recording_t;
 typedef struct sk_graphite_backend_texture_t    sk_graphite_backend_texture_t;
 typedef struct sk_graphite_texture_info_t       sk_graphite_texture_info_t;
 typedef struct sk_graphite_image_provider_t     sk_graphite_image_provider_t;
+typedef struct sk_graphite_backend_semaphore_t  sk_graphite_backend_semaphore_t;
+typedef struct sk_graphite_mutable_texture_state_t sk_graphite_mutable_texture_state_t;
 
 // Backend identification
 
@@ -81,6 +83,7 @@ typedef struct {
 // Release callback for caller-owned backend textures
 
 typedef void (*sk_graphite_release_proc)(void* releaseContext);
+typedef void (*sk_graphite_finished_proc)(void* finishedContext, bool success);
 
 // Context
 
@@ -106,6 +109,20 @@ SK_C_API sk_graphite_recorder_t*       sk_graphite_context_make_recorder(
 
 // Insert / submit. insert returns a status — non-success is not an error path.
 SK_C_API sk_graphite_insert_status_t   sk_graphite_context_insert_recording(sk_graphite_context_t* context, const sk_graphite_insert_recording_info_t* info);
+SK_C_API sk_graphite_insert_status_t   sk_graphite_context_insert_recording_full(
+    sk_graphite_context_t* context,
+    sk_graphite_recording_t* recording,
+    sk_surface_t* targetSurface,
+    int32_t targetTranslationX,
+    int32_t targetTranslationY,
+    const sk_irect_t* targetClip,
+    const sk_graphite_mutable_texture_state_t* targetTextureState,
+    const void* const* waitSemaphores,
+    int32_t waitSemaphoreCount,
+    const void* const* signalSemaphores,
+    int32_t signalSemaphoreCount,
+    sk_graphite_finished_proc finishedProc,
+    void* finishedContext);
 SK_C_API bool                          sk_graphite_context_submit(sk_graphite_context_t* context, const sk_graphite_submit_info_t* info /* nullable -> defaults */);
 
 // Recorder
@@ -115,6 +132,10 @@ SK_C_API sk_graphite_backend_t         sk_graphite_recorder_get_backend(const sk
 SK_C_API int32_t                       sk_graphite_recorder_get_max_texture_size(const sk_graphite_recorder_t* recorder);
 // Snap: returns null if no recording has been recorded since the last snap().
 SK_C_API sk_graphite_recording_t*      sk_graphite_recorder_snap(sk_graphite_recorder_t* recorder);
+SK_C_API sk_canvas_t*                  sk_graphite_recorder_make_deferred_canvas(
+    sk_graphite_recorder_t* recorder,
+    const sk_imageinfo_t* info,
+    const sk_graphite_texture_info_t* textureInfo);
 
 // Recording
 
@@ -181,6 +202,17 @@ SK_C_API void                          sk_graphite_backend_texture_delete       
 SK_C_API bool                          sk_graphite_backend_texture_is_valid     (const sk_graphite_backend_texture_t* tex);
 SK_C_API sk_graphite_backend_t         sk_graphite_backend_texture_get_backend  (const sk_graphite_backend_texture_t* tex);
 SK_C_API void                          sk_graphite_backend_texture_get_dimensions(const sk_graphite_backend_texture_t* tex, int32_t* outWidth, int32_t* outHeight);
+SK_C_API sk_graphite_texture_info_t*   sk_graphite_backend_texture_get_texture_info(const sk_graphite_backend_texture_t* tex);
+
+// BackendSemaphore and MutableTextureState are value types in Graphite. The C
+// ABI wraps copies on the heap so callers can pass stable opaque handles into
+// sk_graphite_context_insert_recording_full and release them immediately after
+// that function returns.
+
+SK_C_API void                          sk_graphite_backend_semaphore_delete(
+    sk_graphite_backend_semaphore_t* semaphore);
+SK_C_API void                          sk_graphite_mutable_texture_state_delete(
+    sk_graphite_mutable_texture_state_t* state);
 
 // TextureInfo handle — describes a backend's texture format/sample/mipmap state
 // without referring to a concrete GPU resource.

--- a/include/c/sk_graphite_vulkan.h
+++ b/include/c/sk_graphite_vulkan.h
@@ -80,6 +80,24 @@ SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new(
     uint32_t queueFamilyIndex,
     void*    vkImage);              // VkImage
 
+// VkImage and VkSemaphore are non-dispatchable 64-bit Vulkan handles on
+// 32-bit targets. These factories preserve the complete handle value, unlike
+// the legacy pointer-shaped backend texture overload above.
+SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new_uint64(
+    int32_t  width,
+    int32_t  height,
+    const sk_graphite_vk_texture_info_t* info,
+    int32_t  imageLayout,
+    uint32_t queueFamilyIndex,
+    uint64_t vkImage);
+
+SK_C_API sk_graphite_backend_semaphore_t* sk_graphite_vk_backend_semaphore_new(
+    uint64_t vkSemaphore);
+
+SK_C_API sk_graphite_mutable_texture_state_t* sk_graphite_vk_mutable_texture_state_new(
+    int32_t imageLayout,
+    uint32_t queueFamilyIndex);
+
 SK_C_PLUS_PLUS_END_GUARD
 
 #endif  // sk_graphite_vulkan_DEFINED

--- a/src/c/sk_graphite.cpp
+++ b/src/c/sk_graphite.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace gr = skgpu::graphite;
 
@@ -227,6 +228,18 @@ static sk_graphite_insert_status_t ToInsertStatus(gr::InsertStatus::V v) {
     SkUNREACHABLE;
 }
 
+namespace {
+struct FfiFinishedBridge {
+    sk_graphite_finished_proc proc;
+    void* context;
+};
+
+void graphite_finished_adapter(void* raw, skgpu::CallbackResult result) {
+    std::unique_ptr<FfiFinishedBridge> bridge(static_cast<FfiFinishedBridge*>(raw));
+    bridge->proc(bridge->context, result == skgpu::CallbackResult::kSuccess);
+}
+}  // namespace
+
 extern "C" SK_C_API sk_graphite_insert_status_t sk_graphite_context_insert_recording(sk_graphite_context_t* h, const sk_graphite_insert_recording_info_t* info) {
     gr::InsertRecordingInfo iri;
     iri.fRecording = AsGraphiteRecording(info->fRecording);
@@ -236,6 +249,59 @@ extern "C" SK_C_API sk_graphite_insert_status_t sk_graphite_context_insert_recor
     iri.fTargetClip = *AsIRect(&info->fTargetClip);
     auto status = AsGraphiteContext(h)->insertRecording(iri);
     return ToInsertStatus(status);
+}
+
+extern "C" SK_C_API sk_graphite_insert_status_t sk_graphite_context_insert_recording_full(
+    sk_graphite_context_t* h,
+    sk_graphite_recording_t* recording,
+    sk_surface_t* targetSurface,
+    int32_t targetTranslationX,
+    int32_t targetTranslationY,
+    const sk_irect_t* targetClip,
+    const sk_graphite_mutable_texture_state_t* targetTextureState,
+    const void* const* waitSemaphores,
+    int32_t waitSemaphoreCount,
+    const void* const* signalSemaphores,
+    int32_t signalSemaphoreCount,
+    sk_graphite_finished_proc finishedProc,
+    void* finishedContext)
+{
+    std::vector<gr::BackendSemaphore> waits;
+    waits.reserve(waitSemaphoreCount);
+    for (int32_t i = 0; i < waitSemaphoreCount; ++i) {
+        waits.push_back(*AsGraphiteBackendSemaphore(
+                static_cast<const sk_graphite_backend_semaphore_t*>(waitSemaphores[i])));
+    }
+
+    std::vector<gr::BackendSemaphore> signals;
+    signals.reserve(signalSemaphoreCount);
+    for (int32_t i = 0; i < signalSemaphoreCount; ++i) {
+        signals.push_back(*AsGraphiteBackendSemaphore(
+                static_cast<const sk_graphite_backend_semaphore_t*>(signalSemaphores[i])));
+    }
+
+    gr::InsertRecordingInfo iri;
+    iri.fRecording = AsGraphiteRecording(recording);
+    iri.fTargetSurface = AsSurface(targetSurface);
+    iri.fTargetTranslation = {targetTranslationX, targetTranslationY};
+    if (targetClip) {
+        iri.fTargetClip = *AsIRect(targetClip);
+    }
+    iri.fTargetTextureState =
+            const_cast<skgpu::MutableTextureState*>(AsGraphiteMutableTextureState(
+                    targetTextureState));
+    iri.fNumWaitSemaphores = waits.size();
+    iri.fWaitSemaphores = waits.data();
+    iri.fNumSignalSemaphores = signals.size();
+    iri.fSignalSemaphores = signals.data();
+
+    if (finishedProc) {
+        auto* bridge = new FfiFinishedBridge{finishedProc, finishedContext};
+        iri.fFinishedContext = bridge;
+        iri.fFinishedProc = graphite_finished_adapter;
+    }
+
+    return ToInsertStatus(AsGraphiteContext(h)->insertRecording(iri));
 }
 
 extern "C" SK_C_API bool sk_graphite_context_submit(sk_graphite_context_t* h, const sk_graphite_submit_info_t* info) {
@@ -272,6 +338,15 @@ extern "C" SK_C_API int32_t sk_graphite_recorder_get_max_texture_size(const sk_g
 extern "C" SK_C_API sk_graphite_recording_t* sk_graphite_recorder_snap(sk_graphite_recorder_t* h) {
     auto recording = AsGraphiteRecorder(h)->snap();
     return ToGraphiteRecording(recording.release());
+}
+
+extern "C" SK_C_API sk_canvas_t* sk_graphite_recorder_make_deferred_canvas(
+    sk_graphite_recorder_t* h,
+    const sk_imageinfo_t* cinfo,
+    const sk_graphite_texture_info_t* textureInfo)
+{
+    return ToCanvas(AsGraphiteRecorder(h)->makeDeferredCanvas(
+            AsImageInfo(cinfo), *AsGraphiteTextureInfo(textureInfo)));
 }
 
 // Recording
@@ -383,6 +458,23 @@ extern "C" SK_C_API void sk_graphite_backend_texture_get_dimensions(const sk_gra
     *outW = d.fWidth;
     *outH = d.fHeight;
 }
+extern "C" SK_C_API sk_graphite_texture_info_t* sk_graphite_backend_texture_get_texture_info(
+    const sk_graphite_backend_texture_t* h)
+{
+    return ToGraphiteTextureInfo(new gr::TextureInfo(AsGraphiteBackendTexture(h)->info()));
+}
+
+extern "C" SK_C_API void sk_graphite_backend_semaphore_delete(
+    sk_graphite_backend_semaphore_t* h)
+{
+    delete AsGraphiteBackendSemaphore(h);
+}
+
+extern "C" SK_C_API void sk_graphite_mutable_texture_state_delete(
+    sk_graphite_mutable_texture_state_t* h)
+{
+    delete AsGraphiteMutableTextureState(h);
+}
 
 // TextureInfo handle.
 
@@ -483,11 +575,13 @@ extern "C" SK_C_API void                          sk_graphite_context_free_gpu_r
 extern "C" SK_C_API void                          sk_graphite_context_perform_deferred_cleanup(sk_graphite_context_t*, int64_t) {}
 extern "C" SK_C_API sk_graphite_recorder_t*       sk_graphite_context_make_recorder(sk_graphite_context_t*, int64_t, sk_graphite_image_provider_t*) { return nullptr; }
 extern "C" SK_C_API sk_graphite_insert_status_t   sk_graphite_context_insert_recording(sk_graphite_context_t*, const sk_graphite_insert_recording_info_t*) { return INVALID_RECORDING_SK_GRAPHITE_INSERT_STATUS; }
+extern "C" SK_C_API sk_graphite_insert_status_t   sk_graphite_context_insert_recording_full(sk_graphite_context_t*, sk_graphite_recording_t*, sk_surface_t*, int32_t, int32_t, const sk_irect_t*, const sk_graphite_mutable_texture_state_t*, const void* const*, int32_t, const void* const*, int32_t, sk_graphite_finished_proc cb, void* ctx) { if (cb) cb(ctx, false); return INVALID_RECORDING_SK_GRAPHITE_INSERT_STATUS; }
 extern "C" SK_C_API bool                          sk_graphite_context_submit(sk_graphite_context_t*, const sk_graphite_submit_info_t*) { return false; }
 extern "C" SK_C_API void                          sk_graphite_recorder_delete(sk_graphite_recorder_t*) {}
 extern "C" SK_C_API sk_graphite_backend_t         sk_graphite_recorder_get_backend(const sk_graphite_recorder_t*) { return VULKAN_SK_GRAPHITE_BACKEND; }
 extern "C" SK_C_API int32_t                       sk_graphite_recorder_get_max_texture_size(const sk_graphite_recorder_t*) { return 0; }
 extern "C" SK_C_API sk_graphite_recording_t*      sk_graphite_recorder_snap(sk_graphite_recorder_t*) { return nullptr; }
+extern "C" SK_C_API sk_canvas_t*                  sk_graphite_recorder_make_deferred_canvas(sk_graphite_recorder_t*, const sk_imageinfo_t*, const sk_graphite_texture_info_t*) { return nullptr; }
 extern "C" SK_C_API void                          sk_graphite_recording_delete(sk_graphite_recording_t*) {}
 extern "C" SK_C_API sk_surface_t*                 sk_graphite_surface_make_render_target(sk_graphite_recorder_t*, const sk_imageinfo_t*, bool, const sk_surfaceprops_t*) { return nullptr; }
 extern "C" SK_C_API void                          sk_graphite_context_async_rescale_and_read_pixels_surface(sk_graphite_context_t*, const sk_surface_t*, const sk_imageinfo_t*, const sk_irect_t*, sk_image_rescale_gamma_t, sk_image_rescale_mode_t, sk_image_async_read_pixels_proc cb, void* ctx) { if (cb) cb(ctx, nullptr); }
@@ -497,6 +591,9 @@ extern "C" SK_C_API void                          sk_graphite_backend_texture_de
 extern "C" SK_C_API bool                          sk_graphite_backend_texture_is_valid(const sk_graphite_backend_texture_t*) { return false; }
 extern "C" SK_C_API sk_graphite_backend_t         sk_graphite_backend_texture_get_backend(const sk_graphite_backend_texture_t*) { return VULKAN_SK_GRAPHITE_BACKEND; }
 extern "C" SK_C_API void                          sk_graphite_backend_texture_get_dimensions(const sk_graphite_backend_texture_t*, int32_t*, int32_t*) {}
+extern "C" SK_C_API sk_graphite_texture_info_t*   sk_graphite_backend_texture_get_texture_info(const sk_graphite_backend_texture_t*) { return nullptr; }
+extern "C" SK_C_API void                          sk_graphite_backend_semaphore_delete(sk_graphite_backend_semaphore_t*) {}
+extern "C" SK_C_API void                          sk_graphite_mutable_texture_state_delete(sk_graphite_mutable_texture_state_t*) {}
 extern "C" SK_C_API void                          sk_graphite_texture_info_delete(sk_graphite_texture_info_t*) {}
 extern "C" SK_C_API bool                          sk_graphite_texture_info_is_valid(const sk_graphite_texture_info_t*) { return false; }
 extern "C" SK_C_API sk_graphite_backend_t         sk_graphite_texture_info_get_backend(const sk_graphite_texture_info_t*) { return VULKAN_SK_GRAPHITE_BACKEND; }

--- a/src/c/sk_graphite.cpp
+++ b/src/c/sk_graphite.cpp
@@ -266,6 +266,13 @@ extern "C" SK_C_API sk_graphite_insert_status_t sk_graphite_context_insert_recor
     sk_graphite_finished_proc finishedProc,
     void* finishedContext)
 {
+    if (targetTextureState && !targetSurface) {
+        if (finishedProc) {
+            finishedProc(finishedContext, false);
+        }
+        return INVALID_RECORDING_SK_GRAPHITE_INSERT_STATUS;
+    }
+
     std::vector<gr::BackendSemaphore> waits;
     waits.reserve(waitSemaphoreCount);
     for (int32_t i = 0; i < waitSemaphoreCount; ++i) {
@@ -345,8 +352,19 @@ extern "C" SK_C_API sk_canvas_t* sk_graphite_recorder_make_deferred_canvas(
     const sk_imageinfo_t* cinfo,
     const sk_graphite_texture_info_t* textureInfo)
 {
-    return ToCanvas(AsGraphiteRecorder(h)->makeDeferredCanvas(
-            AsImageInfo(cinfo), *AsGraphiteTextureInfo(textureInfo)));
+    auto* recorder = AsGraphiteRecorder(h);
+    auto info = AsImageInfo(cinfo);
+    auto* targetInfo = AsGraphiteTextureInfo(textureInfo);
+    if (info.isEmpty() ||
+        info.colorType() == kUnknown_SkColorType ||
+        info.alphaType() == kUnknown_SkAlphaType ||
+        info.width() > recorder->maxTextureSize() ||
+        info.height() > recorder->maxTextureSize() ||
+        !targetInfo->isValid() ||
+        targetInfo->backend() != recorder->backend()) {
+        return nullptr;
+    }
+    return ToCanvas(recorder->makeDeferredCanvas(info, *targetInfo));
 }
 
 // Recording

--- a/src/c/sk_graphite_vulkan.cpp
+++ b/src/c/sk_graphite_vulkan.cpp
@@ -17,6 +17,7 @@
 #include "include/gpu/graphite/vk/VulkanGraphiteTypes.h"
 #include "include/gpu/vk/VulkanBackendContext.h"
 #include "include/gpu/vk/VulkanMemoryAllocator.h"
+#include "include/gpu/vk/VulkanMutableTextureState.h"
 
 // Pulls in Context/BackendTexture/TextureInfo + the matching As/To helpers
 // via the SK_GRAPHITE block.
@@ -25,6 +26,7 @@
 #include "src/gpu/vk/vulkanmemoryallocator/VulkanMemoryAllocatorPriv.h"
 
 #include <memory>
+#include <cstring>
 
 namespace gr = skgpu::graphite;
 
@@ -88,6 +90,14 @@ gr::VulkanTextureInfo MakeNativeVkTextureInfo(const sk_graphite_vk_texture_info_
         static_cast<VkImageAspectFlags>(info.fAspectMask),
         skgpu::VulkanYcbcrConversionInfo{});
 }
+
+template <typename T>
+T MakeNonDispatchableHandle(uint64_t value) {
+    static_assert(sizeof(T) == sizeof(value));
+    T handle;
+    std::memcpy(&handle, &value, sizeof(handle));
+    return handle;
+}
 }  // namespace
 
 extern "C" SK_C_API sk_graphite_texture_info_t* sk_graphite_vk_texture_info_new(const sk_graphite_vk_texture_info_t* info) {
@@ -114,10 +124,49 @@ extern "C" SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_textur
     return ToGraphiteBackendTexture(heap);
 }
 
+extern "C" SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new_uint64(
+    int32_t width, int32_t height,
+    const sk_graphite_vk_texture_info_t* info,
+    int32_t imageLayout,
+    uint32_t queueFamilyIndex,
+    uint64_t vkImage)
+{
+    auto vkti = MakeNativeVkTextureInfo(*info);
+    auto bt = gr::BackendTextures::MakeVulkan(
+        SkISize::Make(width, height),
+        vkti,
+        static_cast<VkImageLayout>(imageLayout),
+        queueFamilyIndex,
+        MakeNonDispatchableHandle<VkImage>(vkImage),
+        skgpu::VulkanAlloc{});
+    return ToGraphiteBackendTexture(new gr::BackendTexture(bt));
+}
+
+extern "C" SK_C_API sk_graphite_backend_semaphore_t* sk_graphite_vk_backend_semaphore_new(
+    uint64_t vkSemaphore)
+{
+    auto semaphore = gr::BackendSemaphores::MakeVulkan(
+        MakeNonDispatchableHandle<VkSemaphore>(vkSemaphore));
+    return ToGraphiteBackendSemaphore(new gr::BackendSemaphore(semaphore));
+}
+
+extern "C" SK_C_API sk_graphite_mutable_texture_state_t*
+sk_graphite_vk_mutable_texture_state_new(
+    int32_t imageLayout,
+    uint32_t queueFamilyIndex)
+{
+    auto state = skgpu::MutableTextureStates::MakeVulkan(
+        static_cast<VkImageLayout>(imageLayout), queueFamilyIndex);
+    return ToGraphiteMutableTextureState(new skgpu::MutableTextureState(state));
+}
+
 #else  // !(SK_GRAPHITE && SK_VULKAN)
 
 extern "C" SK_C_API sk_graphite_context_t* sk_graphite_context_make_vulkan(const sk_graphite_vk_backend_context_init_t, const sk_graphite_context_options_t*) { return nullptr; }
 extern "C" SK_C_API sk_graphite_texture_info_t* sk_graphite_vk_texture_info_new(const sk_graphite_vk_texture_info_t*) { return nullptr; }
 extern "C" SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new(int32_t, int32_t, const sk_graphite_vk_texture_info_t*, int32_t, uint32_t, void*) { return nullptr; }
+extern "C" SK_C_API sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new_uint64(int32_t, int32_t, const sk_graphite_vk_texture_info_t*, int32_t, uint32_t, uint64_t) { return nullptr; }
+extern "C" SK_C_API sk_graphite_backend_semaphore_t* sk_graphite_vk_backend_semaphore_new(uint64_t) { return nullptr; }
+extern "C" SK_C_API sk_graphite_mutable_texture_state_t* sk_graphite_vk_mutable_texture_state_new(int32_t, uint32_t) { return nullptr; }
 
 #endif  // SK_GRAPHITE && SK_VULKAN

--- a/src/c/sk_graphite_vulkan.cpp
+++ b/src/c/sk_graphite_vulkan.cpp
@@ -61,7 +61,7 @@ extern "C" SK_C_API sk_graphite_context_t* sk_graphite_context_make_vulkan(
     // GrVkGpu); the caller must supply one. Until we expose that as part of the C API
     // (deferred to a follow-up), build the default VMA-backed allocator here.
     if (!vkbc.fMemoryAllocator) {
-        vkbc.fMemoryAllocator = skgpu::VulkanMemoryAllocators::Make(vkbc, skgpu::ThreadSafe::kNo);
+        vkbc.fMemoryAllocator = skgpu::VulkanMemoryAllocators::Make(vkbc, skgpu::ThreadSafe::kYes);
         if (!vkbc.fMemoryAllocator) {
             return nullptr;
         }

--- a/src/c/sk_types_priv.h
+++ b/src/c/sk_types_priv.h
@@ -203,6 +203,8 @@ DEF_STRUCT_MAP(GrD3DTextureResourceInfo, gr_d3d_textureresourceinfo_t, GrD3DText
 
 #if defined(SK_GRAPHITE)
 #include "include/c/sk_graphite.h"
+#include "include/gpu/MutableTextureState.h"
+#include "include/gpu/graphite/BackendSemaphore.h"
 #include "include/gpu/graphite/BackendTexture.h"
 #include "include/gpu/graphite/Context.h"
 #include "include/gpu/graphite/Recorder.h"
@@ -213,6 +215,8 @@ DEF_MAP_WITH_NS(skgpu::graphite, Recorder,       sk_graphite_recorder_t,        
 DEF_MAP_WITH_NS(skgpu::graphite, Recording,      sk_graphite_recording_t,       GraphiteRecording)
 DEF_MAP_WITH_NS(skgpu::graphite, BackendTexture, sk_graphite_backend_texture_t, GraphiteBackendTexture)
 DEF_MAP_WITH_NS(skgpu::graphite, TextureInfo,    sk_graphite_texture_info_t,    GraphiteTextureInfo)
+DEF_MAP_WITH_NS(skgpu::graphite, BackendSemaphore, sk_graphite_backend_semaphore_t, GraphiteBackendSemaphore)
+DEF_MAP_WITH_NS(skgpu, MutableTextureState, sk_graphite_mutable_texture_state_t, GraphiteMutableTextureState)
 #endif // SK_GRAPHITE
 
 #include "include/effects/SkRuntimeEffect.h"


### PR DESCRIPTION
## Description

Expose the Graphite primitives required by native on-screen views. Vulkan presentation needs acquisition waits, render-complete signals, a transition to `VK_IMAGE_LAYOUT_PRESENT_SRC_KHR`, and completion callbacks; the existing C shim only supported offscreen recording. This also exposes deferred canvases for multi-recorder rendering and preserves 64-bit non-dispatchable Vulkan handles on 32-bit Android.

The default Graphite Vulkan allocator is now thread-safe so independent recorders can allocate concurrently.

**SkiaSharp issue**

Related to https://github.com/mono/SkiaSharp/issues/4721

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/4729

**Areas affected**

- [x] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [ ] Upstream Skia merge or rebase
- [x] Rendering output / behavior
- [ ] Other

## Changes

**C API**

```c
// added
sk_graphite_insert_status_t sk_graphite_context_insert_recording_full(...);
sk_canvas_t* sk_graphite_recorder_make_deferred_canvas(...);
sk_graphite_texture_info_t* sk_graphite_backend_texture_get_texture_info(...);
void sk_graphite_backend_semaphore_delete(...);
void sk_graphite_mutable_texture_state_delete(...);
sk_graphite_backend_texture_t* sk_graphite_vk_backend_texture_new_uint64(...);
sk_graphite_backend_semaphore_t* sk_graphite_vk_backend_semaphore_new(...);
sk_graphite_mutable_texture_state_t* sk_graphite_vk_mutable_texture_state_new(...);
```

**Behavior**

The fallback Vulkan memory allocator is internally synchronized so multiple Graphite recorders can allocate safely from different threads. Invalid target-state and deferred-canvas inputs now fail without entering unsafe Graphite paths.

## Testing

- Built libSkiaSharp from source for Android (all ABIs), iOS, Mac Catalyst, macOS, and tvOS.
- Verified 16 KB Android ELF alignment.
- Exercised Vulkan acquire/render/present synchronization and deferred multi-recorder replay in the companion MAUI sample on an Android API 36 arm64 emulator.
- Exercised Metal deferred multi-recorder replay on iOS Simulator and Mac Catalyst.

## Checklist

- [x] Targets the `skiasharp` branch
- [x] `Changes` above lists every added/changed C API export (or "None.")
- [x] Companion `mono/SkiaSharp` PR linked above (submodule bump at minimum; regenerates bindings + adds tests for C API changes)