### PR TITLE
[migration] Make Skia transfer-ready with Arcade Backport

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,13 +23,13 @@ What does this change do, and why?
 
 **SkiaSharp issue**
 
-Related to https://github.com/mono/SkiaSharp/issues/<issue-number>
+Related SkiaSharp issue: <issue-url>
 
 <!-- Ensure a SkiaSharp issue exists for the feature or bug before opening this PR. -->
 
 **Required SkiaSharp PR**
 
-Requires https://github.com/mono/SkiaSharp/pull/<pr-number>
+Requires SkiaSharp PR: <pull-request-url>
 
 <!--
 Every change here — including build, CI, or infrastructure — needs a companion
@@ -101,4 +101,4 @@ Rendering change? Copy this in to show the difference:
 
 - [ ] Targets the `skiasharp` branch
 - [ ] `Changes` above lists every added/changed C API export (or "None.")
-- [ ] Companion `mono/SkiaSharp` PR linked above (submodule bump at minimum; regenerates bindings + adds tests for C API changes)
+- [ ] Companion SkiaSharp PR linked above (submodule bump at minimum; regenerates bindings + adds tests for C API changes)

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,36 +1,25 @@
-name: Backport
+name: Backport PR to branch
 
+# Comment `/backport to <branch>` or `/backport <branch>` on a merged pull request.
 on:
-  pull_request_target:
+  issue_comment:
     types:
-      - closed
-      - labeled
+      - created
+  schedule:
+    # Once a day at 13:00 UTC to clean up completed runs of this workflow.
+    - cron: '0 13 * * *'
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   backport:
-    name: Backport
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
-    steps:
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body_template: >
-             Backport of <%= mergeCommitSha %> from #<%= number %>.
-          head_template: "backport/pr-<%= number %>-to-<%= base %>"
-          label_pattern: "^backport/(?<base>([^ ]+))$"
-          labels_template: "[ \"backport\" ]"
-          title_template: "[<%= base %>] <%= title %>"
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@306225d7029934938d109e18df390f04e366a68d # main as of 2026-08-31
+    with:
+      repository_owners: mono,dotnet # Remove mono after the repository transfer.
+      pr_title_template: '[%target_branch%] %source_pr_title%'
+      pr_description_template: 'Backport of #%source_pr_number% to %target_branch%'
+      pr_labels: backport

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,6 +10,9 @@ jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
@@ -22,7 +25,7 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           body_template: >


### PR DESCRIPTION
## Description

Makes the repository-owned GitHub metadata safe to carry from `mono/skia` to `dotnet/skia`:

- makes contributor issue and PR placeholders organization-neutral;
- replaces `tibdex/backport` with the standard .NET-owned Arcade reusable workflow;
- pins the Skia caller to reviewed Arcade commit `306225d7029934938d109e18df390f04e366a68d` instead of `@main`;
- leaves the live issue-contact links on `mono/SkiaSharp` for transfer-day cutover.

### Intentional Backport UX change

Backport labels no longer trigger automation. On a merged pull request, a collaborator with `write` or `admin` access comments either:

```text
/backport to <branch>
```

or:

```text
/backport <branch>
```

Arcade verifies the commenter with `repos.getCollaboratorPermissionLevel`, rejects any permission other than `write` or `admin`, verifies the source PR was merged, and verifies the target branch exists. It preserves the supported existing output conventions: `backport/pr-<number>-to-<branch>`, `[<branch>] <title>`, body `Backport of #<source> to <target>`, and the `backport` label.

`repository_owners: mono,dotnet` keeps the workflow operational before and after transfer. `mono` must be removed from this input after transfer.

### Permissions

| Permission | Reason |
| --- | --- |
| `contents: write` | Checkout and force-push the deterministic temporary backport branch. |
| `issues: write` | Post status/error comments, unlock/re-lock a locked source PR, and apply the `backport` label through the Issues API. |
| `pull-requests: write` | Read the merged source PR and create the backport PR. |
| `actions: write` | The scheduled cleanup workflow enumerates and deletes completed runs of this workflow. |

The deterministic temporary-branch force push allows a repeated command to update the existing backport PR, and scheduled cleanup removes completed runs of this workflow. Maintainers accept both as intentional behavior of trusted .NET organization infrastructure. `mono/skia` currently has no branch protection or ruleset that conflicts with the temporary branch.

The pinned `backport-base.yml` blob is identical to current Arcade `main` and is also deployed by current `dotnet/aspnetcore` and `dotnet/sdk` wrappers; `dotnet/runtime` uses the same reusable workflow from `main`. The reviewed base intentionally follows Arcade's trusted-organization update model by calling `scheduled-action-cleanup-base.yml@main`, whose current blob matches the version at the reviewed commit, and that cleanup uses `actions/github-script@v9`. Maintainers accept these standard Arcade dependencies; they are not merge blockers. The remaining transfer check is that destination organization policy allows `dotnet/arcade` reusable workflows.

Fixes #353

**SkiaSharp issue**

Related SkiaSharp issue: https://github.com/mono/SkiaSharp/issues/4959

**Required SkiaSharp PR**

Requires SkiaSharp PR: N/A — this changes repository GitHub metadata only and does not require a Skia submodule, binding, managed API, or test update.

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [ ] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [x] Other — repository GitHub metadata

## Changes

None.

## Testing

- Parsed the Backport workflow and issue-template config as YAML.
- Verified the caller uses the reviewed 40-character Arcade SHA and exact expected inputs.
- Verified the pinned and current Arcade Backport/cleanup workflow blobs match.
- Verified Arcade accepts both comment forms, restricts execution to `write`/`admin`, requires a merged PR, and uses the expected branch/title/body/label conventions.
- Verified `mono/skia` has no branch protection or ruleset affecting the temporary force-pushed branch.
- Verified only the intended two `.github` files changed.
- Verified no old-owner raw/API fetch exists.
- Verified the three static issue-contact links are unchanged and remain the only transfer-day link edits.
- Verified the historical SkiaSharp issue reference and all 42 fork-patch `mono/skia` references remain unchanged.

## Checklist

- [x] Targets the `skiasharp` branch
- [x] `Changes` above lists every added/changed C API export (or "None.")
- [x] Companion SkiaSharp PR addressed above (not applicable; no submodule, binding, managed API, or test change)