### PR TITLE
[skia-sync] Merge upstream chrome/m152

### DIFF
--- a/src/gpu/ganesh/GrGpu.cpp
+++ b/src/gpu/ganesh/GrGpu.cpp
@@ -908,7 +908,7 @@ GrBackendTexture GrGpu::createBackendTexture(SkISize dimensions,
     if (beTex.isValid()) {
         skgpu::GlobalResourceStats::RecordCreateBackendTexture(
                 isProtected == GrProtected::kYes ? skgpu::Protected::kYes : skgpu::Protected::kNo,
-                GrSurface::ComputeSize(format, dimensions, 1, mipmapped));
+                GrSurface::ComputeSize(beTex.getBackendFormat(), dimensions, 1, mipmapped));
     }
     return beTex;
 }

--- a/src/gpu/ganesh/GrResourceProvider.cpp
+++ b/src/gpu/ganesh/GrResourceProvider.cpp
@@ -922,11 +922,13 @@ sk_sp<GrTexture> GrResourceProvider::writePixels(sk_sp<GrTexture> texture,
     if (tempColorType == GrColorType::kUnknown) {
         return nullptr;
     }
-    SkAssertResult(fGpu->writePixels(texture.get(),
-                                     SkIRect::MakeSize(baseSize),
-                                     colorType,
-                                     tempColorType,
-                                     tmpTexels.get(),
-                                     mipLevelCount));
+    if (!fGpu->writePixels(texture.get(),
+                           SkIRect::MakeSize(baseSize),
+                           colorType,
+                           tempColorType,
+                           tmpTexels.get(),
+                           mipLevelCount)) {
+        return nullptr;
+    }
     return texture;
 }


### PR DESCRIPTION
> [!NOTE]
> **Required merge method**
>
> **Merge commit only. Do not squash or rebase this PR.** The two-parent merge ancestry is required
> so future syncs can prove which upstream commits are already integrated.

## Description

Automated upstream merge of `chrome/m152`.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**SkiaSharp issue**

N/A — automated upstream synchronization.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/4808

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [x] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

Genuine two-parent merge of upstream `chrome/m152` into the mono/skia fork branch `skia-sync/m152`.

- Merge parents: fork base `c14bcfbab83b2182977505c251a02c058f83a321` and target upstream `b6d106297ff9ef2ff8094033695d045e87775581`.
- Authoritative range `2a9b593bab4b2fd019fa494c8d401ff1fab0b883..b6d106297ff9ef2ff8094033695d045e87775581` (2 commits, same milestone m152 bug-fix):
  - `071b39d97f` [ganesh] `GrGpu::createBackendTexture` — compute `GlobalResourceStats` size from the created texture's `beTex.getBackendFormat()` instead of the requested format (internal, unwrapped).
  - `b6d106297f` [ganesh] `GrResourceProvider::writePixels` — return `nullptr` on GPU upload failure instead of `SkAssertResult` (internal, unwrapped).
- Merge applied with **no conflicts**. `audit_fork_patches.py --validate` reports 0 added / 0 changed / 0 removed fork patches — the fork delta is untouched.
- **DEPS:** unchanged by the range (`git diff --stat RANGE -- DEPS` empty). `skia-dependency-changes.json` records zero tracked dependency changes. HarfBuzz kept on the fork revision. No dependency roll, no cgmanifest dependency-version change.
- No public header, C API (`src/c`, `include/c`), asserted-struct, enum, or `SkMilestone.h` change.

## Testing

Native library rebuilt from source on linux/x64 (`libSkiaSharp.so.152.0.0`, `libHarfBuzzSharp.so.0.61421.0`; `externals-linux` 18m33s). `externals-download` was never used. Bindings regenerated — no binding diff, no new native functions.

Full unfiltered `tests/SkiaSharp.Tests.Console.slnx` (net10.0), every host green:
- Core `SkiaSharp.Tests.dll`: 6091 passed, 33 skipped, 0 failed.
- `SkiaSharp.Tests.SingletonInit.dll`: 1 passed, 0 skipped, 0 failed.
- `SkiaSharp.Vulkan.Tests.dll`: 23 passed, 2 skipped, 0 failed.
- `SkiaSharp.Direct3D.Tests.dll`: 2 passed, 3 skipped, 0 failed.

GPU: Vulkan (lavapipe ICD) executed and passed. No **required** `GpuPolicy` backend for linux/x64 was skipped; remaining skips are the existing platform/host-policy skips (e.g. Direct3D on non-Windows).

## Human review

- Only linux/x64 native + tests were executed here. Windows (x64/ARM64, incl. Direct3D/ANGLE), macOS (x64/arm64/Metal), Android, iOS, and Blazor/WASM native builds and test hosts were **not** run locally and need CI coverage.
- Both changes touch the shipped Ganesh GPU backend; while internal and unwrapped, confirm no regression in backend-texture creation stats or pixel-upload failure handling on hardware GPUs.


## Checklist

- [x] Targets the `skiasharp` branch
- [x] `Changes` above lists every added/changed C API export or states that none changed
- [x] Companion `mono/SkiaSharp` PR linked above

_Last rendered by the sync workflow: 2026-08-18T07:39:11Z_
