### PR TITLE
[skia-sync] Merge upstream chrome/m152

### DIFF
--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -65,7 +65,12 @@ void SkCachedData::internalRef(bool fromCache) const {
 }
 
 void SkCachedData::internalUnref(bool fromCache) const {
-    if (AutoMutexWritable(this)->inMutexUnref(fromCache)) {
+    bool shouldDelete = false;
+    {
+        AutoMutexWritable amw(this);
+        shouldDelete = amw->inMutexUnref(fromCache);
+    }
+    if (shouldDelete) {
         // can't delete inside doInternalUnref, since it is locking a mutex (which we own)
         delete this;
     }


### PR DESCRIPTION
> [!NOTE]
> **Required merge method**
>
> **Merge commit only. Do not squash or rebase this PR.** The two-parent merge ancestry is required
> so future syncs can prove which upstream commits are already integrated.

## Description

Automated upstream merge of `chrome/m152`.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**SkiaSharp issue**

N/A — automated upstream synchronization.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/4925

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [x] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

Two-parent merge of upstream `chrome/m152` (`0873ec164a06966b90ae0d43ef783cfb180084ae`)
into the `release/4.152.x` fork line.

- Merge commit: `876a77cd8cdc15b2277e68357dd22f5652e50c54` (parents: fork base
  `9f0d864fd60e9907a8bf5ec84a71d603e6c8db5f` + upstream `0873ec16`).
- Single upstream commit in range `b6d10629..0873ec16`:
  **[M152] Fix UAF in `SkCachedData::internalUnref`** — scopes `AutoMutexWritable` in a
  nested block so the object mutex is unlocked before `delete this`.
- No conflicts. Clean merge; all 1070 fork-delta commits preserved.
- Fork-patch audit: 0 added / 0 changed / 0 removed patches — `--validate` PASSED.
- Dependencies: `DEPS` diff across the sync range is empty; the merge introduces no
  dependency change. All existing fork dependency decisions preserved unchanged
  (see dependency-decisions artifact). No Component Governance metadata change.
- No C API (`src/c`, `include/c`), header, struct-layout, or GN build-list change.
- Milestone unchanged: `SK_MILESTONE = 152` (release-line bug-fix).

## Testing

Native rebuilt from source (`externals-linux --arch=x64`, ~14m45s cold) — no
`externals-download` used. Full unfiltered `tests/SkiaSharp.Tests.Console.slnx`
(net10.0, x64), exit code 0:

- Core `SkiaSharp.Tests.dll`: 6127 passed, 33 skipped
- Vulkan `SkiaSharp.Vulkan.Tests.dll`: 23 passed, 2 skipped
- Direct3D `SkiaSharp.Direct3D.Tests.dll`: 2 passed, 3 skipped
- Singleton init: 1 passed, 0 skipped

No **required** `GpuPolicy` backend was skipped; the Vulkan (lavapipe) backend
initialized and executed. Direct3D skips are platform-policy (non-Windows host).

## Human review

- Only the Linux/x64 host was built and tested here. Windows, macOS (arm64/x64),
  Linux arm64, Android, iOS, and WASM native builds/tests were not executed and need
  CI/cross-platform confirmation.
- Change is an internal UAF/locking fix with no API surface impact; low regression risk.


## Checklist

- [x] Targets the `release/4.152.x` branch
- [x] `Changes` above lists every added/changed C API export or states that none changed
- [x] Companion `mono/SkiaSharp` PR linked above

_Last rendered by the sync workflow: 2026-09-03T00:10:31Z_
