### PR TITLE
[skia-sync] Merge upstream chrome/m153

### DIFF
--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -65,7 +65,12 @@ void SkCachedData::internalRef(bool fromCache) const {
 }
 
 void SkCachedData::internalUnref(bool fromCache) const {
-    if (AutoMutexWritable(this)->inMutexUnref(fromCache)) {
+    bool shouldDelete = false;
+    {
+        AutoMutexWritable amw(this);
+        shouldDelete = amw->inMutexUnref(fromCache);
+    }
+    if (shouldDelete) {
         // can't delete inside doInternalUnref, since it is locking a mutex (which we own)
         delete this;
     }


### PR DESCRIPTION
> [!NOTE]
> **Required merge method**
>
> **Merge commit only. Do not squash or rebase this PR.** The two-parent merge ancestry is required
> so future syncs can prove which upstream commits are already integrated.

## Description

Automated upstream merge of `chrome/m153`.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**SkiaSharp issue**

N/A — automated upstream synchronization.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/4927

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [x] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

Two-parent merge of upstream `chrome/m153` into `skiasharp` (fork base
`ca4e52cbb95210aaf4cc5d2deaa32b478a28429a`).

- Upstream ref: `chrome/m153`
- Base upstream: `9d07e5bad9e3e21da2426946e589daa647218271`
- Target upstream: `4f574af2444846ceca4d277a8095c5d4229d175f` — *[M153] Fix UAF in SkCachedData::internalUnref*
- Merge commit: `d87457da65b27386267485bb10253b5ab9112121` (parents: fork base + target upstream)

The range is a single upstream commit touching exactly one file,
`src/core/SkCachedData.cpp`: it destroys the `AutoMutexWritable` RAII guard before
`delete this` in `internalUnref`, fixing a use-after-free (mutex unlocked after the
owning object was freed).

- **Conflicts:** none — automatic merge, no fork patch touched.
- **Fork patches:** `audit_fork_patches.py --validate` reports 0 added / 0 changed / 0 removed. Every fork patch preserved.
- **Dependencies:** `DEPS` byte-identical between fork base and target; `skia-dependency-changes.json` shows `changes: []`. No revision, cgmanifest, or Component Governance change.
- **C API / build lists:** no changes under `include/c` or `src/c`; no GN build-list changes.

## Testing

Native library built from source on Linux/x64 (`externals-linux --arch=x64`,
`libSkiaSharp.so.153.0.0`, `libHarfBuzzSharp.so.0.61421.0`). Bindings regenerated: no
new native functions, no generated diff. Full unfiltered
`tests/SkiaSharp.Tests.Console.slnx` (net10.0/x64) passed:

- SkiaSharp.Tests: Passed 6127, Skipped 33, Failed 0
- SkiaSharp.Tests.SingletonInit: Passed 1, Failed 0
- SkiaSharp.Vulkan.Tests: Passed 23, Skipped 2, Failed 0
- SkiaSharp.Direct3D.Tests: Passed 2, Skipped 3, Failed 0

No `GpuPolicy`-required backend was skipped; the Vulkan backend (lavapipe) initialized
and executed. Remaining skips are the existing platform-policy skips (Direct3D on
Linux, etc.).

## Human review

- Only Linux/x64 was built and tested here. Windows (x64/Direct3D), macOS (arm64/x64/Metal), Android, iOS, and WASM were not executed and need CI/reviewer coverage.
- Change is an internal-only correctness fix with no API/ABI surface; risk is low.


## Checklist

- [x] Targets the `skiasharp` branch
- [x] `Changes` above lists every added/changed C API export or states that none changed
- [x] Companion `mono/SkiaSharp` PR linked above

_Last rendered by the sync workflow: 2026-09-03T00:49:16Z_
