### PR TITLE
[skia-sync] Merge upstream chrome/m152

### DIFF
--- a/src/gpu/ganesh/text/GlyphData.cpp
+++ b/src/gpu/ganesh/text/GlyphData.cpp
@@ -190,7 +190,14 @@ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
     if (fAtlasGeneration != currentAtlasGen) {
         SkSpan<const Glyph> glyphSpan = glyphVector.accessBackendGlyphs<Glyph>();
         // Calculate the texture coordinates for the vertexes during first use (fAtlasGeneration
-        // is set to kInvalidAtlasGeneration) or the atlas has changed in subsequent calls.
+        // is set to kInvalidAtlasGeneration) or the atlas has changed in subsequent calls. Always
+        // reset the update, even when begin > 0. When begin > 0, this subrun was split across
+        // flushes and previously used glyphs in [0, begin) have an older token. If those glyphs are
+        // not used in [begin, end], they shouldn't be part of the next bulk update (and because
+        // we won't have updated the whole subrun in one go, we won't set `fAtlasGeneration` to take
+        // the fast path on reuse). If we do reuse the glyphs, we need the bulk update to have been
+        // reset so that the call to addGlyphToBulkAndSetUseToken() sees the first use with the new
+        // token and updates the atlas locator.
         fBulkUseUpdater.reset();
 
         SkBulkGlyphMetricsAndImages metricsAndImages{fTextStrike->strikeSpec()};
@@ -219,8 +226,11 @@ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
             glyphsPlacedInAtlas++;
         }
 
-        // Update atlas generation if there are no more glyphs to put in the atlas.
-        if (success && begin + glyphsPlacedInAtlas == glyphVector.glyphCount()) {
+        // Update atlas generation if there are no more glyphs to put in the atlas. We can only do
+        // this if we successfully checked/added the entire glyph vector in one pass. Otherwise, on
+        // a partial update, some of the previous glyphs of the subrun that were already drawn could
+        // have been evicted to make room for these remaining glyphs.
+        if (success && begin == 0 && glyphsPlacedInAtlas == glyphVector.glyphCount()) {
             // Need to get the freshest value of the atlas' generation because
             // updateTextureCoordinates may have changed it.
             fAtlasGeneration = atlasManager->atlasGeneration(maskFormat);

--- a/src/gpu/graphite/text/GlyphData.cpp
+++ b/src/gpu/graphite/text/GlyphData.cpp
@@ -56,7 +56,14 @@ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
 
     if (fAtlasGeneration != currentAtlasGen) {
         // Calculate the texture coordinates for the vertexes during first use (fAtlasGeneration
-        // is set to kInvalidAtlasGeneration) or the atlas has changed in subsequent calls.
+        // is set to kInvalidAtlasGeneration) or the atlas has changed in subsequent calls. Always
+        // reset the update, even when begin > 0. When begin > 0, this subrun was split across
+        // flushes and previously used glyphs in [0, begin) have an older token. If those glyphs are
+        // not used in [begin, end], they shouldn't be part of the next bulk update (and because
+        // we won't have updated the whole subrun in one go, we won't set `fAtlasGeneration` to take
+        // the fast path on reuse). If we do reuse the glyphs, we need the bulk update to have been
+        // reset so that the call to addGlyphToBulkAndSetUseToken() sees the first use with the new
+        // token and updates the atlas locator.
         fBulkUseUpdater.reset();
 
         SkBulkGlyphMetricsAndImages metricsAndImages{fTextStrike->strikeSpec()};
@@ -82,8 +89,11 @@ std::tuple<bool, int> GlyphData::regenerateAtlas(int begin,
             glyphsPlacedInAtlas++;
         }
 
-        // Update atlas generation if there are no more glyphs to put in the atlas.
-        if (success && begin + glyphsPlacedInAtlas == glyphVector.glyphCount()) {
+        // Update atlas generation if there are no more glyphs to put in the atlas. We can only do
+        // this if we successfully checked/added the entire glyph vector in one pass. Otherwise, on
+        // a partial update, some of the previous glyphs of the subrun that were already drawn could
+        // have been evicted to make room for these remaining glyphs.
+        if (success && begin == 0 && glyphsPlacedInAtlas == glyphVector.glyphCount()) {
             // Need to get the freshest value of the atlas' generation because
             // updateTextureCoordinates may have changed it.
             fAtlasGeneration = atlasManager->atlasGeneration(maskFormat);


### PR DESCRIPTION
> [!NOTE]
> **Required merge method**
>
> **Merge commit only. Do not squash or rebase this PR.** The two-parent merge ancestry is required
> so future syncs can prove which upstream commits are already integrated.

## Description

Automated upstream merge of `chrome/m152`.

This pull request was produced by [skia-upstream-sync](https://github.com/mono/SkiaSharp/actions/workflows/auto-skia-sync.lock.yml).

**SkiaSharp issue**

N/A — automated upstream synchronization.

**Required SkiaSharp PR**

Requires https://github.com/mono/SkiaSharp/pull/5047

**Areas affected**

- [ ] C API (`include/c`, `src/c`)
- [ ] Native dependency / `DEPS`
- [ ] Build (gn / build files)
- [x] Upstream Skia merge or rebase
- [ ] Rendering output / behavior
- [ ] Other

## Changes

Merged upstream `chrome/m152` at `4ca59aa7629672a1edc686a06819f56333af45a6` into mono/skia `release/4.152.x` as the genuine two-parent merge `99bb2457f0147756de79349a8b48c751377a8852`.

The upstream change fixes Ganesh and Graphite glyph-atlas generation bookkeeping after partial glyph updates. The merge had no conflicts, preserved all 216 fork-delta files unchanged, and made no C API, build-list, public-header, or DEPS changes. No dependency revisions or Component Governance registrations changed.

## Testing

- Linux x64 native source build: passed.
- C API and generated-binding reconciliation: passed with no new native functions or generated API changes.
- Canonical unfiltered managed suite: passed. Core: 6,127 passed, 33 skipped; singleton initialization: 1 passed, 0 skipped; Vulkan: 23 passed, 2 skipped; Direct3D: 2 passed, 3 skipped.
- Linux-required GPU backends `ganesh-gl`, `ganesh-vulkan`, and `graphite-vulkan` initialized and executed. Platform-policy skips existed, but no required backend was skipped.

## Human review

Review the shared Ganesh/Graphite glyph-atlas behavior and the evidence that generation is recorded only after a complete glyph-vector update. Native and managed validation ran on Linux x64; Windows, macOS, Android, Apple mobile, and browser targets were not executed locally and remain for CI.


## Checklist

- [x] Targets the `release/4.152.x` branch
- [x] `Changes` above lists every added/changed C API export or states that none changed
- [x] Companion `mono/SkiaSharp` PR linked above

_Last rendered by the sync workflow: 2026-09-08T19:06:30Z_
