### PR TITLE
Add ppc64le Support

### DIFF
--- a/third_party/libpng/BUILD.gn
+++ b/third_party/libpng/BUILD.gn
@@ -64,5 +64,13 @@ if (skia_use_system_libpng) {
         "../externals/libpng/loongarch/loongarch_lsx_init.c",
       ]
     }
+
+
+    if (current_cpu == "ppc64" || current_cpu == "ppc64le") {  
+      sources += [  
+        "../externals/libpng/powerpc/powerpc_init.c",  
+        "../externals/libpng/powerpc/filter_vsx_intrinsics.c",  
+      ]  
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the SkiaSharp fork of Skia!

• Target the `skiasharp` branch (our long-lived integration branch) — not `main`.
• This fork adds the C API shim in include/c/ and src/c/ plus build tweaks.
  Keep changes minimal and additive so upstream Skia merges stay clean.
• Just fill in the Description — the other sections have sensible defaults. Each
  section's comment holds a copy-paste block; drop it in only when you have something.
-->

## Description

Enables PowerPC VSX SIMD intrinsics in `libpng` for `ppc64le` architectures when using bundled libpng.

**SkiaSharp issue**

Resolves mono/SkiaSharp#4830

**Required SkiaSharp PR**

None

<!--
Every change here — including build, CI, or infrastructure — needs a companion
SkiaSharp PR to actually take effect: at minimum one that bumps the SkiaSharp
submodule to this commit. A C API change additionally needs that PR to regenerate
the P/Invoke bindings (pwsh ./utils/generate.ps1) and add the managed wrapper +
tests. Link it above; open the SkiaSharp PR first if it doesn't exist yet.
-->

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [x] Build (gn / build files)
- [ ] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

None.

<!--
Scope: the exported C API surface and any observable BEHAVIOR — NOT a file-by-file
list. The diff already shows which files changed; the "what & why" belongs in
Description above. An upstream-merge or build-only PR that changes neither can
just leave "None."

The C API is consumed by SkiaSharp's generated P/Invoke bindings, so any change
here must be paired with a SkiaSharp PR that regenerates them. Copy the parts that
apply over "None." and delete the rest:

**C API**

```c
// added
void sk_canvas_draw_foo(sk_canvas_t* canvas, float x, float y, const sk_paint_t* paint);

// renamed / changed
void sk_object_old_name()  =>  void sk_object_new_name()
```

**Behavior**

A change to rendering output, defaults, or behavior an upgrading app would notice.
-->

## Testing

Verified that `libpng` builds successfully with PowerPC VSX intrinsics on `ppc64le`.

## Checklist

- [x] Targets the `skiasharp` branch
- [x] `Changes` above lists every added/changed C API export (or "None.")
- [x] Companion `mono/SkiaSharp` PR linked above (submodule bump at minimum; regenerates bindings + adds tests for C API changes)
